### PR TITLE
Try to delete pool on Sprout request timeout

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -147,7 +147,13 @@ class ParallelSession(object):
                     delay=5,
                     message="requesting appliances was fulfilled"
                 )
-            finally:
+            except:
+                pool = self.sprout_client.request_check(self.sprout_pool)
+                dump_pool_info(lambda x: self.terminal.write("{}\n".format(x)), pool)
+                self.terminal.write("Destroying the pool on error.\n")
+                self.sprout_client.destroy_pool(pool_id)
+                raise
+            else:
                 pool = self.sprout_client.request_check(self.sprout_pool)
                 dump_pool_info(lambda x: self.terminal.write("{}\n".format(x)), pool)
             self.terminal.write("Provisioning took {0:.1f} seconds\n".format(result.duration))

--- a/fixtures/single_appliance_sprout.py
+++ b/fixtures/single_appliance_sprout.py
@@ -51,12 +51,17 @@ def pytest_configure(config, __multicall__):
         )
         terminal.write("Appliance pool {}. Waiting for fulfillment ...\n".format(pool_id))
         at_exit(destroy_the_pool)
-        result = wait_for(
-            lambda: sprout.request_check(pool_id)["fulfilled"],
-            num_sec=config.option.sprout_provision_timeout * 60,
-            delay=5,
-            message="requesting appliance was fulfilled"
-        )
+        try:
+            result = wait_for(
+                lambda: sprout.request_check(pool_id)["fulfilled"],
+                num_sec=config.option.sprout_provision_timeout * 60,
+                delay=5,
+                message="requesting appliance was fulfilled"
+            )
+        except:
+            terminal.write("Destroying the pool on error.\n")
+            sprout.destroy_pool(pool_id)
+            raise
         terminal.write("Provisioning took {0:.1f} seconds\n".format(result.duration))
         request = sprout.request_check(pool_id)
         ip_address = request["appliances"][0]["ip_address"]


### PR DESCRIPTION
It is not 100% though on the sprout's side (the tasks do not know about each other so maybe some provisioning task will interfere with the deletion task), but it should work on most appliances from the pool.