### PR TITLE
Fixture for level_rails debug for perf ui tests

### DIFF
--- a/cfme/tests/perf/test_ui_automate.py
+++ b/cfme/tests/perf/test_ui_automate.py
@@ -20,6 +20,7 @@ customization_filters = [
 
 
 @pytest.mark.perf_ui_automate
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_automate_explorer(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -37,6 +38,7 @@ def test_perf_ui_automate_explorer(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_automate
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_automate_customization(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/cfme/tests/perf/test_ui_cloud.py
+++ b/cfme/tests/perf/test_ui_cloud.py
@@ -36,7 +36,7 @@ vm_cloud_filters = [
 
 
 @pytest.mark.perf_ui_cloud
-@pytest.mark.usefixtures("setup_cloud_providers")
+@pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_cloud_providers(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -52,7 +52,7 @@ def test_perf_ui_cloud_providers(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_cloud
-@pytest.mark.usefixtures("setup_cloud_providers")
+@pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_cloud_availability_zones(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -70,7 +70,7 @@ def test_perf_ui_cloud_availability_zones(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_cloud
-@pytest.mark.usefixtures("setup_cloud_providers")
+@pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_cloud_tenants(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -88,7 +88,7 @@ def test_perf_ui_cloud_tenants(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_cloud
-@pytest.mark.usefixtures("setup_cloud_providers")
+@pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_cloud_flavors(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -106,7 +106,7 @@ def test_perf_ui_cloud_flavors(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_cloud
-@pytest.mark.usefixtures("setup_cloud_providers")
+@pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_cloud_security_groups(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -124,7 +124,7 @@ def test_perf_ui_cloud_security_groups(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_cloud
-@pytest.mark.usefixtures("setup_cloud_providers")
+@pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_cloud_vm_explorer(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/cfme/tests/perf/test_ui_configure.py
+++ b/cfme/tests/perf/test_ui_configure.py
@@ -18,6 +18,7 @@ configuration_filters = [
 
 
 @pytest.mark.perf_ui_configure
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_configure_configuration(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/cfme/tests/perf/test_ui_control.py
+++ b/cfme/tests/perf/test_ui_control.py
@@ -20,6 +20,7 @@ explorer_filters = [
 
 
 @pytest.mark.perf_ui_control
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_control_explorer(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/cfme/tests/perf/test_ui_infrastructure.py
+++ b/cfme/tests/perf/test_ui_infrastructure.py
@@ -70,7 +70,7 @@ infra_pxe_filters = [
 
 
 @pytest.mark.perf_ui_infrastructure
-@pytest.mark.usefixtures("setup_infrastructure_providers")
+@pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_infra_providers(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -86,7 +86,7 @@ def test_perf_ui_infra_providers(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_infrastructure
-@pytest.mark.usefixtures("setup_infrastructure_providers")
+@pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_infra_clusters(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -113,7 +113,7 @@ def test_perf_ui_infra_clusters(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_infrastructure
-@pytest.mark.usefixtures("setup_infrastructure_providers")
+@pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_infra_hosts(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -131,7 +131,7 @@ def test_perf_ui_infra_hosts(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_infrastructure
-@pytest.mark.usefixtures("setup_infrastructure_providers")
+@pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_infra_vm_explorer(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -150,7 +150,7 @@ def test_perf_ui_infra_vm_explorer(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_infrastructure
-@pytest.mark.usefixtures("setup_infrastructure_providers")
+@pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_infra_resource_pools(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -178,7 +178,7 @@ def test_perf_ui_infra_resource_pools(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_infrastructure
-@pytest.mark.usefixtures("setup_infrastructure_providers")
+@pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_infra_datastores(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -196,7 +196,7 @@ def test_perf_ui_infra_datastores(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_infrastructure
-@pytest.mark.usefixtures("setup_infrastructure_providers")
+@pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
 def test_perf_ui_infra_pxe(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/cfme/tests/perf/test_ui_intelligence.py
+++ b/cfme/tests/perf/test_ui_intelligence.py
@@ -19,6 +19,7 @@ chargeback_filters = [
 
 
 @pytest.mark.perf_ui_intelligence
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_intelligence_reports(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -38,6 +39,7 @@ def test_perf_ui_intelligence_reports(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_intelligence
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_intelligence_chargeback(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/cfme/tests/perf/test_ui_optimize.py
+++ b/cfme/tests/perf/test_ui_optimize.py
@@ -21,6 +21,7 @@ bottlenecks_filters = [
 
 
 @pytest.mark.perf_ui_optimize
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_optimize_utilization(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -37,6 +38,7 @@ def test_perf_ui_optimize_utilization(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_optimize
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_optimize_bottlenecks(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/cfme/tests/perf/test_ui_services.py
+++ b/cfme/tests/perf/test_ui_services.py
@@ -22,6 +22,7 @@ workloads_filters = [
 
 
 @pytest.mark.perf_ui_services
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_services_my_services(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -38,6 +39,7 @@ def test_perf_ui_services_my_services(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_services
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_services_catalogs(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 
@@ -56,6 +58,7 @@ def test_perf_ui_services_catalogs(ssh_client, soft_assert):
 
 
 @pytest.mark.perf_ui_services
+@pytest.mark.usefixtures("cfme_log_level_rails_debug")
 def test_perf_ui_services_workloads(ssh_client, soft_assert):
     pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
 

--- a/fixtures/perf.py
+++ b/fixtures/perf.py
@@ -1,0 +1,62 @@
+from utils.ssh import SSHClient, SSHTail
+from utils.db import get_yaml_config, set_yaml_config
+from utils.log import logger
+import pytest
+import time
+
+
+@pytest.yield_fixture(scope='session')
+def cfme_log_level_rails_debug():
+    set_rails_loglevel('debug')
+    yield
+    set_rails_loglevel('info')
+
+
+def get_worker_pid(worker_type):
+    """Obtains the pid of the first worker with the worker_type specified"""
+    ssh_client = SSHClient()
+    exit_status, out = ssh_client.run_command('service evmserverd status 2> /dev/null | grep '
+        '\'{}\' | awk \'{{print $7}}\''.format(worker_type))
+    worker_pid = str(out).strip()
+    if out:
+        logger.info('Obtained {} PID: {}'.format(worker_type, worker_pid))
+    else:
+        logger.error('Could not obtain {} PID, check evmserverd running or if specific role is'
+            ' enabled...'.format(worker_type))
+        assert out
+    return worker_pid
+
+
+def set_rails_loglevel(level, validate_against_worker='MiqUiWorker'):
+    # Currently use the ui worker to check that rails level was changed
+    ui_worker_pid = '#{}'.format(get_worker_pid(validate_against_worker))
+
+    logger.info('Setting log level_rails on appliance to {}'.format(level))
+    yaml = get_yaml_config('vmdb')
+    if not str(yaml['log']['level_rails']).lower() == level.lower():
+        logger.info('Opening /var/www/miq/vmdb/log/evm.log for tail')
+        evm_tail = SSHTail('/var/www/miq/vmdb/log/evm.log')
+        evm_tail.set_initial_file_end()
+
+        yaml['log']['level_rails'] = level
+        set_yaml_config("vmdb", yaml)
+
+        attempts = 0
+        detected = False
+        while (not detected and attempts < 60):
+            logger.debug('Attempting to detect log level_rails change: {}'.format(attempts))
+            for line in evm_tail:
+                if ui_worker_pid in line:
+                    if 'Log level for production.log has been changed to' in line:
+                        # Detects a log level change but does not validate the log level
+                        logger.info('Detected change to log level for production.log')
+                        detected = True
+                        break
+            time.sleep(1)  # Allow more log lines to accumulate
+            attempts += 1
+        if not (attempts < 60):
+            # Note the error in the logger but continue as the appliance could be slow at logging
+            # that the log level changed
+            logger.error('Could not detect log level_rails change.')
+    else:
+        logger.info('Log level_rails already set to {}'.format(level))


### PR DESCRIPTION
This fixture exposes all queries by enabling changing the log level for level_rails from info to debug.  This allows the perf UI tests to perform analysis of the number of queries per page render.