### PR TITLE
Added filtering possibilities for setup-a_provider()

### DIFF
--- a/cfme/tests/services/test_direct_links.py
+++ b/cfme/tests/services/test_direct_links.py
@@ -21,7 +21,14 @@ pytestmark = [
 
 @pytest.fixture(scope="module")
 def provider():
-    return setup_a_provider("infra")
+    return setup_a_provider(
+        "infra",
+        key_fields=[
+            ("provisioning", "template"),
+            ("provisioning", "host"),
+            ("provisioning", "datastore"),
+        ]
+    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Might be useful as in the direct links tests since scvmm does not have some yaml fields because the provisioning is not supported yet.