### PR TITLE
Found and fixed new type of tabstrip (for upstream)

### DIFF
--- a/cfme/web_ui/tabstrip.py
+++ b/cfme/web_ui/tabstrip.py
@@ -17,7 +17,12 @@ from utils.log import logger
 from utils import version
 from utils.pretty import Pretty
 
-_entry_div = "//div[contains(@class, 'ui-tabs')]"  # Entry point
+# Entry points
+_entry_div = "|".join([
+    # Old type
+    "//div[contains(@class, 'ui-tabs')]",
+    # New, bootstrap type
+    "//div[contains(@class, 'row') and ./div/ul[contains(@class, 'nav-tabs')]]"])
 _entry_ul = {
     '5.3': '//ul[@class="tab2" or @class="tab3"]',
     version.LOWEST: '//ul[@id="tab" and @class="tab"]'


### PR DESCRIPTION
Eg. in `My Settings` and so. This is currently killing some tests.