### PR TITLE
Sprout performance update + UUID

### DIFF
--- a/sprout/appliances/migrations/0008_appliance_uuid.py
+++ b/sprout/appliances/migrations/0008_appliance_uuid.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('appliances', '0007_provider_num_simultaneous_configuring'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='appliance',
+            name='uuid',
+            field=models.CharField(
+                help_text=b'UUID of the machine', max_length=36, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -165,8 +165,8 @@ class Provider(MetadataMixin):
 
     @templates.setter
     def templates(self, value):
-        with self.edit_metadata:
-            self.metadata["templates"] = value
+        with self.edit_metadata as metadata:
+            metadata["templates"] = value
 
     @property
     def template_name_length(self):
@@ -174,8 +174,8 @@ class Provider(MetadataMixin):
 
     @template_name_length.setter
     def template_name_length(self, value):
-        with self.edit_metadata:
-            self.metadata["template_name_length"] = value
+        with self.edit_metadata as metadata:
+            metadata["template_name_length"] = value
 
     def __unicode__(self):
         return "{} {}".format(self.__class__.__name__, self.id)
@@ -318,6 +318,7 @@ class Appliance(MetadataMixin):
         help_text="Appliance's power state")
     ready = models.BooleanField(default=False,
         help_text="Appliance has an IP address and web UI is online.")
+    uuid = models.CharField(max_length=36, null=True, blank=True, help_text="UUID of the machine")
 
     @property
     def provider_api(self):

--- a/sprout/sprout.sh
+++ b/sprout/sprout.sh
@@ -369,9 +369,14 @@ function restart_sprout() {
 function backup_before_update() {
     cddir
     echo ">> Backing up"
-    FILENAME="/tmp/sprout-update-`date +%s | sha256sum | base64 | head -c 8`.tgz"
-    tar -zcvf $FILENAME ../. >/dev/null
+    BKPID="`date +%s | sha256sum | base64 | head -c 8`"
+    FILENAME="/tmp/sprout-update-${BKPID}.tgz"
+    tar -zcvf $FILENAME ../. >/dev/null 2>&1
     echo ">> Backed up to file ${FILENAME}"
+    FILENAME="/tmp/sprout-update-${BKPID}.yaml"
+    echo ">> Dumping the database"
+    ./manage.py dumpdata --format=yaml --natural -e contenttypes -e sessions.Session -e auth.Permission > "/tmp/sprout-update-${BKPID}.yaml"
+    echo ">> Database dumped to ${FILENAME}"
 }
 
 

--- a/sprout/sprout/settings.py
+++ b/sprout/sprout/settings.py
@@ -156,8 +156,8 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=17),
     },
 
-    'retrieve-appliances-power-states': {
-        'task': 'appliances.tasks.retrieve_appliances_power_states',
+    'refresh-appliances': {
+        'task': 'appliances.tasks.refresh_appliances',
         'schedule': timedelta(minutes=7),
     },
 


### PR DESCRIPTION
* Changed the appliances' status retrieval to use less requests
* We now store the UUIDs of the appliances, which makes the life easier. This also makes renaming better since we know what appliance is what.