### PR TITLE
[WIP] - Test flag introduction

### DIFF
--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -93,6 +93,11 @@ def retire_extend_button(request):
 
 
 def test_vm_retire_extend(request, testing_vm, soft_assert, retire_extend_button):
+    """ Tests extending a retirement
+
+    Metadata:
+        test_flag: retire, provision
+    """
     soft_assert(testing_vm.retirement_date is None, "The retirement date is not None!")
     retirement_date = parsetime.now() + timedelta(days=5)
     testing_vm.set_retirement_date(retirement_date)

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -53,6 +53,11 @@ def testing_vm(request, provisioning, provider_crud, provider_key):
 
 def test_vmware_vimapi_hotadd_disk(
         request, testing_group, provider_crud, provider_mgmt, testing_vm):
+    """ Tests hot adding a disk to vmware vm
+
+    Metadata:
+        test_flag: hotdisk, provision
+    """
     # Instance that calls the method and is accessible from the button
     instance = Instance(
         name="VMware_HotAdd_Disk",

--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -11,8 +11,7 @@ from utils import testgen, ssh
 from utils.wait import wait_for
 from utils.randomness import generate_random_string
 
-pytestmark = [pytest.mark.fixtureconf(server_roles="+automate"),
-              pytest.mark.usefixtures('server_roles')]
+pytestmark = [pytest.mark.meta(server_roles="+automate")]
 
 
 def pytest_generate_tests(metafunc):
@@ -59,6 +58,11 @@ def vm_name(request, provider_mgmt):
 
 def test_provision_cloud_init(request, setup_provider, provider_crud, provisioning,
                               setup_ci_template, vm_name):
+    """ Tests provisioning from a template with cloud_init
+
+    Metadata:
+        test_flag: cloud_init, provision
+    """
     image = provisioning.get('ci-image', None) or provisioning['image']['name']
     note = ('Testing provisioning from image %s to vm %s on provider %s' %
             (image, vm_name, provider_crud.key))

--- a/cfme/tests/cloud/test_cloud_instance_discovery.py
+++ b/cfme/tests/cloud/test_cloud_instance_discovery.py
@@ -47,6 +47,9 @@ def test_cloud_instance_discovery(request, provider_crud, provider_init, provide
     (add/delete).
     As there is currently no way to listen to AWS events,
     CFME must be refreshed manually to see the changes.
+
+    Metadata:
+        test_flag: discovery
     """
     if not provider_mgmt.does_vm_exist(instance_name):
         deploy_template(provider_crud.key, instance_name)

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -87,6 +87,11 @@ def count_events(vm_name, nav_step):
 
 @pytest.mark.bugzilla(1139865)
 def test_provider_event(setup_provider, provider_crud, gen_events, test_instance):
+    """ Tests provider events on timelines
+
+    Metadata:
+        test_flag: timelines, provision
+    """
     def nav_step():
         pytest.sel.force_navigate('cloud_provider_timelines',
                                   context={'provider': provider_crud})
@@ -96,6 +101,11 @@ def test_provider_event(setup_provider, provider_crud, gen_events, test_instance
 
 @pytest.mark.bugzilla(1139865)
 def test_azone_event(setup_provider, provider_crud, gen_events, test_instance):
+    """ Tests availablility zone events on timelines
+
+    Metadata:
+        test_flag: timelines, provision
+    """
     def nav_step():
         test_instance.load_details()
         pytest.sel.click(details_page.infoblock.element('Relationships', 'Availability Zone'))
@@ -106,6 +116,11 @@ def test_azone_event(setup_provider, provider_crud, gen_events, test_instance):
 
 @pytest.mark.bugzilla(1139865)
 def test_vm_event(setup_provider, provider_crud, gen_events, test_instance):
+    """ Tests vm events on timelines
+
+    Metadata:
+        test_flag: timelines, provision
+    """
     def nav_step():
         test_instance.load_details()
         toolbar.select('Monitoring', 'Timelines')

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -40,6 +40,11 @@ def reset():
 
 
 def test_delete_instance(setup_provider, provider_crud, remove_test):
+    """ Tests delete instance
+
+    Metadata:
+        test_flag: delete_object
+    """
     instance_name = remove_test['instance']
     test_instance = instance.instance_factory(instance_name, provider_crud)
     test_instance.remove_from_cfme(cancel=False)
@@ -49,6 +54,11 @@ def test_delete_instance(setup_provider, provider_crud, remove_test):
 
 
 def test_delete_image(setup_provider, provider_crud, remove_test, set_grid, request):
+    """ Tests delete image
+
+    Metadata:
+        test_flag: delete_object
+    """
     image_name = remove_test['image']
     test_image = instance.Image(image_name, provider_crud)
     test_image.delete()

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -6,7 +6,7 @@ from utils import error, testgen
 from utils.randomness import generate_random_string
 from utils.wait import wait_for, TimedOutError
 
-pytestmark = pytest.mark.usefixtures('test_power_control')
+pytestmark = [pytest.mark.usefixtures('test_power_control')]
 
 
 def pytest_generate_tests(metafunc):
@@ -139,6 +139,11 @@ def check_power_options(soft_assert, instance, power_state):
 @pytest.mark.long_running
 def test_quadicon_terminate_cancel(setup_provider_funcscope, provider_type, provider_mgmt,
                                    test_instance, verify_vm_running, soft_assert):
+    """ Tests terminate cancel
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_ON, timeout=720)
     test_instance.power_control_from_cfme(option=test_instance.TERMINATE, cancel=True)
@@ -157,6 +162,11 @@ def test_quadicon_terminate_cancel(setup_provider_funcscope, provider_type, prov
 @pytest.mark.bugzilla(1122039)
 def test_quadicon_terminate(setup_provider_funcscope, provider_type, provider_mgmt,
                             test_instance, verify_vm_running, soft_assert):
+    """ Tests terminate instance
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_ON, timeout=720)
     test_instance.power_control_from_cfme(option=test_instance.TERMINATE, cancel=False)
@@ -178,6 +188,11 @@ def test_quadicon_terminate(setup_provider_funcscope, provider_type, provider_mg
 @pytest.mark.long_running
 def test_stop(ec2_only, setup_provider_funcscope, provider_type, provider_mgmt,
               test_instance, soft_assert, verify_vm_running):
+    """ Tests instance stop
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_ON, timeout=720, from_details=True)
     check_power_options(soft_assert, test_instance, 'on')
@@ -196,6 +211,11 @@ def test_stop(ec2_only, setup_provider_funcscope, provider_type, provider_mgmt,
 @pytest.mark.long_running
 def test_start(ec2_only, setup_provider_funcscope, provider_type, provider_mgmt,
                test_instance, soft_assert, verify_vm_stopped):
+    """ Tests instance start
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_OFF, timeout=720, from_details=True)
     check_power_options(soft_assert, test_instance, 'off')
@@ -212,6 +232,11 @@ def test_start(ec2_only, setup_provider_funcscope, provider_type, provider_mgmt,
 @pytest.mark.long_running
 def test_soft_reboot(setup_provider_funcscope, provider_type, provider_mgmt,
                      test_instance, soft_assert, verify_vm_running):
+    """ Tests instance soft reboot
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_ON, timeout=720, from_details=True)
     state_change_time = test_instance.get_detail(('Power Management', 'State Changed On'))
@@ -229,6 +254,11 @@ def test_soft_reboot(setup_provider_funcscope, provider_type, provider_mgmt,
 @pytest.mark.long_running
 def test_hard_reboot(openstack_only, setup_provider_funcscope, provider_type,
                      provider_mgmt, test_instance, soft_assert, verify_vm_running):
+    """ Tests instance hard reboot
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_ON, timeout=720, from_details=True)
     state_change_time = test_instance.get_detail(('Power Management', 'State Changed On'))
@@ -246,6 +276,11 @@ def test_hard_reboot(openstack_only, setup_provider_funcscope, provider_type,
 @pytest.mark.long_running
 def test_suspend(openstack_only, setup_provider_funcscope, provider_type, provider_mgmt,
                  test_instance, soft_assert, verify_vm_running):
+    """ Tests instance suspend
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_ON, timeout=720, from_details=True)
     check_power_options(soft_assert, test_instance, 'on')
@@ -263,6 +298,11 @@ def test_suspend(openstack_only, setup_provider_funcscope, provider_type, provid
 @pytest.mark.bugzilla(1183757)
 def test_resume(openstack_only, setup_provider_funcscope,
         provider_type, provider_mgmt, test_instance, soft_assert, verify_vm_suspended):
+    """ Tests instance resume
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_SUSPENDED, timeout=720, from_details=True)
     check_power_options(soft_assert, test_instance, 'off')
@@ -279,6 +319,11 @@ def test_resume(openstack_only, setup_provider_funcscope,
 @pytest.mark.long_running
 def test_terminate(setup_provider_funcscope,
         provider_type, provider_mgmt, test_instance, soft_assert, verify_vm_running):
+    """ Tests instance terminate
+
+    Metadata:
+        test_flag: power_control, provision
+    """
     test_instance.wait_for_vm_state_change(
         desired_state=test_instance.STATE_ON, timeout=720, from_details=True)
     test_instance.power_control_from_cfme(

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -57,6 +57,11 @@ def test_providers_discovery_amazon():
 
 @pytest.mark.usefixtures('has_no_cloud_providers')
 def test_provider_add_with_bad_credentials(provider_crud):
+    """ Tests provider add with bad credentials
+
+    Metadata:
+        test_flag: crud
+    """
     provider_crud.credentials = provider.get_credentials_from_config('bad_credentials')
     with error.expected('Login failed due to a bad username or password.'):
         provider_crud.create(validate_credentials=True)
@@ -64,7 +69,11 @@ def test_provider_add_with_bad_credentials(provider_crud):
 
 @pytest.mark.usefixtures('has_no_cloud_providers')
 def test_provider_crud(provider_crud):
-    """ Tests that a provider can be added """
+    """ Tests provider add with good credentials
+
+    Metadata:
+        test_flag: crud
+    """
     provider_crud.create()
     provider_crud.validate(db=False)
 

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -43,6 +43,11 @@ def vm_name(request, provider_mgmt):
 
 
 def test_provision_from_template(request, setup_provider, provider_crud, provisioning, vm_name):
+    """ Tests instance provision from template
+
+    Metadata:
+        test_flag: provision
+    """
     image = provisioning['image']['name']
     note = ('Testing provisioning from image %s to vm %s on provider %s' %
             (image, vm_name, provider_crud.key))
@@ -84,6 +89,11 @@ ONE_FIELD = """{:volume_id => "%s", :device_name => "%s"}"""
 def test_provision_from_template_with_attached_disks(
         request, setup_provider, provider_crud, provisioning, vm_name, provider_mgmt, disks,
         soft_assert):
+    """ Tests provisioning from a template and attaching disks
+
+    Metadata:
+        test_flag: provision
+    """
     if not isinstance(provider_crud, OpenStackProvider):
         pytest.skip("Openstack only so far")
     image = provisioning['image']['name']

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -17,4 +17,9 @@ def tenant(provider_key):
 
 
 def test_tenant(provider_mgmt, tenant, provider_key):
+    """ Tests tenant (currently disabled)
+
+    Metadata:
+        test_flag: tenant
+    """
     print tenant.name, tenant.description, provider_key

--- a/cfme/tests/configure/test_visuals.py
+++ b/cfme/tests/configure/test_visuals.py
@@ -47,6 +47,11 @@ def go_to_grid(page):
 
 @pytest.mark.parametrize('page', cfme_data.get('grid_pages'), scope="module")
 def test_grid_page_per_item(request, setup_first_provider, page, set_grid):
+    """ Tests grid items per page
+
+    Metadata:
+        test_flag: visuals
+    """
     request.addfinalizer(lambda: go_to_grid(page))
     limit = visual.grid_view_limit
     sel.force_navigate(page)
@@ -57,6 +62,11 @@ def test_grid_page_per_item(request, setup_first_provider, page, set_grid):
 
 @pytest.mark.parametrize('page', cfme_data.get('grid_pages'), scope="module")
 def test_tile_page_per_item(request, setup_first_provider, page, set_tile):
+    """ Tests tile items per page
+
+    Metadata:
+        test_flag: visuals
+    """
     request.addfinalizer(lambda: go_to_grid(page))
     limit = visual.tile_view_limit
     sel.force_navigate(page)
@@ -67,6 +77,11 @@ def test_tile_page_per_item(request, setup_first_provider, page, set_tile):
 
 @pytest.mark.parametrize('page', cfme_data.get('grid_pages'), scope="module")
 def test_list_page_per_item(request, setup_first_provider, page, set_list):
+    """ Tests list items per page
+
+    Metadata:
+        test_flag: visuals
+    """
     request.addfinalizer(lambda: go_to_grid(page))
     limit = visual.list_view_limit
     sel.force_navigate(page)
@@ -77,6 +92,11 @@ def test_list_page_per_item(request, setup_first_provider, page, set_list):
 
 @pytest.mark.parametrize('start_page', cfme_data.get('landing_pages'), scope="module")
 def test_start_page(request, setup_first_provider, start_page):
+    """ Tests start page
+
+    Metadata:
+        test_flag: visuals
+    """
     request.addfinalizer(set_default_page)
     visual.login_page = start_page
     login.logout()

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -236,6 +236,9 @@ def test_action_start_virtual_machine_after_stopping(request, assign_policy_for_
     This test sets the policy that it turns on the VM when it is turned off
     (https://www.youtube.com/watch?v=UOn4gxj2Dso), then turns the VM off and waits for it coming
     back alive.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power Off", ["Start Virtual Machine"])
@@ -255,6 +258,9 @@ def test_action_stop_virtual_machine_after_starting(request, assign_policy_for_t
     This test sets the policy that it turns off the VM when it is turned on
     (https://www.youtube.com/watch?v=UOn4gxj2Dso), then turns the VM on and waits for it coming
     back off.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power On", ["Stop Virtual Machine"])
@@ -274,6 +280,9 @@ def test_action_suspend_virtual_machine_after_starting(request,
 
     This test sets the policy that it suspends the VM when it's turned on. Then it powers on the vm,
     waits for it becoming alive and then it waits for the VM being suspended.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power On", ["Suspend Virtual Machine"])
@@ -295,6 +304,9 @@ def test_action_prevent_event(request, assign_policy_for_testing, vm, vm_off):
 
     This test sets the policy that it prevents powering the VM up. Then the vm is powered up
     and then it waits that VM does not come alive.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power On Request",
@@ -315,6 +327,9 @@ def test_action_power_on_logged(request, assign_policy_for_testing, vm, vm_off, 
 
     This test sets the policy that it logs powering on of the VM. Then it powers up the vm and
     checks whether logs contain message about that.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power On", ["Generate log message"])
@@ -349,6 +364,9 @@ def test_action_power_on_audit(request, assign_policy_for_testing, vm, vm_off, s
 
     This test sets the policy that it logs powering on of the VM. Then it powers up the vm and
     checks whether audit logs contain message about that.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power On", ["Generate Audit Event"])
@@ -381,6 +399,9 @@ def test_action_create_snapshot_and_delete_last(request, assign_policy_for_testi
 
     This test sets the policy that it makes snapshot of VM after it's powered off and when it is
     powered back on, it deletes the last snapshot.
+
+    Metadata:
+        test_flag: actions, provision
     """
     if isinstance(vm.provider, mgmt_system.RHEVMSystem):
         pytest.skip("No snapshots on RHEV")
@@ -421,6 +442,9 @@ def test_action_create_snapshots_and_delete_them(request, assign_policy_for_test
     This test sets the policy that it makes snapshot of VM after it's powered off and then it cycles
     several time that it generates a couple of snapshots. Then the 'Delete all Snapshots' is
     assigned to power on event, VM is powered on and it waits for all snapshots to disappear.
+
+    Metadata:
+        test_flag: actions, provision
     """
     if isinstance(vm.provider, mgmt_system.RHEVMSystem):
         pytest.skip("No snapshots on RHEV")
@@ -468,6 +492,9 @@ def test_action_initiate_smartstate_analysis(request, assign_policy_for_testing,
 
     This test sets the policy that it analyses VM after it's powered on. Then it checks whether
     that really happened.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power On",
@@ -502,6 +529,9 @@ def test_action_raise_automation_event(request, assign_policy_for_testing, vm, v
 
     This test sets the policy that it raises an automation event VM after it's powered on.
     Then it checks logs whether that really happened.
+
+    Metadata:
+        test_flag: actions, provision
     """
     # Set up the policy and prepare finalizer
     assign_policy_for_testing.assign_actions_to_event("VM Power Off", ["Raise Automation Event"])
@@ -529,6 +559,11 @@ def test_action_raise_automation_event(request, assign_policy_for_testing, vm, v
 
 # Purely custom actions
 def test_action_tag(request, assign_policy_for_testing, vm, vm_off):
+    """ Tests action tag
+
+    Metadata:
+        test_flag: actions, provision
+    """
     tag_assign_action = explorer.Action(
         generate_random_string(),
         action_type="Tag",
@@ -555,6 +590,11 @@ def test_action_tag(request, assign_policy_for_testing, vm, vm_off):
 
 
 def test_action_untag(request, assign_policy_for_testing, vm, vm_off):
+    """ Tests action untag
+
+    Metadata:
+        test_flag: actions, provision
+    """
     tag_unassign_action = explorer.Action(
         generate_random_string(),
         action_type="Remove Tags",

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -88,6 +88,11 @@ def setup_for_alerts(request, alerts, event, vm_name, provider_data, provider_ke
 def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(
         test_vm_power_control, provider_crud, provider_data, provider_mgmt, provider_type, request,
         smtp_test, provider_key, register_event):
+    """ Tests alerts for vm turned on more than twice in 15 minutes
+
+    Metadata:
+        test_flag: alerts, provision
+    """
     if test_vm_power_control is None or len(test_vm_power_control) == 0:
         pytest.skip("No power control vm specified!")
     test_vm_power_control = test_vm_power_control[0]

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -19,6 +19,8 @@ from utils.wait import wait_for
 
 pytestmark = [pytest.mark.long_running]
 
+pytest_generate_tests = testgen.generate(testgen.infra_providers, scope="module")
+
 random_vm_test = []
 
 
@@ -137,6 +139,9 @@ def test_vm(request, provider_crud, provider_mgmt, vm_name):
 def test_appliance_replicate_between_regions(request, provider_crud):
     """Tests that a provider added to an appliance in one region
         is replicated to the parent appliance in another region.
+
+    Metadata:
+        test_flag: replication
     """
     appl1, appl2 = get_replication_appliances()
 
@@ -158,6 +163,11 @@ def test_appliance_replicate_between_regions(request, provider_crud):
 
 @pytest.mark.ignore_stream("upstream")
 def test_appliance_replicate_sync_role_change(request, provider_crud):
+    """Tests that a role change is replicated
+
+    Metadata:
+        test_flag: replication
+    """
     appl1, appl2 = get_replication_appliances()
 
     def finalize():
@@ -188,6 +198,11 @@ def test_appliance_replicate_sync_role_change(request, provider_crud):
 
 @pytest.mark.ignore_stream("upstream")
 def test_appliance_replicate_sync_role_change_with_backlog(request, provider_crud):
+    """Tests that a role change is replicated with backlog
+
+    Metadata:
+        test_flag: replication
+    """
     appl1, appl2 = get_replication_appliances()
 
     def finalize():
@@ -218,6 +233,11 @@ def test_appliance_replicate_sync_role_change_with_backlog(request, provider_cru
 
 @pytest.mark.ignore_stream("upstream")
 def test_appliance_replicate_database_disconnection(request, provider_crud):
+    """Tests a database disconnection
+
+    Metadata:
+        test_flag: replication
+    """
     appl1, appl2 = get_replication_appliances()
 
     def finalize():
@@ -246,6 +266,11 @@ def test_appliance_replicate_database_disconnection(request, provider_crud):
 
 @pytest.mark.ignore_stream("upstream")
 def test_appliance_replicate_database_disconnection_with_backlog(request, provider_crud):
+    """Tests a database disconnection with backlog
+
+    Metadata:
+        test_flag: replication
+    """
     appl1, appl2 = get_replication_appliances()
 
     def finalize():
@@ -279,6 +304,9 @@ def test_distributed_vm_power_control(request, test_vm, provider_crud,
                                       verify_vm_running, register_event, soft_assert):
     """Tests that a replication parent appliance can control the power state of a
     VM being managed by a replication child appliance.
+
+    Metadata:
+        test_flag: replication
     """
     appl1, appl2 = get_replication_appliances()
 

--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -10,8 +10,8 @@ from utils.randomness import generate_random_string
 from utils.wait import wait_for
 
 pytestmark = [
-    pytest.mark.fixtureconf(server_roles="+automate +notifier"),
-    pytest.mark.usefixtures('server_roles', 'uses_infra_providers')
+    pytest.mark.usefixtures('uses_infra_providers'),
+    pytest.mark.meta(server_roles="+automate +notifier")
 ]
 
 
@@ -71,7 +71,11 @@ def vm_name():
 def test_provision_cloud_init(provider_init, provider_key, provider_crud, provider_type,
                               setup_ci_template,
                               provider_mgmt, provisioning, vm_name, smtp_test, request):
+    """Tests cloud init provisioning
 
+    Metadata:
+        test_flag: cloud_init, provision
+    """
     # generate_tests makes sure these have values
     template = provisioning.get('ci-image', None) or provisioning['image']['name']
     host, datastore = map(provisioning.get, ('host', 'datastore'))

--- a/cfme/tests/infrastructure/test_datastore_analysis.py
+++ b/cfme/tests/infrastructure/test_datastore_analysis.py
@@ -69,7 +69,10 @@ def get_host_data_by_name(provider_key, host_name):
 )
 def test_run_datastore_analysis(request, setup_provider, provider_key, provider_type,
                                 datastore_type, datastore_name):
-    """ Run host SmartState analysis
+    """Tests smarthost analysis
+
+    Metadata:
+        test_flag: datastore_analysis
     """
     test_datastore = datastore.Datastore(datastore_name, provider_key)
 

--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -30,6 +30,11 @@ def pytest_generate_tests(metafunc):
 
 
 def test_delete_cluster(setup_provider, provider_crud, remove_test):
+    """ Tests delete cluster
+
+    Metadata:
+        test_flag: delete_object
+    """
     cluster_name = remove_test['cluster']
     test_cluster = cluster.Cluster(name=cluster_name)
     test_cluster.delete(cancel=False)
@@ -39,6 +44,11 @@ def test_delete_cluster(setup_provider, provider_crud, remove_test):
 
 
 def test_delete_host(setup_provider, provider_crud, remove_test):
+    """ Tests delete host
+
+    Metadata:
+        test_flag: delete_object
+    """
     host_name = remove_test['host']
     test_host = host.Host(name=host_name)
     test_host.delete(cancel=False)
@@ -48,6 +58,11 @@ def test_delete_host(setup_provider, provider_crud, remove_test):
 
 
 def test_delete_vm(setup_provider, provider_crud, remove_test):
+    """ Tests delete vm
+
+    Metadata:
+        test_flag: delete_object
+    """
     vm = remove_test['vm']
     test_vm = virtual_machines.Vm(vm, provider_crud)
     test_vm.remove_from_cfme(cancel=False)
@@ -57,6 +72,11 @@ def test_delete_vm(setup_provider, provider_crud, remove_test):
 
 
 def test_delete_template(setup_provider, provider_crud, remove_test):
+    """ Tests delete template
+
+    Metadata:
+        test_flag: delete_object
+    """
     template = remove_test['template']
     test_template = virtual_machines.Template(template, provider_crud)
     test_template.remove_from_cfme(cancel=False)
@@ -66,6 +86,11 @@ def test_delete_template(setup_provider, provider_crud, remove_test):
 
 
 def test_delete_resource_pool(setup_provider, provider_crud, remove_test):
+    """ Tests delete pool
+
+    Metadata:
+        test_flag: delete_object
+    """
     resourcepool_name = remove_test['resource_pool']
     test_resourcepool = resource_pool.ResourcePool(name=resourcepool_name)
     test_resourcepool.delete(cancel=False)
@@ -75,6 +100,11 @@ def test_delete_resource_pool(setup_provider, provider_crud, remove_test):
 
 
 def test_delete_datastore(setup_provider, provider_crud, remove_test):
+    """ Tests delete datastore
+
+    Metadata:
+        test_flag: delete_object
+    """
     data_store = remove_test['datastore']
     test_datastore = datastore.Datastore(name=data_store)
     host_count = test_datastore.get_hosts()

--- a/cfme/tests/infrastructure/test_genealogy.py
+++ b/cfme/tests/infrastructure/test_genealogy.py
@@ -44,6 +44,11 @@ def vm_name():
 @pytest.mark.github("ManageIQ/manageiq:473")
 def test_vm_genealogy(
         setup_provider, vm_name, provider_crud, provisioning, soft_assert, provider_mgmt, request):
+    """Tests vm geneaology
+
+    Metadata:
+        test_flag: geneaology, provision
+    """
     if isinstance(provider_crud, RHEVMProvider):
         pytest.skip("RHEV-M does not support creating templates from VM")
     original_template = provisioning["template"]

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -56,7 +56,11 @@ def get_host_data_by_name(provider_key, host_name):
 )
 def test_run_host_analysis(request, setup_provider, provider_key, provider_type, provider_ver,
                            host_type, host_name, register_event, soft_assert):
-    """ Run host SmartState analysis """
+    """ Run host SmartState analysis
+
+    Metadata:
+        test_flag: host_analysis
+    """
     # Add credentials to host
     host_data = get_host_data_by_name(provider_key, host_name)
     test_host = host.Host(name=host_name)

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -25,7 +25,7 @@ def pytest_generate_tests(metafunc):
             test_id = '{}-{}-{}'.format(prov_key, test_host['type'], test_host['name'])
             idlist.append(test_id)
 
-    metafunc.parametrize(argnames, argvalues, ids=idlist, scope="module")
+    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
 def get_host_data_by_name(provider_key, host_name):
@@ -37,6 +37,11 @@ def get_host_data_by_name(provider_key, host_name):
 
 def test_host_drift_analysis(request, setup_provider, provider_key, host_type, host_name,
                              soft_assert):
+    """Tests host drift analysis
+
+    Metadata:
+        test_flag: host_drift_analysis
+    """
     host_data = get_host_data_by_name(provider_key, host_name)
     test_host = host.Host(name=host_name)
 

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -14,7 +14,7 @@ from utils import testgen
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate +notifier"),
-    pytest.mark.usefixtures('uses_infra_providers')
+    pytest.mark.usefixtures('uses_infra_providers'),
 ]
 
 
@@ -78,6 +78,11 @@ def setup_pxe_servers_host_prov(pxe_server, pxe_cust_template, host_provisioning
 @pytest.mark.usefixtures('setup_pxe_servers_host_prov')
 def test_host_provisioning(provider_init, cfme_data, host_provisioning,
                            provider_crud, smtp_test, request):
+    """Tests host provisioning
+
+    Metadata:
+        test_flag: host_provision
+    """
 
     # Add host before provisioning
     test_host = host.get_from_config('esx')

--- a/cfme/tests/infrastructure/test_iso_datastore.py
+++ b/cfme/tests/infrastructure/test_iso_datastore.py
@@ -6,7 +6,7 @@ from utils.providers import setup_provider
 
 pytestmark = [
     pytest.mark.usefixtures("logged_in"),
-    pytest.mark.usefixtures('uses_infra_providers')
+    pytest.mark.usefixtures('uses_infra_providers'),
 ]
 
 
@@ -49,6 +49,9 @@ def test_iso_datastore_crud(provider_init, no_iso_dss, provider_crud, iso_datast
 
     Note:
         An ISO datastore cannot be edited.
+
+    Metadata:
+        test_flag: iso
     """
     template_crud = pxe.ISODatastore(provider_crud.name)
     template_crud.create()

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -77,7 +77,11 @@ def vm_name():
 
 def test_iso_provision_from_template(provider_key, provider_crud, provider_type, provider_mgmt,
                                      provisioning, vm_name, smtp_test, provider_init, request):
+    """Tests ISO provisioning
 
+    Metadata:
+        test_flag: iso, provision
+    """
     # generate_tests makes sure these have values
     iso_template, host, datastore, iso_file, iso_kickstart,\
         iso_root_password, iso_image_type, vlan = map(provisioning.get, ('pxe_template', 'host',

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -11,6 +11,7 @@ from utils import providers
 from utils.randomness import generate_random_string
 from utils.update import update
 
+
 pytest_generate_tests = testgen.generate(testgen.infra_providers, scope="function")
 
 
@@ -122,6 +123,11 @@ def test_api_port_max_character_validation():
 
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_providers_discovery(request, provider_crud):
+    """Tests provider discovery
+
+    Metadata:
+        test_flag: crud
+    """
     provider.discover_from_provider(provider_crud)
     flash.assert_message_match('Infrastructure Providers: Discovery successfully initiated')
     request.addfinalizer(providers.clear_infra_providers)
@@ -130,6 +136,11 @@ def test_providers_discovery(request, provider_crud):
 
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_add_with_bad_credentials(provider_crud):
+    """Tests provider add with bad credentials
+
+    Metadata:
+        test_flag: crud
+    """
     provider_crud.credentials = provider.get_credentials_from_config('bad_credentials')
     if isinstance(provider_crud, provider.VMwareProvider):
         with error.expected('Cannot complete login due to an incorrect user name or password.'):
@@ -141,7 +152,11 @@ def test_provider_add_with_bad_credentials(provider_crud):
 
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_crud(provider_crud):
-    """ Tests that a provider can be added """
+    """Tests provider add with good credentials
+
+    Metadata:
+        test_flag: crud
+    """
     provider_crud.create()
     # Fails on upstream, all provider types - BZ1087476
     provider_crud.validate(db=False)

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -56,6 +56,11 @@ def vm_name():
 
 def test_provision_from_template(provider_init, provider_key, provider_crud, provider_type,
                                  provider_mgmt, provisioning, vm_name, smtp_test, request):
+    """ Tests provisioning from a template
+
+    Metadata:
+        test_flag: provision
+    """
 
     # generate_tests makes sure these have values
     template, host, datastore = map(provisioning.get, ('template', 'host', 'datastore'))
@@ -87,6 +92,11 @@ def test_provision_from_template(provider_init, provider_key, provider_crud, pro
 
 def test_provision_approval(provider_init, provider_key, provider_crud, provider_type,
                             provider_mgmt, provisioning, vm_name, smtp_test, request):
+    """ Tests provisioning approval
+
+    Metadata:
+        test_flag: provision
+    """
     # generate_tests makes sure these have values
     template, host, datastore = map(provisioning.get, ('template', 'host', 'datastore'))
 

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -124,6 +124,11 @@ def provisioner(request, provider_key, provider_mgmt, provider_crud):
 
 
 def test_change_cpu_ram(provisioner, prov_data, template_name, soft_assert):
+    """ Tests change RAM and CPU
+
+    Metadata:
+        test_flag: provision
+    """
     prov_data["vm_name"] = "test_prov_dlg_{}".format(generate_random_string())
     prov_data["num_sockets"] = "4"
     prov_data["cores_per_socket"] = "1"
@@ -140,6 +145,11 @@ def test_change_cpu_ram(provisioner, prov_data, template_name, soft_assert):
 
 @pytest.mark.parametrize("disk_format", ["thin", "thick", "preallocated"])
 def test_disk_format_select(provisioner, prov_data, template_name, disk_format, provider_type):
+    """ Tests disk format
+
+    Metadata:
+        test_flag: provision
+    """
     if (
             (provider_type == "rhevm" and disk_format == "thick") or
             (provider_type != "rhevm" and disk_format == "preallocated")):
@@ -162,6 +172,11 @@ def test_disk_format_select(provisioner, prov_data, template_name, disk_format, 
 @pytest.mark.parametrize("started", [True, False])
 def test_power_on_or_off_after_provision(
         provisioner, prov_data, template_name, provider_mgmt, started):
+    """ Tests power cycle after provisioning
+
+    Metadata:
+        test_flag: provision
+    """
     prov_data["vm_name"] = "test_prov_dlg_{}".format(generate_random_string())
     prov_data["power_on"] = started
 
@@ -175,6 +190,11 @@ def test_power_on_or_off_after_provision(
 
 
 def test_tag(provisioner, prov_data, template_name):
+    """ Tests tagging
+
+    Metadata:
+        test_flag: provision
+    """
     prov_data["vm_name"] = "test_prov_dlg_{}".format(generate_random_string())
     prov_data["apply_tags"] = [
         ([version.pick({version.LOWEST: "Service Level", "5.3": "Service Level *"}), "Gold"], True)]
@@ -186,6 +206,11 @@ def test_tag(provisioner, prov_data, template_name):
 
 
 def test_provisioning_schedule(provisioner, prov_data, template_name):
+    """ Tests provision scheduling
+
+    Metadata:
+        test_flag: provision
+    """
     prov_data["vm_name"] = "test_prov_dlg_{}".format(generate_random_string())
     prov_data["schedule_type"] = "schedule"
     now = datetime.utcnow()

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -81,6 +81,11 @@ def vm_name():
 @pytest.mark.usefixtures('setup_pxe_servers_vm_prov')
 def test_pxe_provision_from_template(provider_key, provider_crud, provider_type, provider_mgmt,
                                      provisioning, vm_name, smtp_test, provider_init, request):
+    """Tests provisioning via PXE
+
+    Metadata:
+        test_flag: pxe, provision
+    """
 
     # generate_tests makes sure these have values
     pxe_template, host, datastore, pxe_server, pxe_image, pxe_kickstart,\

--- a/cfme/tests/infrastructure/test_retirement.py
+++ b/cfme/tests/infrastructure/test_retirement.py
@@ -70,16 +70,31 @@ def verify_retirement(vm):
 
 
 def test_retirement_now(vm):
+    """Tests retirement
+
+    Metadata:
+        test_flag: retire, provision
+    """
     vm.retire()
     verify_retirement(vm)
 
 
 def test_set_retirement_date(vm):
+    """Tests retirement
+
+    Metadata:
+        test_flag: retire, provision
+    """
     vm.set_retirement_date(datetime.date.today())
     verify_retirement(vm)
 
 
 def test_unset_retirement_date(vm):
+    """Tests retirement
+
+    Metadata:
+        test_flag: retire, provision
+    """
     try:
         tomorrow = datetime.date.today() + datetime.timedelta(days=1)
         vm.set_retirement_date(tomorrow)

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -64,53 +64,68 @@ def new_snapshot(test_vm):
 
 
 def test_snapshot_crud(test_vm, provider_key):
-        snapshot = new_snapshot(test_vm)
-        snapshot.create()
-        snapshot.delete()
+    """Tests snapshot crud
+
+    Metadata:
+        test_flag: snapshot, provision
+    """
+    snapshot = new_snapshot(test_vm)
+    snapshot.create()
+    snapshot.delete()
 
 
 def test_delete_all_snapshots(test_vm, provider_key):
-        snapshot1 = new_snapshot(test_vm)
-        snapshot1.create()
-        snapshot2 = new_snapshot(test_vm)
-        snapshot2.create()
-        snapshot2.delete_all()
+    """Tests snapshot removal
+
+    Metadata:
+        test_flag: snapshot, provision
+    """
+    snapshot1 = new_snapshot(test_vm)
+    snapshot1.create()
+    snapshot2 = new_snapshot(test_vm)
+    snapshot2.create()
+    snapshot2.delete_all()
 
 
 def test_verify_revert_snapshot(test_vm, provider_key, soft_assert, register_event, request):
-        snapshot1 = new_snapshot(test_vm)
-        ip = snapshot1.vm.provider_crud.get_mgmt_system().get_ip_address(snapshot1.vm.name)
-        print ip
-        ssh_kwargs = {
-            'username': credentials['random_vm_ssh']['username'],
-            'password': credentials['random_vm_ssh']['password'],
-            'hostname': ip
-        }
-        ssh = SSHClient(**ssh_kwargs)
-        ssh.run_command('touch snapshot1.txt')
-        snapshot1.create()
-        ssh.run_command('touch snapshot2.txt')
-        snapshot2 = new_snapshot(test_vm)
-        snapshot2.create()
-        snapshot1.revert_to()
-        # Wait for the snapshot to become active
-        logger.info('Waiting for vm %s to become active', snapshot1.name)
-        wait_for(snapshot1.wait_for_snapshot_active, num_sec=300, delay=20, fail_func=sel.refresh)
-        test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_OFF, timeout=720)
-        register_event(
-            test_vm.provider_crud.get_yaml_data()['type'],
-            "vm", test_vm.name, ["vm_power_on_req", "vm_power_on"])
-        test_vm.power_control_from_cfme(option=Vm.POWER_ON, cancel=False)
-        pytest.sel.force_navigate(
-            'infrastructure_provider', context={'provider': test_vm.provider_crud})
-        test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_ON, timeout=900)
-        soft_assert(test_vm.find_quadicon().state == 'currentstate-on')
-        soft_assert(
-            test_vm.provider_crud.get_mgmt_system().is_vm_running(test_vm.name), "vm not running")
-        client = SSHClient(**ssh_kwargs)
-        status, out = client.run_command('test -e snapshot2.txt')
-        if status != 0:
-            logger.info('Revert to snapshot %s successful', snapshot1.name)
-        else:
-            logger.info('Revert to snapshot %s Failed', snapshot1.name)
-        request.addfinalizer(test_vm.delete_from_provider)
+    """Tests revert snapshot
+
+    Metadata:
+        test_flag: snapshot, provision
+    """
+    snapshot1 = new_snapshot(test_vm)
+    ip = snapshot1.vm.provider_crud.get_mgmt_system().get_ip_address(snapshot1.vm.name)
+    print ip
+    ssh_kwargs = {
+        'username': credentials['random_vm_ssh']['username'],
+        'password': credentials['random_vm_ssh']['password'],
+        'hostname': ip
+    }
+    ssh = SSHClient(**ssh_kwargs)
+    ssh.run_command('touch snapshot1.txt')
+    snapshot1.create()
+    ssh.run_command('touch snapshot2.txt')
+    snapshot2 = new_snapshot(test_vm)
+    snapshot2.create()
+    snapshot1.revert_to()
+    # Wait for the snapshot to become active
+    logger.info('Waiting for vm %s to become active', snapshot1.name)
+    wait_for(snapshot1.wait_for_snapshot_active, num_sec=300, delay=20, fail_func=sel.refresh)
+    test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_OFF, timeout=720)
+    register_event(
+        test_vm.provider_crud.get_yaml_data()['type'],
+        "vm", test_vm.name, ["vm_power_on_req", "vm_power_on"])
+    test_vm.power_control_from_cfme(option=Vm.POWER_ON, cancel=False)
+    pytest.sel.force_navigate(
+        'infrastructure_provider', context={'provider': test_vm.provider_crud})
+    test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_ON, timeout=900)
+    soft_assert(test_vm.find_quadicon().state == 'currentstate-on')
+    soft_assert(
+        test_vm.provider_crud.get_mgmt_system().is_vm_running(test_vm.name), "vm not running")
+    client = SSHClient(**ssh_kwargs)
+    status, out = client.run_command('test -e snapshot2.txt')
+    if status != 0:
+        logger.info('Revert to snapshot %s successful', snapshot1.name)
+    else:
+        logger.info('Revert to snapshot %s Failed', snapshot1.name)
+    request.addfinalizer(test_vm.delete_from_provider)

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -80,6 +80,11 @@ def count_events(vm_name, nav_step):
 
 
 def test_provider_event(provider_crud, gen_events, test_vm):
+    """Tests provider event on timelines
+
+    Metadata:
+        test_flag: timelines, provision
+    """
     def nav_step():
         pytest.sel.force_navigate('infrastructure_provider',
                                   context={'provider': provider_crud})
@@ -89,6 +94,11 @@ def test_provider_event(provider_crud, gen_events, test_vm):
 
 
 def test_host_event(provider_crud, gen_events, test_vm):
+    """Tests host event on timelines
+
+    Metadata:
+        test_flag: timelines, provision
+    """
     def nav_step():
         test_vm.load_details()
         pytest.sel.click(details_page.infoblock.element('Relationships', 'Host'))
@@ -98,6 +108,11 @@ def test_host_event(provider_crud, gen_events, test_vm):
 
 
 def test_vm_event(provider_crud, gen_events, test_vm):
+    """Tests vm event on timelines
+
+    Metadata:
+        test_flag: timelines, provision
+    """
     def nav_step():
         test_vm.load_details()
         toolbar.select('Monitoring', 'Timelines')
@@ -106,6 +121,11 @@ def test_vm_event(provider_crud, gen_events, test_vm):
 
 
 def test_cluster_event(provider_crud, gen_events, test_vm):
+    """Tests cluster event on timelines
+
+    Metadata:
+        test_flag: timelines, provision
+    """
     def nav_step():
         test_vm.load_details()
         pytest.sel.click(details_page.infoblock.element('Relationships', 'Cluster'))

--- a/cfme/tests/infrastructure/test_vm_analysis.py
+++ b/cfme/tests/infrastructure/test_vm_analysis.py
@@ -391,6 +391,11 @@ class TestVmAnalysisOfVmStates():
             os,
             fs_type,
             soft_assert):  # , register_event):
+        """Tests stopped vm
+
+        Metadata:
+            test_flag: vm_analysis
+        """
         _scan_test(provider_crud, vm, os, fs_type, soft_assert)
 
     def test_suspended_vm(
@@ -402,6 +407,11 @@ class TestVmAnalysisOfVmStates():
             os,
             fs_type,
             soft_assert):  # , register_event):
+        """Tests suspended vm
+
+        Metadata:
+            test_flag: vm_analysis, provision
+        """
         _scan_test(provider_crud, vm, os, fs_type, soft_assert)
 
 
@@ -426,4 +436,9 @@ class TestVmFileSystemsAnalysis():
             os,
             fs_type,
             soft_assert):  # , register_event):
+        """Tests running vm
+
+        Metadata:
+            test_flag: vm_analysis, provision
+        """
         _scan_test(provider_crud, vm, os, fs_type, soft_assert)

--- a/cfme/tests/infrastructure/test_vm_discovery.py
+++ b/cfme/tests/infrastructure/test_vm_discovery.py
@@ -47,6 +47,9 @@ def test_vm_discovery(request, setup_provider, provider_crud, provider_mgmt, vm_
     """
     Tests whether cfme will discover a vm change
     (add/delete) without being manually refreshed.
+
+    Metadata:
+        test_flag: discovery
     """
     vm = virtual_machines.Vm(vm_name, provider_crud)
 

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -9,7 +9,7 @@ from utils.wait import wait_for
 from utils import testgen
 
 pytestmark = [
-    pytest.mark.fixtureconf(server_roles="+automate")
+    pytest.mark.meta(server_roles="+automate")
 ]
 
 
@@ -28,6 +28,11 @@ def provider_init(provider_key):
 
 @pytest.mark.bugzilla(1174881)
 def test_vm_migrate(provider_init, provider_crud, provider_mgmt, request):
+    """Tests migration of a vm
+
+    Metadata:
+        test_flag: migrate, provision
+    """
     vm = Vm("vmtest", provider_crud)
     vm.migrate_vm("email@xyz.com", "first", "last", "host", "datstore")
     flash.assert_no_errors()

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -14,7 +14,6 @@ from utils.wait import wait_for, TimedOutError
 
 pytestmark = [pytest.mark.long_running]
 
-
 # GLOBAL vars
 random_vm_test = []    # use the same values(provider/vm) for all the quadicon tests
 
@@ -89,6 +88,11 @@ def if_scvmm_refresh_provider(provider):
 class TestControlOnQuadicons(object):
 
     def test_power_off_cancel(self, test_vm, verify_vm_running, soft_assert):
+        """Tests power off cancel
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_ON, timeout=720)
         test_vm.power_control_from_cfme(option=Vm.POWER_OFF, cancel=True)
         if_scvmm_refresh_provider(test_vm.provider_crud)
@@ -98,6 +102,11 @@ class TestControlOnQuadicons(object):
             test_vm.provider_crud.get_mgmt_system().is_vm_running(test_vm.name), "vm not running")
 
     def test_power_off(self, test_vm, verify_vm_running, soft_assert, register_event):
+        """Tests power off
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_ON, timeout=720)
         register_event(
             test_vm.provider_crud.get_yaml_data()['type'],
@@ -113,6 +122,11 @@ class TestControlOnQuadicons(object):
             not test_vm.provider_crud.get_mgmt_system().is_vm_running(test_vm.name), "vm running")
 
     def test_power_on_cancel(self, test_vm, verify_vm_stopped, soft_assert):
+        """Tests power on cancel
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_OFF, timeout=720)
         test_vm.power_control_from_cfme(option=Vm.POWER_ON, cancel=True)
         if_scvmm_refresh_provider(test_vm.provider_crud)
@@ -122,6 +136,11 @@ class TestControlOnQuadicons(object):
             not test_vm.provider_crud.get_mgmt_system().is_vm_running(test_vm.name), "vm running")
 
     def test_power_on(self, test_vm, verify_vm_stopped, soft_assert, register_event):
+        """Tests power on
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         test_vm.wait_for_vm_state_change(desired_state=Vm.STATE_OFF, timeout=720)
         register_event(
             test_vm.provider_crud.get_yaml_data()['type'],
@@ -201,6 +220,11 @@ class TestVmDetailsPowerControlPerProvider(object):
             not vm.is_pwr_option_available_in_cfme(option=Vm.RESET, from_details=from_details))
 
     def test_power_off(self, test_vm, verify_vm_running, soft_assert, register_event, bug):
+        """Tests power off
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         test_vm.wait_for_vm_state_change(
             desired_state=Vm.STATE_ON, timeout=720, from_details=True)
         last_boot_time = test_vm.get_detail(properties=("Power Management", "Last Boot Time"))
@@ -225,6 +249,11 @@ class TestVmDetailsPowerControlPerProvider(object):
                         "ui: {} should ==  orig: {}".format(new_last_boot_time, last_boot_time))
 
     def test_power_on(self, test_vm, verify_vm_stopped, soft_assert, register_event, bug):
+        """Tests power on
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         test_vm.wait_for_vm_state_change(
             desired_state='off', timeout=720, from_details=True)
         register_event(
@@ -253,6 +282,11 @@ class TestVmDetailsPowerControlPerProvider(object):
                         "ui: {} ==  orig: {}".format(new_last_boot_time, last_boot_time))
 
     def test_suspend(self, test_vm, verify_vm_running, soft_assert, register_event, bug):
+        """Tests suspend
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         test_vm.wait_for_vm_state_change(
             desired_state=Vm.STATE_ON, timeout=720, from_details=True)
         last_boot_time = test_vm.get_detail(properties=("Power Management", "Last Boot Time"))
@@ -284,6 +318,11 @@ class TestVmDetailsPowerControlPerProvider(object):
 
     def test_start_from_suspend(
             self, test_vm, verify_vm_suspended, soft_assert, register_event, bug):
+        """Tests start from suspend
+
+        Metadata:
+            test_flag: power_control, provision
+        """
         try:
             test_vm.provider_crud.refresh_provider_relationships()
             test_vm.wait_for_vm_state_change(
@@ -320,7 +359,7 @@ class TestVmDetailsPowerControlPerProvider(object):
 
 
 def test_no_template_power_control(provider_crud, setup_provider_funcscope):
-    """ Ensures that no power button is displayed for templates. """
+    """ Ensures that no power button is displayed for templates."""
     provider_crud.load_all_provider_templates()
     toolbar.set_vms_grid_view()
     try:

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -20,11 +20,11 @@ import utils.randomness as rand
 pytestmark = [
     pytest.mark.usefixtures("logged_in"),
     pytest.mark.usefixtures("vm_name"),
-    pytest.mark.fixtureconf(server_roles="+automate"),
-    pytest.mark.usefixtures('server_roles', 'uses_infra_providers'),
+    pytest.mark.usefixtures('uses_infra_providers'),
     pytest.mark.long_running,
     pytest.mark.ignore_stream("5.2"),
-    pytest.mark.ignore_stream("upstream")
+    pytest.mark.ignore_stream("upstream"),
+    pytest.mark.meta(server_roles="+automate")
 ]
 
 item_name = generate_random_string()
@@ -189,6 +189,11 @@ def myservice(provider_init, provider_key, provider_mgmt, catalog_item, request)
 
 
 def test_add_vm_to_service(request, myservice, create_method):
+    """Tests adding vm to service
+
+    Metadata:
+        test_flag: provision
+    """
 
     simulate(
         instance="Request",

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -90,6 +90,12 @@ def cleanup_vm(vm_name, provider_key, provider_mgmt):
 @pytest.mark.bugzilla(1144207)
 def test_cloud_catalog_item(provider_init, provider_key, provider_mgmt, provider_crud,
                             provider_type, provisioning, dialog, catalog, request):
+    """Tests cloud catalog item
+
+    Metadata:
+        test_flag: provision
+    """
+
     vm_name = 'test_servicecatalog-%s' % generate_random_string()
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
     image = provisioning['image']['name']

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -129,6 +129,11 @@ def catalog_item(setup_provider, provider_crud, provider_type, provisioning, vm_
 @pytest.mark.usefixtures('setup_iso_datastore')
 def test_rhev_iso_servicecatalog(setup_provider, provider_key, provider_mgmt,
                                  catalog_item, request):
+    """Tests RHEV ISO service catalog
+
+    Metadata:
+        test_flag: iso, provision
+    """
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
     catalog_item.create()

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -126,6 +126,11 @@ def catalog_item(provider_crud, provider_type,
 
 @pytest.fixture
 def myservice(provider_init, provider_key, provider_mgmt, catalog_item, request):
+    """Tests my service
+
+    Metadata:
+        test_flag: provision
+    """
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
     catalog_item.create()
@@ -144,17 +149,32 @@ def myservice(provider_init, provider_key, provider_mgmt, catalog_item, request)
 
 @pytest.mark.bugzilla(1144207)
 def test_retire_service(myservice):
+    """Tests my service
+
+    Metadata:
+        test_flag: provision
+    """
     myservice.retire()
 
 
 @pytest.mark.bugzilla(1144207)
 def test_retire_service_on_date(myservice):
+    """Tests my service retirement
+
+    Metadata:
+        test_flag: provision
+    """
     dt = datetime.utcnow()
     myservice.retire_on_date(dt)
 
 
 @pytest.mark.bugzilla(1144207)
 def test_myservice_crud(myservice):
+    """Tests my service crud
+
+    Metadata:
+        test_flag: provision
+    """
     myservice.update("edited", "edited_desc")
     edited_name = myservice.service_name + "_" + "edited"
     myservice.delete(edited_name)
@@ -162,9 +182,19 @@ def test_myservice_crud(myservice):
 
 @pytest.mark.bugzilla(1144207)
 def test_set_ownership(myservice):
+    """Tests my service ownership
+
+    Metadata:
+        test_flag: provision
+    """
     myservice.set_ownership("Administrator", "EvmGroup-administrator")
 
 
 @pytest.mark.bugzilla(1144207)
 def test_edit_tags(myservice):
+    """Tests my service edit tags
+
+    Metadata:
+        test_flag: provision
+    """
     myservice.edit_tags("Cost Center 001")

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -140,6 +140,11 @@ def catalog_item(provider_crud, provider_type, provisioning, vm_name, dialog, ca
 @pytest.mark.bugzilla(1160486)
 @pytest.mark.usefixtures('setup_providers', 'setup_pxe_servers_vm_prov')
 def test_rhev_pxe_servicecatalog(provider_key, provider_mgmt, catalog_item, request):
+    """Tests RHEV PXE service catalog
+
+    Metadata:
+        test_flag: pxe, provision
+    """
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
     catalog_item.create()

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -119,6 +119,11 @@ def catalog_item(provider_crud, provider_type, provisioning, vm_name, dialog, ca
 
 @pytest.mark.bugzilla(1144207)
 def test_order_catalog_item(provider_key, provider_mgmt, provider_init, catalog_item, request):
+    """Tests order catalog item
+
+    Metadata:
+        test_flag: provision
+    """
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
     catalog_item.create()
@@ -135,6 +140,12 @@ def test_order_catalog_item(provider_key, provider_mgmt, provider_init, catalog_
 
 @pytest.mark.bugzilla(1144207)
 def test_order_catalog_bundle(provider_key, provider_mgmt, provider_init, catalog_item, request):
+    """Tests ordering a catalog bundle
+
+    Metadata:
+        test_flag: provision
+    """
+
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
     catalog_item.create()
@@ -153,9 +164,15 @@ def test_order_catalog_bundle(provider_key, provider_mgmt, provider_init, catalo
     assert row.last_message.text == 'Request complete'
 
 
+# Note here this needs to be reduced, doesn't need to test against all providers
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_no_template_catalog_item(provider_crud, provider_type, provisioning,
                                   vm_name, dialog, catalog):
+    """Tests no template catalog item
+
+    Metadata:
+        test_flag: provision
+    """
     template, catalog_item_type = map(provisioning.get,
         ('template', 'catalog_item_type'))
     if provider_type == 'rhevm':

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -53,6 +53,12 @@ def provision_data(provider_crud, provider_key, provider_data, small_template, p
 @pytest.mark.meta(server_roles="+automate")
 @pytest.mark.usefixtures("setup_provider")
 def test_provision(request, provision_data, provider_mgmt):
+    """Tests provision via rest
+
+    Metadata:
+        test_flag: rest, provision
+    """
+
     vm_name = provision_data["vm_fields"]["vm_name"]
     request.addfinalizer(
         lambda: provider_mgmt.delete_vm(vm_name) if provider_mgmt.does_vm_exist(vm_name) else None)

--- a/cfme/tests/test_soap.py
+++ b/cfme/tests/test_soap.py
@@ -9,7 +9,6 @@ from utils.miq_soap import MiqVM, set_client
 from utils.providers import setup_a_provider as _setup_a_provider
 from utils.randomness import generate_random_string
 
-
 pytest_generate_tests = testgen.generate(
     testgen.infra_providers,
     "small_template",
@@ -25,35 +24,85 @@ def setup_a_provider():
 @pytest.mark.usefixtures("setup_a_provider")
 class TestSoapBasicInteraction(object):
     def test_connectivity(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert soap_client.service.EVMPing(), "Could not do EVMPing()!"
 
     def test_evm_host_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert isinstance(soap_client.service.EVMHostList(), list)
 
     def test_evm_vm_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert isinstance(soap_client.service.EVMVmList("*"), list)
 
     def test_evm_cluster_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert isinstance(soap_client.service.EVMClusterList(), list)
 
     def test_evm_resource_pool_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert isinstance(soap_client.service.EVMResourcePoolList(), list)
 
     def test_evm_datastore_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert isinstance(soap_client.service.EVMDatastoreList(), list)
 
     def test_get_ems_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert isinstance(soap_client.service.GetEmsList(), list)
 
     def test_version(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         assert isinstance(soap_client.service.Version(), list)
 
     @pytest.mark.bugzilla(1096768)
     def test_get_hosts_from_ems(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for ems in soap_client.service.GetEmsList():
             assert isinstance(soap_client.service.EVMGetHosts(ems.guid), list)
 
     def test_get_host(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for host in soap_client.service.EVMHostList():
             get_host = soap_client.service.EVMGetHost(host.guid)
             assert get_host.guid == host.guid
@@ -61,11 +110,21 @@ class TestSoapBasicInteraction(object):
 
     @pytest.mark.bugzilla(1096768)
     def test_get_clusters_from_ems(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for ems in soap_client.service.GetEmsList():
             assert isinstance(soap_client.service.EVMGetClusters(ems.guid), list)
 
     @pytest.mark.bugzilla(1096708)
     def test_get_cluster(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for cluster in soap_client.service.EVMClusterList():
             get_cluster = soap_client.service.EVMGetCluster(cluster.id)
             assert get_cluster.id == cluster.id
@@ -73,11 +132,21 @@ class TestSoapBasicInteraction(object):
 
     @pytest.mark.bugzilla(1096768)
     def test_get_resource_pools_from_ems(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for ems in soap_client.service.GetEmsList():
             assert isinstance(soap_client.service.EVMGetResourcePools(ems.guid), list)
 
     @pytest.mark.bugzilla(1096708)
     def test_get_resource_pool(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for resource_pool in soap_client.service.EVMResourcePoolList():
             get_resource_pool = soap_client.service.EVMGetResourcePool(resource_pool.id)
             assert get_resource_pool.id == resource_pool.id
@@ -85,11 +154,21 @@ class TestSoapBasicInteraction(object):
 
     @pytest.mark.bugzilla(1096768)
     def test_get_datastores_from_ems(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for ems in soap_client.service.GetEmsList():
             assert isinstance(soap_client.service.EVMGetDatastores(ems.guid), list)
 
     @pytest.mark.bugzilla(1096708)
     def test_get_datastore(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         for datastore in soap_client.service.EVMDatastoreList():
             get_datastore = soap_client.service.EVMGetDatastore(datastore.id)
             assert get_datastore.id == datastore.id
@@ -97,6 +176,11 @@ class TestSoapBasicInteraction(object):
 
     @pytest.mark.bugzilla(1096768)
     def test_get_vms_from_host(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         host = choice(soap_client.service.EVMHostList())
         vms = soap_client.service.EVMGetVms(host.guid)
         assert isinstance(vms, list)
@@ -106,32 +190,67 @@ class TestSoapBasicInteraction(object):
             assert get_vm.name == vm.name
 
     def test_get_host_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         ems = choice(soap_client.service.GetEmsList())
         assert isinstance(soap_client.service.GetHostList(ems.guid), list)
 
     def test_get_cluster_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         ems = choice(soap_client.service.GetEmsList())
         assert isinstance(soap_client.service.GetClusterList(ems.guid), list)
 
     def test_get_resource_pool_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         ems = choice(soap_client.service.GetEmsList())
         assert isinstance(soap_client.service.GetResourcePoolList(ems.guid), list)
 
     def test_get_datastore_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         ems = choice(soap_client.service.GetEmsList())
         assert isinstance(soap_client.service.GetDatastoreList(ems.guid), list)
 
     def test_get_vm_list(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         host = choice(soap_client.service.EVMHostList())
         assert isinstance(soap_client.service.GetVmList(host.guid), list)
 
     def test_find_ems_by_guid(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         ems = choice(soap_client.service.GetEmsList())
         get_ems = soap_client.service.FindEmsByGuid(ems.guid)
         assert get_ems.guid == ems.guid
         assert get_ems.name == ems.name
 
     def test_find_host_by_guid(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         host = choice(soap_client.service.EVMHostList())
         get_host = soap_client.service.FindHostByGuid(host.guid)
         assert get_host.guid == host.guid
@@ -139,6 +258,11 @@ class TestSoapBasicInteraction(object):
         assert isinstance(soap_client.service.FindHostsByGuid(host.guid), list)
 
     def test_find_cluster_by_id(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         cluster = choice(soap_client.service.EVMClusterList())
         get_cluster = soap_client.service.FindClusterById(cluster.id)
         assert get_cluster.id == cluster.id
@@ -146,6 +270,11 @@ class TestSoapBasicInteraction(object):
         assert isinstance(soap_client.service.FindClustersById(cluster.id), list)
 
     def test_find_datastore_by_id(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         datastore = choice(soap_client.service.EVMDatastoreList())
         get_datastore = soap_client.service.FindDatastoreById(datastore.id)
         assert get_datastore.id == datastore.id
@@ -153,6 +282,11 @@ class TestSoapBasicInteraction(object):
         assert isinstance(soap_client.service.FindDatastoresById(datastore.id), list)
 
     def test_find_resource_pool_by_id(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         resource_pool = choice(soap_client.service.EVMResourcePoolList())
         get_resource_pool = soap_client.service.FindResourcePoolById(resource_pool.id)
         assert get_resource_pool.id == resource_pool.id
@@ -161,6 +295,11 @@ class TestSoapBasicInteraction(object):
 
     # Goes through hosts because EVMVmList does not work at all.
     def test_find_vm_by_guid(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         vm = choice(soap_client.service.EVMVmList("*"))
         get_vm = soap_client.service.FindVmByGuid(vm.guid)
         assert get_vm.guid == vm.guid
@@ -169,15 +308,30 @@ class TestSoapBasicInteraction(object):
 
     # Goes through hosts because EVMVmList does not work at all.
     def test_evm_vm_software(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         vm = choice(soap_client.service.EVMVmList("*"))
         assert isinstance(soap_client.service.EVMVmSoftware(vm.guid), list)
 
     # Goes through hosts because EVMVmList does not work at all.
     def test_evm_vm_accounts(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         vm = choice(soap_client.service.EVMVmList("*"))
         assert isinstance(soap_client.service.EVMVmAccounts(vm.guid), list)
 
     def test_ems_tagging(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         ems = choice(soap_client.service.GetEmsList())
         # Prepare (find the opposite tag if already tagged)
         cc = "001"
@@ -195,6 +349,11 @@ class TestSoapBasicInteraction(object):
             pytest.fail("Could not find tags for Ems {}".format(ems.name))
 
     def test_cluster_tagging(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         cluster = choice(soap_client.service.EVMClusterList())
         # Prepare (find the opposite tag if already tagged)
         cc = "001"
@@ -212,6 +371,11 @@ class TestSoapBasicInteraction(object):
             pytest.fail("Could not find tags for cluster {}".format(cluster.name))
 
     def test_datastore_tagging(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         datastore = choice(soap_client.service.EVMDatastoreList())
         # Prepare (find the opposite tag if already tagged)
         cc = "001"
@@ -229,6 +393,11 @@ class TestSoapBasicInteraction(object):
             pytest.fail("Could not find tags for datastore {}".format(datastore.name))
 
     def test_host_tagging(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         host = choice(soap_client.service.EVMHostList())
         # Prepare (find the opposite tag if already tagged)
         cc = "001"
@@ -246,6 +415,11 @@ class TestSoapBasicInteraction(object):
             pytest.fail("Could not find tags for host {}".format(host.name))
 
     def test_resource_pool_tagging(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         pool = choice(soap_client.service.EVMResourcePoolList())
         # Prepare (find the opposite tag if already tagged)
         cc = "001"
@@ -263,6 +437,11 @@ class TestSoapBasicInteraction(object):
             pytest.fail("Could not find tags for pool {}".format(pool.name))
 
     def test_vm_tagging(self, soap_client):
+        """Tests soap
+
+        Metadata:
+            test_flag: soap
+        """
         vm = choice(soap_client.service.EVMVmList("*"))
         # Prepare (find the opposite tag if already tagged)
         cc = "001"
@@ -287,6 +466,11 @@ class TestSoapBasicInteraction(object):
 @pytest.mark.usefixtures("setup_provider")
 def test_provision_via_soap(
         request, soap_client, provider_key, provider_data, provider_mgmt, small_template):
+    """Tests soap
+
+    Metadata:
+        test_flag: soap, provision
+    """
     vm_name = "test_soap_provision_{}".format(generate_random_string())
     vlan = provider_data.get("provisioning", {}).get("vlan", None)
 

--- a/cfme/tests/test_utilization.py
+++ b/cfme/tests/test_utilization.py
@@ -32,7 +32,11 @@ def handle_provider(provider_key):
 
 
 def test_metrics_collection(handle_provider, provider_key, provider_crud, enable_candu):
-    '''check the db is gathering collection data for the given provider'''
+    """check the db is gathering collection data for the given provider
+
+    Metadata:
+        test_flag: metrics_collection
+    """
     metrics_tbl = db.cfmedb()['metrics']
     mgmt_systems_tbl = db.cfmedb()['ext_management_systems']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
-    'utils.nelson',
+    'fixtures.nelson',
     'utils.apidoc'
 ]
 

--- a/docs/guides/documenting.rst
+++ b/docs/guides/documenting.rst
@@ -15,11 +15,11 @@ should be `built locally <#building-the-docs>`_ before making a pull request.
 docstrings
 ----------
 
-The cartouche library parses our docstrings and turns them into nicely rendered API docs
-in the sphinx output. As such, we should follow cartouche's usage guidelines when writing
+The napoleon library parses our docstrings and turns them into nicely rendered API docs
+in the sphinx output. As such, we should follow napoleon's usage guidelines when writing
 docstrings:
 
-    http://cartouche.readthedocs.org/en/latest/usage.html
+    https://pypi.python.org/pypi/sphinxcontrib-napoleon
 
 According to PEP 257, docstrings should use triple double-quotes, not triple single-quotes
 (""" vs. ''').
@@ -31,6 +31,33 @@ Example:
     """This is a docstring."""
 
     '''This is not a docstring.'''
+
+Documenting Tests
+-----------------
+
+Tests are documented slightly differently to modules, in that they require certain extra
+information that isn't required for a module/class/function. If a test uses the testgen library
+it **must** also specify a test_flag in the metadata section. An example of this is shown below.
+
+.. code:: yaml
+
+    """Tests provisioning via PXE
+
+    Metadata:
+        test_flag: pxe, provision
+    """
+
+These flags are also defined in the ``cfme_data.yaml`` file, under the ``test_flags:`` key. A
+provider in the ``cfme_data.yaml`` can opt out of collection for a particular *test_flag* by
+including the flag in the list of ``excluded_test_flags:`` key in the providers stanza.
+All of the flags listings are listed in comma separated format. This was chosen to cut down on
+syntax characters and all values are whitespace stripped.
+
+For a test to be collected for a provider:
+ * the *test_flag* must be listed in the ``cfme_data.yaml`` file ``test_flags:`` key
+ * the *test_flag* must be listed in the metadata section of the test's docstring
+ * the *test_flag* must **NOT** appear in the list of ``excluded_test_flags:`` for a particular
+   provider
 
 Linking new modules
 -------------------

--- a/fixtures/nelson.py
+++ b/fixtures/nelson.py
@@ -1,28 +1,52 @@
+import os
+from textwrap import dedent
+from types import FunctionType
+
 from six import iteritems
 from sphinxcontrib.napoleon import _skip_member, Config
 from sphinxcontrib.napoleon import docstring
 from sphinxcontrib.napoleon.docstring import NumpyDocstring
 import sphinx
 
+from utils.log import get_rel_path, logger
+
+config = Config(napoleon_use_param=True, napoleon_use_rtype=True)
+
+
+def pytest_pycollect_makeitem(collector, name, obj):
+    """pytest hook that adds docstring metadata (if found) to a test's meta mark"""
+    if not isinstance(obj, FunctionType) and not hasattr(obj, 'meta'):
+        # This relies on the meta mark having already been applied to
+        # all test functions before this hook is called
+        return
+
+    # __doc__ can be empty or nonexistent, make sure it's an empty string in that case
+    doc = getattr(obj, '__doc__') or ''
+    p = GoogleDocstring(stripper(doc), config)
+
+    obj.meta.kwargs.update({
+        'from_docs': p.metadata
+    })
+    if p.metadata:
+        test_path = get_rel_path(collector.fspath)
+        logger.debug('Parsed docstring metadata on {} in {}'.format(name, test_path))
+        logger.trace('{} doc metadata: {}'.format(name, str(p.metadata)))
+
 
 def stripper(docstring):
-    lines = docstring.split("\n")
+    """Slightly smarter :func:`dedent <python:textwrap.dedent>`
 
-    indent = 100
-    for line in lines[1:]:
-        whitespace = line.lstrip()
-        if whitespace:
-            indent = min(indent, len(line) - len(whitespace))
+    It strips a docstring's first line indentation and dedents the rest
 
-    trimmed_lines = [lines[0].strip()]
-    for line in lines[1:]:
-        trimmed_line = line[indent:].rstrip()
-        trimmed_lines.append(trimmed_line)
-
-    return "\n".join(trimmed_lines)
+    """
+    lines = docstring.splitlines()
+    return os.linesep.join([
+        lines[0].strip(), dedent("\n".join(lines[1:]))
+    ])
 
 
 class GoogleDocstring(docstring.GoogleDocstring):
+    """Custom version of napoleon's GoogleDocstring that adds some special cases"""
     def __init__(self, *args, **kwargs):
         self.metadata = {}
         super(GoogleDocstring, self).__init__(*args, **kwargs)
@@ -60,23 +84,8 @@ class GoogleDocstring(docstring.GoogleDocstring):
 def setup(app):
     """Sphinx extension setup function.
 
-    When the extension is loaded, Sphinx imports this module and executes
-    the ``setup()`` function, which in turn notifies Sphinx of everything
-    the extension offers.
-
-    Parameters
-    ----------
-    app : sphinx.application.Sphinx
-        Application object representing the Sphinx process
-
-    See Also
-    --------
-    The Sphinx documentation on `Extensions`_, the `Extension Tutorial`_, and
-    the `Extension API`_.
-
-    .. _Extensions: http://sphinx-doc.org/extensions.html
-    .. _Extension Tutorial: http://sphinx-doc.org/ext/tutorial.html
-    .. _Extension API: http://sphinx-doc.org/ext/appapi.html
+    See Also:
+        http://sphinx-doc.org/extensions.html
 
     """
     from sphinx.application import Sphinx

--- a/fixtures/nelson.py
+++ b/fixtures/nelson.py
@@ -24,6 +24,8 @@ def pytest_pycollect_makeitem(collector, name, obj):
     doc = getattr(obj, '__doc__') or ''
     p = GoogleDocstring(stripper(doc), config)
 
+    if not hasattr(obj.meta, 'kwargs'):
+        obj.meta.kwargs = dict()
     obj.meta.kwargs.update({
         'from_docs': p.metadata
     })
@@ -39,10 +41,13 @@ def stripper(docstring):
     It strips a docstring's first line indentation and dedents the rest
 
     """
-    lines = docstring.splitlines()
-    return os.linesep.join([
-        lines[0].strip(), dedent("\n".join(lines[1:]))
-    ])
+    if docstring:
+        lines = docstring.splitlines()
+        return os.linesep.join([
+            lines[0].strip(), dedent("\n".join(lines[1:]))
+        ])
+    else:  # If docstring is a null string, GoogleDocstring will expect an iterable type
+        return ''
 
 
 class GoogleDocstring(docstring.GoogleDocstring):

--- a/markers/meta.py
+++ b/markers/meta.py
@@ -44,8 +44,10 @@ after this selection, only the action with the most matched keywords is called. 
 in your mind. If this is not enough in the future, it can be extended if you wish.
 
 """
-import pytest
 from collections import namedtuple
+from types import FunctionType
+
+import pytest
 
 from utils import kwargify
 from utils.log import logger
@@ -65,9 +67,16 @@ def pytest_configure(config):
 
 
 @pytest.mark.tryfirst
+def pytest_pycollect_makeitem(collector, name, obj):
+    # Put the meta mark on objects as soon as pytest begins to collect them
+    if isinstance(obj, FunctionType) and not hasattr(obj, 'meta'):
+        pytest.mark.meta(obj)
+
+
+@pytest.mark.tryfirst
 def pytest_collection_modifyitems(session, config, items):
     for item in items:
-        item._metadata = metadict()
+        item._metadata = metadict(item.function.meta.kwargs)
         meta = item.get_marker("meta")
         if meta is None:
             continue

--- a/test_metadoc.py
+++ b/test_metadoc.py
@@ -1,0 +1,15 @@
+import pytest
+
+pytestmark = pytest.mark.meta(from_pytest='yep')
+
+@pytest.mark.meta(from_decorator='seems to be')
+def test_metadoc(meta):
+    """This test function has a docstring!
+
+    Metadata:
+
+        valid_yaml: True
+    """
+    assert meta['from_docs']['valid_yaml']
+    assert meta['from_pytest'] == 'yep'
+    assert meta['from_decorator'] == 'seems to be'

--- a/utils/tests/test_metadoc.py
+++ b/utils/tests/test_metadoc.py
@@ -2,6 +2,7 @@ import pytest
 
 pytestmark = pytest.mark.meta(from_pytest='yep')
 
+
 @pytest.mark.meta(from_decorator='seems to be')
 def test_metadoc(meta):
     """This test function has a docstring!


### PR DESCRIPTION
This allows us to group tests together and make sure providers are allowed to run those particular tests, as an example in the commit, ```test_provision_from_template``` has been marked with ```provision``` by using the **metadata** marker. ```pytest.mark.meta(test_flag="provision")```. By default all providers run against ALL flags, but specific flags can be disabled by adding them to a ```excluded_test_flags``` field in the provider yaml stanza.