### PR TITLE
Count with Prototype (Ajax) removed + do not test mingw package on 5.4

### DIFF
--- a/cfme/js.py
+++ b/cfme/js.py
@@ -7,7 +7,7 @@ function isHidden(el) {if(el === null) return true; return el.offsetParent === n
 
 return {
     jquery: jQuery.active,
-    prototype: Ajax.activeRequestCount,
+    prototype: (typeof Ajax === "undefined") ? 0 : Ajax.activeRequestCount,
     miq: window.miqAjaxTimers,
     spinner: (!isHidden(document.getElementById("spinner_div")))
         && isHidden(document.getElementById("lightbox_div")),

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -24,6 +24,9 @@ pytestmark = pytest.mark.smoke
     'rhn-check',
     'rhnlib',
 ])
+@pytest.mark.meta(
+    # TODO: Change to uncollecting when possible.
+    skip=lambda package: package == "mingw32-cfme-host" and version.current_version() >= "5.4")
 def test_rpms_present(ssh_client, package):
     """Verifies nfs-util rpms are in place needed for pxe & nfs operations"""
     exit, stdout = ssh_client.run_command('rpm -q %s' % package)

--- a/metaplugins/blockers.py
+++ b/metaplugins/blockers.py
@@ -41,6 +41,7 @@ from kwargify import kwargify as _kwargify
 from markers.meta import plugin
 from utils import version
 from utils.blockers import Blocker
+from utils.pytest_shortcuts import extract_fixtures_values
 
 
 def kwargify(f):
@@ -69,13 +70,7 @@ def resolve_blockers(item, blockers):
     # We will now extend the env with fixtures, so they can be used in the guard functions
     # We will however add only those that are not in the global_env otherwise we could overwrite
     # our own stuff.
-    if hasattr(item, "callspec"):
-        params = item.callspec.params
-    else:
-        # Some of the test items do not have this, so fall back
-        # This can cause some problems if the fixtures are used in the guards in this case, but
-        # that will tell use where is the problem and we can then find it out properly.
-        params = {}
+    params = extract_fixtures_values(item)
     for funcarg, value in params.iteritems():
         if funcarg not in global_env:
             global_env[funcarg] = value

--- a/metaplugins/skip.py
+++ b/metaplugins/skip.py
@@ -3,16 +3,20 @@
 from markers.meta import plugin
 
 import pytest
+from kwargify import kwargify
+
+from utils.pytest_shortcuts import extract_fixtures_values
 
 
-@plugin("skip", keys=["skip"])
-@plugin("skip", keys=["skip", "reason"])
-def skip_plugin(skip, reason="Skipped"):
+@plugin("skip", keys=["skip"], run=plugin.BEFORE_RUN)
+@plugin("skip", keys=["skip", "reason"], run=plugin.BEFORE_RUN)
+def skip_plugin(item, skip, reason="Skipped"):
     if isinstance(skip, bool):
         if skip:
             pytest.skip(reason)
     elif callable(skip):
-        if skip():
+        skip_kwargified = kwargify(skip)
+        if skip_kwargified(**extract_fixtures_values(item)):
             pytest.skip(reason)
     else:
         if bool(skip):

--- a/utils/pytest_shortcuts.py
+++ b/utils/pytest_shortcuts.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+
+def extract_fixtures_values(item):
+    """Extracts names and values of all the fixtures that the test has.
+
+    Args:
+        item: py.test test item
+    Returns:
+        :py:class:`dict` with fixtures and their values.
+    """
+    if hasattr(item, "callspec"):
+        return item.callspec.params
+    else:
+        # Some of the test items do not have this, so fall back
+        # This can cause some problems if the fixtures are used in the guards in this case, but
+        # that will tell use where is the problem and we can then find it out properly.
+        return {}


### PR DESCRIPTION
The Prototype framework was removed completely so the script needs to count with the fact that Ajax can be undefined. Then it returns just 0 if Ajax is not defined, making everything backwards-compatible

{{pytest: -m smoke -v --use-provider vsphere55}}