### PR TITLE
Able to ignore some of bugs in BZ

### DIFF
--- a/cfme/tests/infrastructure/test_customization_template.py
+++ b/cfme/tests/infrastructure/test_customization_template.py
@@ -62,7 +62,7 @@ def test_pxe_image_type_required_error_validation():
         template_name.create()
 
 
-@pytest.mark.bugzilla(1092951)
+@pytest.mark.bugzilla(1092951, ignore=[1083198])
 def test_duplicate_name_error_validation():
     """Test to validate duplication in customization templates."""
     template_name = pxe.CustomizationTemplate(

--- a/utils/bz.py
+++ b/utils/bz.py
@@ -130,7 +130,8 @@ class Bugzilla(object):
                 expanded.add(b)
         return found
 
-    def resolve_blocker(self, blocker, version=None):
+    def resolve_blocker(self, blocker, version=None, ignore_bugs=set([])):
+        # ignore_bugs is mutable but is not mutated here!
         if isinstance(id, BugWrapper):
             bug = blocker
         else:
@@ -142,6 +143,8 @@ class Bugzilla(object):
         variants = self.get_bug_variants(bug)
         filtered = set([])
         for variant in variants:
+            if variant.id in ignore_bugs:
+                continue
             if variant.version is not None and variant.version > version:
                 continue
             if variant.release_flag is not None and version.is_in_series(variant.release_flag):
@@ -159,7 +162,7 @@ class Bugzilla(object):
                     if version < variant.release_flag:
                         filtered.add((variant, True))
         if not filtered:
-            return
+            return None
         # Prefer release_flag
         for bug, forceskip in filtered:
             if bug.release_flag and version.is_in_series(bug.release_flag):


### PR DESCRIPTION
@jkrocil pointed out that the bug 1092951 resolved to 1083198 that is already closed (but for correct version) because they merged the system image type and customization template issue together. This enables to ignore particular bugs if such cases occur.