### PR TITLE
Multiple fixes to provider setup

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -303,6 +303,8 @@ class Provider(Updateable, Pretty):
             ProviderHasNoProperty: If the provider does not have the property defined.
         """
         host_stats = client.stats(*stats_to_match)
+        if not db:
+            sel.refresh()
 
         if refresh_timer:
             if refresh_timer.is_it_time():

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -295,6 +295,8 @@ class Provider(Updateable, Pretty):
             ProviderHasNoProperty: If the provider does not have the property defined.
         """
         host_stats = client.stats(*stats_to_match)
+        if not db:
+            sel.refresh()
 
         if refresh_timer:
             if refresh_timer.is_it_time():

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -18,12 +18,17 @@ _failed_providers = set()
 
 
 def _setup_provider(provider_key):
-    def skip(provider_key):
-        raise pytest.skip('Provider {} failed to set up, skipping test'.format(provider_key))
+    def skip(provider_key, previous_fail=False):
+        if previous_fail:
+            raise pytest.skip('Provider {} failed to set up previously in another test, '
+                              'skipping test'.format(provider_key))
+        else:
+            raise pytest.skip('Provider {} failed to set up this time, '
+                              'skipping test'.format(provider_key))
     # This function is dynamically "fixturized" to setup up a specific provider,
     # optionally skipping the provider setup if that provider has previously failed.
     if provider_key in _failed_providers:
-        skip(provider_key)
+        skip(provider_key, previous_fail=True)
 
     try:
         providers.setup_provider(provider_key)


### PR DESCRIPTION
* Skipping a provider when it fails to set up is now a little more
  verbose and explains whether the test was skipped because the provider
  failed to set up in this test, or in a previous one.
* Providers were failing to stats match when being setup using the
  provider crud test because of a bug in the way non-db stats matching
  was handled. A refresh of the UI was not performed for each
  retry. This had two consequences:
 * Stats matching generally took a lot longer than it needed to due to
   the fact that first time the page is landed on, the counters will sit
   at 0 for at least until the first RefreshTimer is activated.
 * Stats matching was inaccurate as the counters would hold on their
   current page value, until the a RefreshTimer timeout triggered a
   refresh, causing the page to coincidentally be refreshed. During the 5
   minute window that is usual for a RefreshTimer, it was likely that a
   providers number of VMs would change, thus reducing the chance of a
   stats match.

{{pytest: -k test_provider_crud}}