### PR TITLE
login works for 5.4 and miq

### DIFF
--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -5,15 +5,19 @@
 import cfme.fixtures.pytest_selenium as sel
 from cfme.web_ui import Region, Table, tabstrip, toolbar
 from utils.timeutil import parsetime
-from utils.wait import wait_for
 from utils.pretty import Pretty
+from utils.version import LOWEST
+from utils.wait import wait_for
 
 page = Region(
     title="Dashboard",
     locators={
         'reset_widgets_button': toolbar.root_loc('Reset Dashboard Widgets'),
         'csrf_token': "//meta[@name='csrf-token']",
-        'user_dropdown': '//div[@id="page_header_div"]//li[contains(@class, "dropdown")]',
+        'user_dropdown': {
+            LOWEST: '//div[@id="page_header_div"]//li[contains(@class, "dropdown")]',
+            '5.4': '//nav//ul[contains(@class, "navbar-utility")]/li[contains(@class, "dropdown")]'
+        }
     },
     identifying_loc='reset_widgets_button')
 

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -23,10 +23,3 @@ def test_bad_password():
     with error.expected('Sorry, the username or password you entered is incorrect.'):
         login.login(conf.credentials['default']['username'], "badpassword@#$")
     assert login.page.is_displayed()
-
-
-@pytest.sel.go_to('dashboard')
-def test_logout(logged_in):
-    """ Tests that the provider can be logged out of. """
-    login.logout()
-    assert login.page.is_displayed()


### PR DESCRIPTION
- Automated clicking of the login button **does not work** on 5.4 and up,
  so I employed a JS hack to get around it. We need to find a better solution,
  but right now we need CI results more. :)
- I removed test_logout because test_login asserts that logout works; it's not
  completely appropriate testing, but I got over it pretty quick
- I also threw in an `ensure_browser_open` so you don't have to manually open
  a browser to login. Now you can just call `cfme.login.login_admin`