### PR TITLE
Fixed automatic InfoBlock type detection.

### DIFF
--- a/cfme/storage/managers.py
+++ b/cfme/storage/managers.py
@@ -85,7 +85,6 @@ class StorageManager(Updateable):
 
     validate = form_buttons.FormButton("Validate the credentials by logging into the Server")
     add = form_buttons.FormButton("Add this Storage Manager")
-    infoblock = InfoBlock("detail")
 
     ##
     # Types constants. Extend if needed :)
@@ -145,7 +144,7 @@ class StorageManager(Updateable):
     def wait_until_updated(self, num_sec=300):
         def _wait_func():
             self.navigate()
-            return self.infoblock.text("Properties", "Last Update Status").strip().lower() == "ok"
+            return InfoBlock("Properties", "Last Update Status").text.strip().lower() == "ok"
         wait_for(_wait_func, num_sec=num_sec, delay=5)
 
     @property

--- a/cfme/tests/configure/test_db_backup_schedule.py
+++ b/cfme/tests/configure/test_db_backup_schedule.py
@@ -197,9 +197,8 @@ def test_db_backup_schedule(request, db_backup_data):
     # ---- Wait for schedule to run
     sel.force_navigate('cfg_settings_schedule',
                        context={'schedule_name': db_backup_data.schedule_name})
-    form_infoblocks = InfoBlock('form')
     wait_for(
-        lambda: form_infoblocks.text('Schedule Info', 'Last Run Time') != '',
+        lambda: InfoBlock('Schedule Info', 'Last Run Time').text != '',
         num_sec=600,
         delay=30,
         fail_func=sel.refresh,

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -132,7 +132,7 @@ def test_appliance_registration(request, unset_org_id,
         set_default_repository=set_default_repo
     )
 
-    used_repo_or_channel = InfoBlock("form").text('Red Hat Software Updates', 'Update Repository')
+    used_repo_or_channel = InfoBlock('Red Hat Software Updates', 'Update Repository').text
 
     red_hat_updates.register_appliances()  # Register all
 

--- a/cfme/tests/configure/test_server_name.py
+++ b/cfme/tests/configure/test_server_name.py
@@ -10,7 +10,6 @@ from cfme.web_ui import flash, InfoBlock
 @pytest.mark.sauce
 def test_server_name():
     """Tests that changing the server name updates the about page"""
-    form_infoblocks = InfoBlock('form')
     flash_msg = 'Configuration settings saved for CFME Server "{}'
 
     sel.force_navigate('cfg_settings_currentserver_server')
@@ -21,7 +20,7 @@ def test_server_name():
     flash.assert_message_contain(flash_msg.format(new_server_name))
 
     sel.force_navigate('about')
-    assert new_server_name == form_infoblocks.text('Session Information', 'Server Name'),\
+    assert new_server_name == InfoBlock('Session Information', 'Server Name').text,\
         "Server name in About section does not match the new name"
 
     del(store.current_appliance.configuration_details)

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1731,14 +1731,18 @@ class InfoBlock(Pretty):
                     self.title)
             }),
             # Form type
-            '//fieldset/p[@class="legend"][contains(., "{}")]/..'.format(self.title)
+            (
+                '//*[p[@class="legend"][contains(., "{}")] and table/tbody/tr/td['
+                'contains(@class, "key")]]'.format(self.title)
+            )
+            # The root element must contain table element because listaccordions were caught by the
+            # locator. It used to be fieldset but it seems it can be really anything
         ]
         found = sel.elements("|".join(possible_locators))
         if not found:
             raise exceptions.BlockTypeUnknown("The block type requested is unknown")
         root_el = found[0]
-        tag = sel.tag(root_el)
-        if tag == "fieldset":
+        if sel.elements("./table/tbody/tr/td[contains(@class, 'key')]", root=root_el):
             self._type = self.FORM
         else:
             self._type = self.DETAIL
@@ -1821,7 +1825,7 @@ class InfoBlock(Pretty):
         @property
         def icon_href(self):
             try:
-                return sel.get_attribute(sel.element("./img", root=self.container), "href")
+                return sel.get_attribute(sel.element("./img", root=self.container), "src")
             except sel_exceptions.NoSuchElementException:
                 return None
 

--- a/markers/bz.py
+++ b/markers/bz.py
@@ -160,7 +160,10 @@ def pytest_runtest_setup(item):
             skippers.add(bug)
         if bug.upstream_bug:
             if not appliance_is_downstream() and bug.can_test_on_upstream:
-                skippers.remove(bug)
+                try:
+                    skippers.remove(bug)
+                except KeyError:
+                    pass
 
     # Custom skip/xfail handler
     global_env = dict(


### PR DESCRIPTION
List accordion (the one in left eg. in Provider details) was mistakenly caught by the form type locator, therefore failing everything. Now I have put a check in it that ensures there is a table in it.

I could have done this simply by filtering by `is_displayed` but I don't see that as a clean way to do it since each call to `is_displayed` is a slowdown.

I also found there were separate instances of `InfoBlock` in some places, found and fixed that too.

I also discovered the form type infoblock does not have to have the fieldset as the root element. I then had to add additional selenium call for the detection :(. But it works now.