### PR TITLE
Added require_fields to testgen parametrized tests

### DIFF
--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -5,7 +5,6 @@ from utils import testgen
 from utils.randomness import generate_random_string
 
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, ['openstack'],
-                                         'provider_key', 'provider_mgmt', 'provider_data',
                                          scope='module')
 
 

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -16,7 +16,7 @@ pytestmark = [pytest.mark.long_running]
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provider_key')
+    argnames, argvalues, idlist = testgen.infra_providers(metafunc)
 
     new_idlist = []
     new_argvalues = []

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -298,11 +298,14 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
         for key in data_values.keys():
             if data_values[key] is None:
                 if 'require_fields' not in options:
-                    options['require_fields'] = False
+                    options['require_fields'] = True
                 if options['require_fields']:
                     skip = True
-                    idlist.remove(provider)
-                    logger.debug('Field "%s" not defined for provider "%s", skipping' %
+                    try:
+                        idlist.remove(provider)
+                    except ValueError:
+                        pass
+                    logger.warning('Field "%s" not defined for provider "%s", skipping' %
                         (key, provider)
                     )
                 else:
@@ -345,12 +348,12 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
     return argnames, argvalues, idlist
 
 
-def cloud_providers(metafunc, *fields):
+def cloud_providers(metafunc, *fields, **options):
     """Wrapper for :py:func:`provider_by_type` that pulls types from
     :py:attr:`utils.providers.cloud_provider_type_map`
 
     """
-    return provider_by_type(metafunc, cloud_provider_type_map, *fields)
+    return provider_by_type(metafunc, cloud_provider_type_map, *fields, **options)
 
 
 def infra_providers(metafunc, *fields, **options):


### PR DESCRIPTION
Added require_fields to testgen parametrized tests to make it sure that the tests don't go crazy when some not-so-well specified provider will come in.