### PR TITLE
ui_worker_pid fixture

### DIFF
--- a/cfme/tests/perf/test_ui_automate.py
+++ b/cfme/tests/perf/test_ui_automate.py
@@ -21,8 +21,8 @@ customization_filters = [
 
 @pytest.mark.perf_ui_automate
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_automate_explorer(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_automate_explorer(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'automate_explorer'), soft_assert))
@@ -39,8 +39,8 @@ def test_perf_ui_automate_explorer(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_automate
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_automate_customization(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_automate_customization(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'automate_customization'), soft_assert))

--- a/cfme/tests/perf/test_ui_cloud.py
+++ b/cfme/tests/perf/test_ui_cloud.py
@@ -37,8 +37,8 @@ vm_cloud_filters = [
 
 @pytest.mark.perf_ui_cloud
 @pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_cloud_providers(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_cloud_providers(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'providers' in ui_bench_tests['page_check']['cloud']:
@@ -53,8 +53,8 @@ def test_perf_ui_cloud_providers(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_cloud
 @pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_cloud_availability_zones(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_cloud_availability_zones(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'availability_zones' in ui_bench_tests['page_check']['cloud']:
@@ -71,8 +71,8 @@ def test_perf_ui_cloud_availability_zones(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_cloud
 @pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_cloud_tenants(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_cloud_tenants(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'tenants' in ui_bench_tests['page_check']['cloud']:
@@ -89,8 +89,8 @@ def test_perf_ui_cloud_tenants(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_cloud
 @pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_cloud_flavors(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_cloud_flavors(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'flavors' in ui_bench_tests['page_check']['cloud']:
@@ -107,8 +107,8 @@ def test_perf_ui_cloud_flavors(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_cloud
 @pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_cloud_security_groups(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_cloud_security_groups(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'security_groups' in ui_bench_tests['page_check']['cloud']:
@@ -127,8 +127,8 @@ def test_perf_ui_cloud_security_groups(ssh_client, soft_assert):
 @pytest.mark.bugzilla(1170778, unskip={1170778: True})
 @pytest.mark.perf_ui_cloud
 @pytest.mark.usefixtures("setup_cloud_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_cloud_vm_explorer(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_cloud_vm_explorer(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'clouds_instances'), soft_assert))

--- a/cfme/tests/perf/test_ui_configure.py
+++ b/cfme/tests/perf/test_ui_configure.py
@@ -19,8 +19,8 @@ configuration_filters = [
 
 @pytest.mark.perf_ui_configure
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_configure_configuration(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_configure_configuration(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'configuration'), soft_assert))

--- a/cfme/tests/perf/test_ui_control.py
+++ b/cfme/tests/perf/test_ui_control.py
@@ -22,8 +22,8 @@ explorer_filters = [
 @pytest.mark.bugzilla(1182271)
 @pytest.mark.perf_ui_control
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_control_explorer(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_control_explorer(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'control_explorer'), soft_assert))

--- a/cfme/tests/perf/test_ui_infrastructure.py
+++ b/cfme/tests/perf/test_ui_infrastructure.py
@@ -71,8 +71,8 @@ infra_pxe_filters = [
 
 @pytest.mark.perf_ui_infrastructure
 @pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_infra_providers(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_infra_providers(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'providers' in ui_bench_tests['page_check']['infrastructure']:
@@ -87,8 +87,8 @@ def test_perf_ui_infra_providers(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_infrastructure
 @pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_infra_clusters(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_infra_clusters(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'clusters' in ui_bench_tests['page_check']['infrastructure']:
@@ -114,8 +114,8 @@ def test_perf_ui_infra_clusters(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_infrastructure
 @pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_infra_hosts(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_infra_hosts(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'hosts' in ui_bench_tests['page_check']['infrastructure']:
@@ -134,8 +134,8 @@ def test_perf_ui_infra_hosts(ssh_client, soft_assert):
 @pytest.mark.bugzilla(1086386, 1175504, unskip={1175504: True})
 @pytest.mark.perf_ui_infrastructure
 @pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_infra_vm_explorer(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_infra_vm_explorer(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'infrastructure_virtual_machines'), soft_assert))
@@ -155,8 +155,8 @@ def test_perf_ui_infra_vm_explorer(ssh_client, soft_assert):
 @pytest.mark.bugzilla(1129260, unskip={1129260: True})
 @pytest.mark.perf_ui_infrastructure
 @pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_infra_resource_pools(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_infra_resource_pools(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'resource_pools' in ui_bench_tests['page_check']['infrastructure']:
@@ -183,8 +183,8 @@ def test_perf_ui_infra_resource_pools(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_infrastructure
 @pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_infra_datastores(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_infra_datastores(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     nav_limit = 0
     if 'datastores' in ui_bench_tests['page_check']['infrastructure']:
@@ -201,8 +201,8 @@ def test_perf_ui_infra_datastores(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_infrastructure
 @pytest.mark.usefixtures("setup_infrastructure_providers", "cfme_log_level_rails_debug")
-def test_perf_ui_infra_pxe(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_infra_pxe(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'infrastructure_pxe'), soft_assert))

--- a/cfme/tests/perf/test_ui_intelligence.py
+++ b/cfme/tests/perf/test_ui_intelligence.py
@@ -21,8 +21,8 @@ chargeback_filters = [
 @pytest.mark.bugzilla(1174300)
 @pytest.mark.perf_ui_intelligence
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_intelligence_reports(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_intelligence_reports(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'reports'), soft_assert))
@@ -41,8 +41,8 @@ def test_perf_ui_intelligence_reports(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_intelligence
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_intelligence_chargeback(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_intelligence_chargeback(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'chargeback'), soft_assert))

--- a/cfme/tests/perf/test_ui_optimize.py
+++ b/cfme/tests/perf/test_ui_optimize.py
@@ -22,8 +22,8 @@ bottlenecks_filters = [
 
 @pytest.mark.perf_ui_optimize
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_optimize_utilization(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_optimize_utilization(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'utilization'), soft_assert))
@@ -39,8 +39,8 @@ def test_perf_ui_optimize_utilization(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_optimize
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_optimize_bottlenecks(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_optimize_bottlenecks(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'bottlenecks'), soft_assert))

--- a/cfme/tests/perf/test_ui_services.py
+++ b/cfme/tests/perf/test_ui_services.py
@@ -23,8 +23,8 @@ workloads_filters = [
 
 @pytest.mark.perf_ui_services
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_services_my_services(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_services_my_services(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'my_services'), soft_assert))
@@ -40,8 +40,8 @@ def test_perf_ui_services_my_services(ssh_client, soft_assert):
 
 @pytest.mark.perf_ui_services
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_services_catalogs(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_services_catalogs(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'services_catalogs'), soft_assert))
@@ -60,8 +60,8 @@ def test_perf_ui_services_catalogs(ssh_client, soft_assert):
 @pytest.mark.bugzilla(1179478)
 @pytest.mark.perf_ui_services
 @pytest.mark.usefixtures("cfme_log_level_rails_debug")
-def test_perf_ui_services_workloads(ssh_client, soft_assert):
-    pages, ui_worker_pid, prod_tail = standup_perf_ui(ssh_client, soft_assert)
+def test_perf_ui_services_workloads(ui_worker_pid, ssh_client, soft_assert):
+    pages, prod_tail = standup_perf_ui(ui_worker_pid, ssh_client, soft_assert)
 
     pages.extend(analyze_page_stat(perf_click(ui_worker_pid, prod_tail, True, sel.force_navigate,
         'services_workloads'), soft_assert))

--- a/fixtures/perf.py
+++ b/fixtures/perf.py
@@ -12,6 +12,11 @@ def cfme_log_level_rails_debug():
     set_rails_loglevel('info')
 
 
+@pytest.yield_fixture(scope='module')
+def ui_worker_pid():
+    yield get_worker_pid('MiqUiWorker')
+
+
 def get_worker_pid(worker_type):
     """Obtains the pid of the first worker with the worker_type specified"""
     ssh_client = SSHClient()

--- a/utils/pagestats.py
+++ b/utils/pagestats.py
@@ -215,19 +215,7 @@ def navigate_split_table(table, page_name, nav_limit, ui_worker_pid, prod_tail, 
     return pages
 
 
-def standup_perf_ui(ssh_client, soft_assert):
-    # Use evmserverd status to determine MiqUiWorker Pid (assuming 1 worker)
-    exit_status, out = ssh_client.run_command('service evmserverd status 2> /dev/null | grep '
-        '\'MiqUiWorker\' | awk \'{print $7}\'')
-    assert exit_status == 0
-
-    ui_worker_pid = str(out).strip()
-    if out:
-        logger.info('Obtained MiqUiWorker PID: {}'.format(ui_worker_pid))
-    else:
-        logger.error('Could not obtain MiqUiWorker PID, check evmserverd running...')
-        assert out
-
+def standup_perf_ui(ui_worker_pid, ssh_client, soft_assert):
     logger.info('Opening /var/www/miq/vmdb/log/production.log for tail')
     prod_tail = SSHTail('/var/www/miq/vmdb/log/production.log')
     prod_tail.set_initial_file_end()
@@ -235,7 +223,7 @@ def standup_perf_ui(ssh_client, soft_assert):
     ensure_browser_open()
     pages = analyze_page_stat(perf_click(ui_worker_pid, prod_tail, False, login_admin), soft_assert)
 
-    return pages, ui_worker_pid, prod_tail
+    return pages, prod_tail
 
 
 def pages_to_csv(pages, file_name):


### PR DESCRIPTION
Reduces the total number of times these tests grep for the ui worker pid.  I set the scope to the module level rather than session incase the UI worker does fail, not all hope is lost of using the incorrect pid when it restarts, perhaps a few tests while the worker is restarted.