### PR TITLE
A few fixes to the delete obj tests

### DIFF
--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 from cfme.infrastructure import host, datastore, cluster, resource_pool, virtual_machines
 from cfme.web_ui import Region
 from utils import testgen
@@ -8,29 +7,29 @@ from utils import testgen
 
 details_page = Region(infoblock_type='detail')
 
-pytestmark = [pytest.mark.usefixtures("setup_infrastructure_providers")]
-
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'remove_test')
+    argnames, argvalues, idlist = testgen.infra_providers(metafunc)
 
+    argnames.append('remove_test')
     new_idlist = []
     new_argvalues = []
 
     for i, argvalue_tuple in enumerate(argvalues):
         args = dict(zip(argnames, argvalue_tuple))
-        if not args['remove_test']:
+        if 'remove_test' not in args['provider_crud'].get_yaml_data():
             # No provisioning data available
             continue
 
         new_idlist.append(idlist[i])
+        argvalues[i].append(args['provider_crud'].get_yaml_data()['remove_test'])
         new_argvalues.append(argvalues[i])
 
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 
 
-def test_delete_cluster(provider_crud, remove_test):
+def test_delete_cluster(setup_provider, provider_crud, remove_test):
     cluster_name = remove_test['cluster']
     test_cluster = cluster.Cluster(name=cluster_name)
     test_cluster.delete(cancel=False)
@@ -39,7 +38,7 @@ def test_delete_cluster(provider_crud, remove_test):
     test_cluster.wait_for_appear()
 
 
-def test_delete_host(provider_crud, remove_test):
+def test_delete_host(setup_provider, provider_crud, remove_test):
     host_name = remove_test['host']
     test_host = host.Host(name=host_name)
     test_host.delete(cancel=False)
@@ -48,7 +47,7 @@ def test_delete_host(provider_crud, remove_test):
     host.wait_for_host_to_appear(test_host)
 
 
-def test_delete_vm(provider_crud, remove_test):
+def test_delete_vm(setup_provider, provider_crud, remove_test):
     vm = remove_test['vm']
     test_vm = virtual_machines.Vm(vm, provider_crud)
     test_vm.remove_from_cfme(cancel=False)
@@ -57,7 +56,7 @@ def test_delete_vm(provider_crud, remove_test):
     test_vm.wait_to_appear()
 
 
-def test_delete_template(provider_crud, remove_test):
+def test_delete_template(setup_provider, provider_crud, remove_test):
     template = remove_test['template']
     test_template = virtual_machines.Template(template, provider_crud)
     test_template.remove_from_cfme(cancel=False)
@@ -66,7 +65,7 @@ def test_delete_template(provider_crud, remove_test):
     test_template.wait_to_appear()
 
 
-def test_delete_resource_pool(provider_crud, remove_test):
+def test_delete_resource_pool(setup_provider, provider_crud, remove_test):
     resourcepool_name = remove_test['resource_pool']
     test_resourcepool = resource_pool.ResourcePool(name=resourcepool_name)
     test_resourcepool.delete(cancel=False)
@@ -75,7 +74,7 @@ def test_delete_resource_pool(provider_crud, remove_test):
     test_resourcepool.wait_for_appear()
 
 
-def test_delete_datastore(provider_crud, remove_test):
+def test_delete_datastore(setup_provider, provider_crud, remove_test):
     data_store = remove_test['datastore']
     test_datastore = datastore.Datastore(name=data_store)
     host_count = test_datastore.get_hosts()


### PR DESCRIPTION
* Remove tests is now handled correctly in the case that it does not
  exist.
* Reliance on setup_infrastructure_providers is also removed and each
  provider is tested and only setup if necessary.