### PR TITLE
Dump the pool info after request

### DIFF
--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -392,6 +392,10 @@ class Appliance(MetadataMixin):
             provider=self.template.provider.id,
             marked_for_deletion=self.marked_for_deletion,
             uuid=self.uuid,
+            template_version=self.template.version,
+            template_build_date=self.template.date.isoformat(),
+            template_group=self.template.template_group.id,
+            template_sprout_name=self.template.name,
         )
 
     @property


### PR DESCRIPTION
This will write something like this when pool request is completed or timed out:

```
Fulfilled: True
Progress: 100%
Appliances:
	s_appl_downstream-53z_150127_Fk8IAcd7:
		datetime_leased: 2015-02-10T09:20:33.724988+00:00
		id: 3809
		ip_address: xxxx
		leased_until: 2015-02-10T10:50:34.216523+00:00
		marked_for_deletion: False
		power_state: on
		provider: xxxx
		ready: True
		status: The appliance is ready.
		status_changed: 2015-02-10T09:20:45.142070+00:00
		template_id: 873
		template_name: xxxx
		uuid: 7868ac12-c174-436c-8f1a-8e31b68e2547
	s_appl_downstream-53z_150127_7QAxQQuy:
		datetime_leased: 2015-02-10T09:20:33.725061+00:00
		id: 3811
		ip_address: xxxx
		leased_until: 2015-02-10T10:50:34.228248+00:00
		marked_for_deletion: False
		power_state: on
		provider: xxxx
		ready: True
		status: The appliance is ready.
		status_changed: 2015-02-10T09:20:45.183689+00:00
		template_id: 873
		template_name: xxxx
		uuid: 7b45ff2b-85f8-4e41-b222-7b2430ddb17d
...
...
```