### PR TITLE
Skips are now treated as failures

### DIFF
--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -177,7 +177,7 @@ class Reporter(ArtifactorBasePlugin):
 
         if self.only_failed:
             template_data['tests'] = [x for x in template_data['tests']
-                                  if x['outcomes']['overall'] not in ['skipped', 'passed']]
+                                  if x['outcomes']['overall'] not in ['passed']]
 
         # Render the report
         data = template_env.get_template('test_report.html').render(**template_data)


### PR DESCRIPTION
From a reporting PoV, skips are now treated as failures so that the
only_failed option in artifactor shows up skips and failures, not just
failures.