### PR TITLE
Sprout - better RHEV-M handling

### DIFF
--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -89,6 +89,10 @@ class Provider(MetadataMixin):
                 ready=False, marked_for_deletion=False, template__provider=self, ip_address=None))
 
     @property
+    def num_templates_preparing(self):
+        return len(Template.objects.filter(provider=self, ready=False))
+
+    @property
     def num_currently_managing(self):
         return len(Appliance.objects.filter(template__provider=self))
 


### PR DESCRIPTION
* limit number of concurrent template builds
* added some template methods in mgmt_system + longer timeouts for rhev-m and deleting after unsuccessful attempt