### PR TITLE
EC2 Cleanup

### DIFF
--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -21,7 +21,7 @@ def parse_cmd_line():
         help='Max days since the VM was created or last powered on (varies by provider, default 2)')
     parser.add_argument('--provider', dest='providers', action='append', default=None,
         help='Provider(s) to inspect, can be used multiple times', metavar='PROVIDER')
-    parser.add_argument('text_to_match', nargs='*', default=['^test_', '^jenkins'],
+    parser.add_argument('text_to_match', nargs='*', default=['^test_', '^jenkins', '^i-'],
         help='Regex in the name of vm to be affected, can be use multiple times'
         ' (Defaults to "^test_" and "^jenkins")')
     args = parser.parse_args()

--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -1200,7 +1200,8 @@ class EC2System(MgmtSystemAPIBase):
 
     def list_vm(self):
         """Returns a list from instance IDs currently active on EC2 (not terminated)"""
-        return [inst.id for inst in self._get_all_instances() if inst.state != 'terminated']
+        instances = [inst for inst in self._get_all_instances() if inst.state != 'terminated']
+        return [i.tags.get('Name', i.id) for i in instances]
 
     def list_template(self):
         private_images = self.api.get_all_images(owners=['self'],


### PR DESCRIPTION
* list_vm() uses Name tag if present (makes the cleanup script work again)
* cleanup script now checks for old `^i-` instances.