### PR TITLE
[WIPTEST] lint

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -118,9 +118,12 @@ def tag(tag_name, **kwargs):
         return prefix
 
 input = partial(tag, "input")
-select = lambda **kwargs: Select(tag("select", **kwargs))
 img = partial(tag, "img")
 table = partial(tag, "table")
+
+
+def select(**kwargs):
+    return Select(tag("select", **kwargs))
 
 report_form = TabStripForm(
     # These are displayed always

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -81,7 +81,8 @@ def is_vm_analysis_finished(vm_name):
 
 
 def do_scan(vm):
-    scan = lambda: vm.get_detail(properties=("Lifecycle", "Last Analyzed")).lower()
+    def scan():
+        return vm.get_detail(properties=("Lifecycle", "Last Analyzed")).lower()
     vm.load_details()
     original = scan()
     vm.smartstate_scan(cancel=False, from_details=True)
@@ -128,7 +129,9 @@ def test_check_package_presence(request, compliance_vm, ssh_client):
     profile.create()
     compliance_vm.assign_policy_profiles(profile.description)
     request.addfinalizer(lambda: compliance_vm.unassign_policy_profiles(profile.description))
-    detail = lambda: compliance_vm.get_detail(properties=("Compliance", "Status")).lower()
+
+    def detail():
+        return compliance_vm.get_detail(properties=("Compliance", "Status")).lower()
 
     # Non-compliant
     ssh_client.run_command("yum remove -y mc")

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -407,14 +407,20 @@ class Table(Pretty):
         # Only include rows where the expected values are in the right columns
         matching_rows = list()
         if partial_check:
-            matching_row_filter = lambda heading, value: value in row[heading].text
+            matching_row_filter = self._matching_row_contains
         else:
-            matching_row_filter = lambda heading, value: row[heading].text == value
+            matching_row_filter = self._matching_row_equals
         for row in rows:
-            if all(matching_row_filter(*cell) for cell in cells.items()):
+            if all(matching_row_filter(row, *cell) for cell in cells.items()):
                 matching_rows.append(row)
 
         return matching_rows
+
+    def _matching_row_contains(self, row, heading, value):
+        return value in row[heading].text
+
+    def _matchin_row_equals(self, row, heading, value):
+        return row[heading].text == value
 
     def find_row_by_cells(self, cells, partial_check=False):
         """Find the first row containing cells

--- a/metaplugins/blockers.py
+++ b/metaplugins/blockers.py
@@ -49,12 +49,10 @@ def kwargify(f):
     If you pass False or None, a function which always returns False is returned.
     If you pass True, a function which always returns True is returned.
     """
-    if f is None or f is False:
-        f = lambda: False
-    elif f is True:
-        f = lambda: True
+    if f is None:
+        f = False
 
-    return _kwargify(f)
+    return _kwargify(lambda: f)
 
 
 @plugin("blockers", ["blockers"])

--- a/sprout/sprout/__init__.py
+++ b/sprout/sprout/__init__.py
@@ -1,17 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
 from contextlib import contextmanager
+
+from django.core.cache import cache
+from redis import StrictRedis
+
+from sprout import settings
+from utils.wait import wait_for
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-from .celery import app as celery_app
-assert celery_app
 
-from django.core.cache import cache
-from sprout import settings
-from redis import StrictRedis
-from utils.wait import wait_for
+# import to initialize celery_app.app
+from .celery import app as celery_app  # NOQA
 
 redis_client = StrictRedis(**settings.GENERAL_REDIS)
 

--- a/sprout/sprout/wsgi.py
+++ b/sprout/sprout/wsgi.py
@@ -6,9 +6,8 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
-
 import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sprout.settings")
-
 from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sprout.settings")
 application = get_wsgi_application()

--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -810,8 +810,9 @@ class VMWareSystem(MgmtSystemAPIBase):
             pass
 
         if progress_callback is None:
-            progress_callback = lambda progress: logger.info(
-                "Provisioning progress {}->{}: {}".format(source, destination, str(progress)))
+            def progress_callback(progress):
+                logger.info("Provisioning progress {}->{}: {}".format(
+                    source, destination, str(progress)))
 
         source_template = mobs.VirtualMachine.get(self.api, name=source)
 

--- a/utils/wait.py
+++ b/utils/wait.py
@@ -60,7 +60,8 @@ def wait_for(func, func_args=[], func_kwargs={}, **kwargs):
             message = "function %s()" % func.func_name
     fail_condition = kwargs.get('fail_condition', False)
     if not callable(fail_condition):
-        fail_condition_check = lambda result: result == fail_condition
+        def fail_condition_check(result):
+            return result == fail_condition
     else:
         fail_condition_check = fail_condition
     handle_exception = kwargs.get('handle_exception', False)


### PR DESCRIPTION
We have fallen behind on linting:
```
flake8 .
./metaplugins/blockers.py:53:9: E731 do not assign a lambda expression, use a def
./metaplugins/blockers.py:55:9: E731 do not assign a lambda expression, use a def
./utils/testgen.py:163:5: E731 do not assign a lambda expression, use a def
./utils/wait.py:63:9: E731 do not assign a lambda expression, use a def
./sprout/sprout/wsgi.py:13:1: E402 module level import not at top of file
./utils/appliance.py:195:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:216:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:219:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:576:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:579:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:640:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:643:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:685:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:688:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:735:9: E731 do not assign a lambda expression, use a def
./utils/appliance.py:802:13: E731 do not assign a lambda expression, use a def
./utils/appliance.py:805:13: E731 do not assign a lambda expression, use a def
./sprout/sprout/__init__.py:11:1: E402 module level import not at top of file
./sprout/sprout/__init__.py:12:1: E402 module level import not at top of file
./sprout/sprout/__init__.py:13:1: E402 module level import not at top of file
./sprout/sprout/__init__.py:14:1: E402 module level import not at top of file
./utils/mgmt_system.py:813:13: E731 do not assign a lambda expression, use a def
./cfme/intelligence/reports/reports.py:121:1: E731 do not assign a lambda expression, use a def
./cfme/tests/control/test_compliance.py:84:5: E731 do not assign a lambda expression, use a def
./cfme/tests/control/test_compliance.py:131:5: E731 do not assign a lambda expression, use a def
./cfme/web_ui/__init__.py:410:13: E731 do not assign a lambda expression, use a def
./cfme/web_ui/__init__.py:412:13: E731 do not assign a lambda expression, use a def
./cfme/tests/configure/test_docs.py:71:9: E731 do not assign a lambda expression, use a def
./cfme/tests/configure/test_docs.py:77:9: E731 do not assign a lambda expression, use a def
./cfme/storage/file_shares.py:7:1: E402 module level import not at top of file
./cfme/storage/file_shares.py:8:1: E402 module level import not at top of file
./cfme/storage/filers.py:7:1: E402 module level import not at top of file
./cfme/storage/filers.py:8:1: E402 module level import not at top of file
./cfme/storage/luns.py:7:1: E402 module level import not at top of file
./cfme/storage/luns.py:8:1: E402 module level import not at top of file
./cfme/storage/volumes.py:7:1: E402 module level import not at top of file
./cfme/storage/volumes.py:8:1: E402 module level import not at top of file
./cfme/control/explorer.py:1071:9: E731 do not assign a lambda expression, use a def
./scripts/providers.py:28:1: E402 module level import not at top of file
./markers/uses.py:46:5: E731 do not assign a lambda expression, use a def
```

E731 is a new addition to flake8, I've got a few examples of how to deal with it, though it will likely be a while until everything's worked out properly. We are pretty bad about redefining functions in function bodies, apparently.