### PR TITLE
UI Coverage Parallel Appliance refactor

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -43,6 +43,7 @@ import zmq
 from _pytest import runner
 
 from fixtures.parallelizer import remote
+from fixtures.pytest_store import store
 from fixtures.terminalreporter import reporter
 from utils import at_exit, conf
 from utils.appliance import IPAppliance
@@ -83,11 +84,12 @@ def pytest_addoption(parser):
 
 @pytest.mark.tryfirst
 def pytest_configure(config, __multicall__):
-    __multicall__.execute()
     if config.option.appliances or (config.option.use_sprout
             and config.option.sprout_appliances > 1):
         session = ParallelSession(config)
         config.pluginmanager.register(session, "parallel_session")
+        store.parallelizer_role = 'master'
+    __multicall__.execute()
 
 
 class ParallelSession(object):

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -8,6 +8,7 @@ import zmq
 from py.path import local
 
 import utils.log
+from fixtures.pytest_store import store
 from utils import conf
 from utils.sprout import SproutClient, SproutException
 
@@ -218,6 +219,7 @@ if __name__ == '__main__':
 
     conf.runtime['env']['slaveid'] = args.slaveid
     conf.runtime['env']['base_url'] = args.base_url
+    store.parallelizer_role = 'slave'
 
     slave_args = conf.slave_config.pop('args')
     slave_options = conf.slave_config.pop('options')

--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -49,8 +49,14 @@ class Store(object):
 
     """
     def __init__(self):
+        #: The py.test config instance, None if not in py.test
         self.config = None
+
+        #: The current py.test session, None if not in a py.test session
         self.session = None
+
+        #: Parallelizer role, None if not running a parallelized session
+        self.parallelizer_role = None
         self._current_appliance = []
 
     @property
@@ -103,6 +109,10 @@ class Store(object):
             reporter = self.pluginmanager.getplugin('terminaldistreporter')
             if reporter:
                 return reporter
+
+    @property_or_none
+    def parallel_session(self):
+        return self.pluginmanager.getplugin('parallel_session')
 
     @property_or_none
     def slave_manager(self):

--- a/scripts/data/coverage/coverage_hook.rb
+++ b/scripts/data/coverage/coverage_hook.rb
@@ -1,25 +1,19 @@
 # goes in rails config dir, then require it from boot.rb
 
 # set up simplecov, broken out by process for recombining later
+require 'appliance_console/env'
+require 'fileutils'
 require 'simplecov'
+require 'yaml'
 
 rails_root = File.expand_path(File.join(File.dirname(__FILE__), "..", "vmdb"))
 SimpleCov.start 'rails' do
-  coverage_dir File.join(rails_root, "coverage", Process.pid.to_s)
+  # Set the coverage dir for this process to "RAILS_ROOT/coverage/[ipaddress]/[pid]/"
+  coverage_dir File.join(rails_root, "coverage", ApplianceConsole::Env["IP"], Process.pid.to_s)
+  # make sure coverage_dir exists
+  FileUtils.mkdir_p(SimpleCov.coverage_dir)
   # coverage root is one level below the rails root so we pick up vmdb/../lib
   root File.join(rails_root, '..')
   # This needs to be unique per simplecov runner
-  command_name Process.pid
-  # Make this a big number, so all generated reports are merged
-  merge_timeout 2 << 28
-  # APIs were ungrouped, so be nice to them
-  add_group "APIs", "app/apis"
-  # filter non-vmdb libs out of the default libraries group
-  add_group "Libraries", "vmdb/lib/"
-  # match lib dir outside of vmdb, exclude util
-  # will false-positive on vmdb/lib/blah/lib/something.rb...
-  # bonus points for the regex that doesn't
-  add_group "MIQ Libraries", "(?<!vmdb)/lib/(?!util/).*$"
-  #  match lib/util by itself
-  add_group "MIQ Utils", "(?<!vmdb)/lib/util/.*$"
+  command_name "%s-%s" % [ApplianceConsole::Env["IP"], Process.pid]
 end


### PR DESCRIPTION
This is working, but merits some discussion, and testing. Until we get PRT metadata support, PRT doesn't know that you need to add `--ui-coverage` to your pytest commandline to test this. This is *completely* untested in non-parallelized runs, but might work. I'd prefer to get feedback on parallelized sessions, though. :)

I moved all of the appliance-specific stuff over into IPAppliance, but I think that just made a bit of a mess. We definitely want to leave all of the public `IPAppliance.coverage*` methods on IPAppliance so it's easy to install coverage and collect reports, but all of the work should probably be done inside `fixtures.ui_coverage`.

`fixtures.ui_coverage` itself should have the work it's doing broken out into manageable functions, if for no other reason than to simplify development. I hacked on this in a notebook which right now makes nuclear wastelands look like a nice vacation destination, so I'll refrain from adding that to the PR...