### PR TITLE
[WIP] Add temporary name to the RHEV templates

### DIFF
--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -222,6 +222,21 @@ class Template(MetadataMixin):
     def cfme(self):
         return CFMEAppliance(self.provider_name, self.name)
 
+    @property
+    def temporary_name(self):
+        return self.metadata.get("temporary_name", None)
+
+    @temporary_name.setter
+    def temporary_name(self, name):
+        with self.edit_metadata as metadata:
+            metadata["temporary_name"] = name
+
+    @temporary_name.deleter
+    def temporary_name(self):
+        with self.edit_metadata as metadata:
+            if "temporary_name" in metadata:
+                del metadata["temporary_name"]
+
     @classmethod
     def get_versions(cls, **filters):
         versions = []


### PR DESCRIPTION
By adding a temporary name, it is possible to recover from the timeout. The temporary name is passed to all the templatizing functions and all templates no matter what provider is used, it is however used only in RHEV-M, the rest is ignored.


*/me now finds mgmt_system quite cumbersome for such a complex process ...*