### PR TITLE
Configurable provisioning timeout for Sprout

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -73,6 +73,8 @@ def pytest_addoption(parser):
         default=1, help="How many Sprout appliances to use?.")
     group._addoption('--sprout-timeout', dest='sprout_timeout', type=int,
         default=60, help="How many minutes is the lease timeout.")
+    group._addoption('--sprout-provision-timeout', dest='sprout_provision_timeout', type=int,
+        default=40, help="How many minutes to wait for appliances provisioned.")
     group._addoption(
         '--sprout-group', dest='sprout_group', default=None, help="Which stream to use.")
     group._addoption(
@@ -127,7 +129,7 @@ class ParallelSession(object):
             at_exit(self.sprout_client.destroy_pool, self.sprout_pool)
             result = wait_for(
                 lambda: self.sprout_client.request_check(self.sprout_pool)["fulfilled"],
-                num_sec=30 * 60,  # 30 minutes
+                num_sec=self.config.option.sprout_provision_timeout * 60,
                 delay=5,
                 message="requesting appliances was fulfilled"
             )

--- a/fixtures/single_appliance_sprout.py
+++ b/fixtures/single_appliance_sprout.py
@@ -49,7 +49,7 @@ def pytest_configure(config, __multicall__):
         at_exit(sprout.destroy_pool, pool_id)
         result = wait_for(
             lambda: sprout.request_check(pool_id)["fulfilled"],
-            num_sec=30 * 60,  # 30 minutes
+            num_sec=config.option.sprout_provision_timeout * 60,
             delay=5,
             message="requesting appliance was fulfilled"
         )


### PR DESCRIPTION
When providers are having bad times, it can help to be able to raise the value.