### PR TITLE
Fix customization_paginator test 

### DIFF
--- a/cfme/automate/service_dialogs.py
+++ b/cfme/automate/service_dialogs.py
@@ -50,8 +50,8 @@ element_form = Form(fields=[
 ])
 
 dialogs_table = SplitTable(
-    header_data=("//div[@id='records_div']//table[contains(@class, 'hdr')]", 1),
-    body_data=("//div[@id='records_div']//div[contains(@class, 'objbox')]/table", 1))
+    header_data=('//div[@class="xhdr"]/table/tbody', 1),
+    body_data=('//div[@class="objbox"]/table/tbody', 1))
 
 
 def _all_servicedialogs_add_new(context):

--- a/cfme/tests/automate/test_customization_paginator.py
+++ b/cfme/tests/automate/test_customization_paginator.py
@@ -10,9 +10,15 @@ from utils.randomness import generate_random_string
 def some_dialogs(request):
     to_delete = []
     request.addfinalizer(lambda: map(lambda obj: obj.delete(), to_delete))
-    for i in range(15):
-        desc = "test_paginator_{}".format(generate_random_string(16))
-        dialog = ServiceDialog(label=desc, description=desc)
+    for i in range(6):
+        random_str = generate_random_string(16)
+        dialog = ServiceDialog(
+            label='test_paginator_{}'.format(random_str),
+            tab_label='tab_{}'.format(random_str),
+            box_label='box_{}'.format(random_str),
+            ele_label='ele_label_{}'.format(random_str),
+            ele_name='ele_name_{}'.format(random_str),
+            choose_type='Check Box')
         dialog.create()
         to_delete.append(dialog)
     return to_delete
@@ -49,8 +55,7 @@ def test_paginator(some_dialogs, soft_assert):
         for text in get_relevant_rows(dialogs_table):
             dialogs_found.add(text)
         current_rec_offset = paginator.rec_offset()
-    soft_assert(dialogs_found == set(map(lambda dlg: dlg.label, some_dialogs)),
-                "Could not find all dialogs by clicking the paginator!")
+    soft_assert(set([dlg.label for dlg in some_dialogs]).issubset(dialogs_found))
 
 
 # test_ordering - after it starts working somehow, otherwise cannot test it properly


### PR DESCRIPTION
SplitTable locator in service_dialogs updated

ServiceDialogs are now created with all the necessary fields/elements

customization_paginator test now works if other dialogs are present as well

---

Looking at the 5.2.z jenkins run, it failed on the locator as well, so verpicking doesn't seem necessary.