### PR TITLE
Slight update on configuration; sprout client tweaks

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -486,9 +486,11 @@ class ServerLogDepot(Pretty):
                     smb="Samba"
                 ),
                 "5.3": dict(
+                    anon_ftp="Anonymous FTP",
                     ftp="FTP",
                     nfs="NFS",
-                    smb="Samba"
+                    smb="Samba",
+                    dropbox="Red Hat Dropbox",
                 )
             })
 
@@ -512,7 +514,7 @@ class ServerLogDepot(Pretty):
                 self.server_collect_logs,
                 details
             )
-            if validate and self.p_type != "nfs":
+            if validate and self.p_type not in {"nfs", "anon_ftp", "dropbox"}:
                 sel.click(self.validate)
                 flash.assert_no_errors()
             sel.click(form_buttons.cancel if cancel else form_buttons.save)


### PR DESCRIPTION
Made the appliance deleting more verbose and more 'hardened'. Moved the responsibility of deleting the appliances from slaves to master (had to add a signal for that).

@seandst Can the appliance deletion somehow intercept the cov gathering process or whatever happens in the end? Because it deletes appliances right when the slave ends.