### PR TITLE
py.test collection works with nonexistent cfme_data

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -260,7 +260,7 @@ class Provider(Updateable, Pretty):
         if not self.key:
             raise ProviderHasNoKey('Provider %s has no key, so cannot get yaml data')
         else:
-            return conf.cfme_data['management_systems'][self.key]
+            return conf.cfme_data.get('management_systems', {})[self.key]
 
     def get_mgmt_system(self):
         """ Returns the mgmt_system using the :py:func:`utils.providers.provider_factory` method.
@@ -537,7 +537,7 @@ def get_from_config(provider_config_name):
     Returns: A Provider object that has methods that operate on CFME
     """
 
-    prov_config = conf.cfme_data['management_systems'][provider_config_name]
+    prov_config = conf.cfme_data.get('management_systems', {})[provider_config_name]
     credentials = get_credentials_from_config(prov_config['credentials'])
     prov_type = prov_config.get('type')
     if prov_type == 'ec2':

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -31,7 +31,7 @@ class Tenant(object):
 
     def exists(self):
         sel.force_navigate('clouds_tenants')
-        provider_name = cfme_data['management_systems'][self.provider_key]['name']
+        provider_name = cfme_data.get('management_systems', {})[self.provider_key]['name']
         res = list_page.tenant_table.find_row_by_cells({'Name': self.name,
                                                         'Cloud Provider': provider_name})
         if res:

--- a/cfme/fixtures/configure_auth_mode.py
+++ b/cfme/fixtures/configure_auth_mode.py
@@ -14,7 +14,7 @@ def available_auth_modes():
 def configure_ldap_auth_mode(browser, available_auth_modes):
     """Configure LDAP authentication mode"""
     if 'ldap' in available_auth_modes:
-        server_data = cfme_data['auth_modes']['ldap']
+        server_data = cfme_data.get('auth_modes', {})['ldap']
         configuration.set_auth_mode(**server_data)
         yield
         login_admin()
@@ -27,7 +27,7 @@ def configure_ldap_auth_mode(browser, available_auth_modes):
 def configure_openldap_auth_mode(browser, available_auth_modes):
     """Configure LDAP authentication mode"""
     if 'openldap' in available_auth_modes:
-        server_data = cfme_data['auth_modes']['openldap']
+        server_data = cfme_data.get('auth_modes', {})['openldap']
         configuration.set_auth_mode(**server_data)
         yield
         login_admin()
@@ -40,7 +40,7 @@ def configure_openldap_auth_mode(browser, available_auth_modes):
 def configure_aws_iam_auth_mode(browser, available_auth_modes):
     """Configure AWS IAM authentication mode"""
     if 'aws_iam' in available_auth_modes:
-        aws_iam_data = dict(cfme_data['auth_modes']['aws_iam'])
+        aws_iam_data = dict(cfme_data.get('auth_modes', {})['aws_iam'])
         aws_iam_creds = credentials[aws_iam_data.pop('credentials')]
         aws_iam_data['access_key'] = aws_iam_creds['username']
         aws_iam_data['secret_key'] = aws_iam_creds['password']
@@ -55,7 +55,7 @@ def configure_aws_iam_auth_mode(browser, available_auth_modes):
 def _configure_external_auth_ipa(request):
     if "ipa" not in cfme_data:
         pytest.skip("No IPA server in configuration!")
-    data = cfme_data["ipa"]
+    data = cfme_data.get("ipa", {})
     request.addfinalizer(disable_external_auth_ipa)
     setup_external_auth_ipa(**data)
 

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -421,7 +421,7 @@ def get_from_config(provider_config_name):
     Returns: A Host object that has methods that operate on CFME
     """
 
-    prov_config = conf.cfme_data['management_hosts'][provider_config_name]
+    prov_config = conf.cfme_data.get('management_hosts', {})[provider_config_name]
     credentials = get_credentials_from_config(prov_config['credentials'])
     ipmi_credentials = get_credentials_from_config(prov_config['ipmi_credentials'])
     ipmi_credentials.ipmi = True

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -630,7 +630,7 @@ def get_from_config(provider_config_name):
     Returns: A Provider object that has methods that operate on CFME
     """
 
-    prov_config = conf.cfme_data['management_systems'][provider_config_name]
+    prov_config = conf.cfme_data.get('management_systems', {})[provider_config_name]
     credentials = get_credentials_from_config(prov_config['credentials'])
     prov_type = prov_config.get('type')
 

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -594,7 +594,7 @@ def get_template_from_config(template_config_name):
     Convenience function to grab the details for a template from the yamls.
     """
 
-    template_config = conf.cfme_data['customization_templates'][template_config_name]
+    template_config = conf.cfme_data.get('customization_templates', {})[template_config_name]
 
     script_data = load_data_file(str(project_path.join(template_config['script_file'])),
                                  replacements=template_config['replacements'])
@@ -613,7 +613,7 @@ def get_pxe_server_from_config(pxe_config_name):
     Convenience function to grab the details for a pxe server fomr the yamls.
     """
 
-    pxe_config = conf.cfme_data['pxe_servers'][pxe_config_name]
+    pxe_config = conf.cfme_data.get('pxe_servers', {})[pxe_config_name]
 
     return PXEServer(name=pxe_config['name'],
                      depot_type=pxe_config['depot_type'],

--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -33,7 +33,7 @@ def pytest_generate_tests(metafunc):
             continue
 
         cloud_init_template = args['provisioning']['ci-template']
-        if cloud_init_template not in cfme_data['customization_templates'].keys():
+        if cloud_init_template not in cfme_data.get('customization_templates', {}).keys():
             continue
 
         argvalues[i].append(get_template_from_config(cloud_init_template))

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -29,7 +29,12 @@ def pytest_generate_tests(metafunc):
     argnames = ['reg_method', 'reg_data', 'proxy_url', 'proxy_creds']
     argvalues = []
     idlist = []
-    all_reg_data = conf.cfme_data['redhat_updates']['registration']
+    try:
+        all_reg_data = conf.cfme_data.get('redhat_updates', {})['registration']
+    except KeyError:
+        pytest.mark.uncollect(metafunc.function)
+        return
+
     if 'reg_method' in metafunc.fixturenames:
         for reg_method in REG_METHODS:
             reg_data = all_reg_data.get(reg_method, None)

--- a/cfme/tests/configure/test_update_appliances.py
+++ b/cfme/tests/configure/test_update_appliances.py
@@ -72,7 +72,7 @@ redhat_updates:
 
 @pytest.fixture(scope='module')
 def rh_updates_data(cfme_data):
-    return cfme_data['redhat_updates']
+    return cfme_data.get('redhat_updates', {})
 
 
 @pytest.fixture(scope='module')
@@ -99,7 +99,7 @@ def appliances_to_update(rh_updates_data):
 
 @pytest.yield_fixture(scope='function')
 def appliance_set(cfme_data):
-    appliance_set_data = cfme_data['appliance_provisioning']['appliance_set']
+    appliance_set_data = cfme_data.get('appliance_provisioning', {})['appliance_set']
     appliance_set = provision_appliance_set(appliance_set_data, 'rh_updates')
 
     yield appliance_set
@@ -386,11 +386,14 @@ def run_platform_updates(appliance_set, appliances_to_update):
                  fail_func=check_updates_and_refresh)
         logger.info("Done")
 
+try:
+    skip_rhsm_direct = not conf.cfme_data.redhat_updates.registration.rhsm.test_direct
+except KeyError:
+    skip_rhsm_direct = True
 
-@pytest.mark.skipif(
-    conf.cfme_data['redhat_updates']['registration']['rhsm']['test_direct'] is not True,
-    reason='RH Update test using RHSM is not enabled'
-)
+
+@pytest.mark.uncollectif(skip_rhsm_direct,
+    reason='RH Update test using RHSM is not enabled')
 @pytest.mark.long_running
 def test_rhsm_direct(appliance_set, rh_updates_data,
                      appliances_to_register, appliances_to_update):
@@ -403,11 +406,14 @@ def test_rhsm_direct(appliance_set, rh_updates_data,
     run_cfme_updates(appliance_set, rh_updates_data, appliances_to_update)
     run_platform_updates(appliance_set, appliances_to_update)
 
+try:
+    skip_rhsm_rhn_mirror = not conf.cfme_data.redhat_updates.registration.rhsm.test_rhn_mirror
+except KeyError:
+    skip_rhsm_rhn_mirror = True
 
-@pytest.mark.skipif(
-    conf.cfme_data['redhat_updates']['registration']['rhsm']['test_rhn_mirror'] is not True,
-    reason='RH Update test using RHSM/RHN Mirror is not enabled'
-)
+
+@pytest.mark.uncollectif(skip_rhsm_rhn_mirror,
+    reason='RH Update test using RHSM/RHN Mirror is not enabled')
 @pytest.mark.long_running
 def test_rhsm_rhn_mirror(appliance_set, rh_updates_data, appliances_to_update):
     # Use only primary to register_appliances(), download_repo_files() and enable_repos()
@@ -423,11 +429,14 @@ def test_rhsm_rhn_mirror(appliance_set, rh_updates_data, appliances_to_update):
     run_cfme_updates(appliance_set, rh_updates_data, appliances_to_update)
     run_platform_updates(appliance_set, appliances_to_update)
 
+try:
+    skip_sat5_direct = not conf.cfme_data.redhat_updates.registration.sat5.test_direct
+except KeyError:
+    skip_sat5_direct = True
 
-@pytest.mark.skipif(
-    conf.cfme_data['redhat_updates']['registration']['sat5']['test_direct'] is not True,
-    reason='RH Update test using Sat5 is not enabled'
-)
+
+@pytest.mark.uncollectif(skip_sat5_direct,
+    reason='RH Update test using Sat5 is not enabled')
 @pytest.mark.long_running
 def test_sat5_direct(appliance_set, rh_updates_data,
                      appliances_to_register, appliances_to_update):
@@ -440,11 +449,14 @@ def test_sat5_direct(appliance_set, rh_updates_data,
     run_cfme_updates(appliance_set, rh_updates_data, appliances_to_update)
     run_platform_updates(appliance_set, appliances_to_update)
 
+try:
+    skip_sat6_direct = not conf.cfme_data.redhat_updates.registration.sat6.test_direct
+except KeyError:
+    skip_sat6_direct = True
 
-@pytest.mark.skipif(
-    conf.cfme_data['redhat_updates']['registration']['sat6']['test_direct'] is not True,
-    reason='RH Update test using Sat6 is not enabled'
-)
+
+@pytest.mark.uncollectif(skip_sat6_direct,
+    reason='RH Update test using Sat6 is not enabled')
 @pytest.mark.long_running
 def test_sat6_direct(appliance_set, rh_updates_data,
                      appliances_to_register, appliances_to_update):
@@ -457,11 +469,14 @@ def test_sat6_direct(appliance_set, rh_updates_data,
     run_cfme_updates(appliance_set, rh_updates_data, appliances_to_update)
     run_platform_updates(appliance_set, appliances_to_update)
 
+try:
+    skip_sat6_rhn_mirror = not conf.cfme_data.redhat_updates.registration.sat6.test_rhn_mirror
+except KeyError:
+    skip_sat6_rhn_mirror = True
 
-@pytest.mark.skipif(
-    conf.cfme_data['redhat_updates']['registration']['sat6']['test_rhn_mirror'] is not True,
-    reason='RH Update test using Sat6/RHN Mirror is not enabled'
-)
+
+@pytest.mark.uncollectif(skip_sat6_rhn_mirror,
+    reason='RH Update test using Sat6/RHN Mirror is not enabled')
 @pytest.mark.long_running
 def test_sat6_rhn_mirror(appliance_set, rh_updates_data, appliances_to_update):
     # Use only primary to register_appliances(), download_repo_files() and enable_repos()

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -10,6 +10,18 @@ from cfme.web_ui import paginator, toolbar as tb, menu
 from utils.conf import cfme_data
 from utils.providers import setup_a_provider as _setup_a_provider
 
+try:
+    grid_pages = cfme_data.grid_pages.cloud
+except KeyError:
+    grid_pages = []
+grid_uncollectif = pytest.mark.uncollectif(not grid_pages, reason='no grid pages configured')
+
+try:
+    landing_pages = cfme_data.landing_pages.cloud
+except KeyError:
+    landing_pages = []
+landing_uncollectif = pytest.mark.uncollectif(not grid_pages, reason='no landing pages configured')
+
 
 @pytest.fixture(scope="module")
 def setup_a_provider():
@@ -56,7 +68,8 @@ def set_cloud_provider_quad():
     visual.cloud_provider_quad = True
 
 
-@pytest.mark.parametrize('page', cfme_data.get('grid_pages').get('cloud'), scope="module")
+@grid_uncollectif
+@pytest.mark.parametrize('page', grid_pages, scope="module")
 def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
     """ Tests grid items per page
 
@@ -71,7 +84,8 @@ def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
         assert int(paginator.rec_end()) == int(limit), "Gridview Failed for page {}!".format(page)
 
 
-@pytest.mark.parametrize('page', cfme_data.get('grid_pages').get('cloud'), scope="module")
+@grid_uncollectif
+@pytest.mark.parametrize('page', grid_pages, scope="module")
 def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
     """ Tests tile items per page
 
@@ -86,7 +100,8 @@ def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
         assert int(paginator.rec_end()) == int(limit), "Tileview Failed for page {}!".format(page)
 
 
-@pytest.mark.parametrize('page', cfme_data.get('grid_pages').get('cloud'), scope="module")
+@grid_uncollectif
+@pytest.mark.parametrize('page', grid_pages, scope="module")
 def test_list_page_per_item(request, setup_a_provider, page, set_list):
     """ Tests list items per page
 
@@ -101,7 +116,8 @@ def test_list_page_per_item(request, setup_a_provider, page, set_list):
         assert int(paginator.rec_end()) == int(limit), "Listview Failed for page {}!".format(page)
 
 
-@pytest.mark.parametrize('start_page', cfme_data.get('landing_pages').get('cloud'), scope="module")
+@landing_uncollectif
+@pytest.mark.parametrize('start_page', landing_pages, scope="module")
 def test_start_page(request, setup_a_provider, start_page):
     """ Tests start page
 

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -10,6 +10,18 @@ from cfme.web_ui import paginator, toolbar as tb, menu
 from utils.conf import cfme_data
 from utils.providers import setup_a_provider as _setup_a_provider
 
+try:
+    grid_pages = cfme_data.grid_pages.infra
+except KeyError:
+    grid_pages = []
+grid_uncollectif = pytest.mark.uncollectif(not grid_pages, reason='no grid pages configured')
+
+try:
+    landing_pages = cfme_data.landing_pages.infra
+except KeyError:
+    landing_pages = []
+landing_uncollectif = pytest.mark.uncollectif(not grid_pages, reason='no landing pages configured')
+
 
 @pytest.fixture(scope="module")
 def setup_a_provider():
@@ -84,7 +96,8 @@ def set_template_quad():
     visual.template_quad = True
 
 
-@pytest.mark.parametrize('page', cfme_data.get('grid_pages').get('infra'), scope="module")
+@grid_uncollectif
+@pytest.mark.parametrize('page', grid_pages, scope="module")
 def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
     """ Tests grid items per page
 
@@ -99,7 +112,8 @@ def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
         assert int(paginator.rec_end()) == int(limit), "Gridview Failed for page {}!".format(page)
 
 
-@pytest.mark.parametrize('page', cfme_data.get('grid_pages').get('infra'), scope="module")
+@grid_uncollectif
+@pytest.mark.parametrize('page', grid_pages, scope="module")
 def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
     """ Tests tile items per page
 
@@ -114,7 +128,8 @@ def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
         assert int(paginator.rec_end()) == int(limit), "Tileview Failed for page {}!".format(page)
 
 
-@pytest.mark.parametrize('page', cfme_data.get('grid_pages').get('infra'), scope="module")
+@grid_uncollectif
+@pytest.mark.parametrize('page', grid_pages, scope="module")
 def test_list_page_per_item(request, setup_a_provider, page, set_list):
     """ Tests list items per page
 
@@ -129,7 +144,8 @@ def test_list_page_per_item(request, setup_a_provider, page, set_list):
         assert int(paginator.rec_end()) == int(limit), "Listview Failed for page {}!".format(page)
 
 
-@pytest.mark.parametrize('start_page', cfme_data.get('landing_pages').get('infra'), scope="module")
+@landing_uncollectif
+@pytest.mark.parametrize('start_page', landing_pages, scope="module")
 def test_start_page(request, setup_a_provider, start_page):
     """ Tests start page
 

--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -37,7 +37,7 @@ def pytest_generate_tests(metafunc):
             continue
 
         cloud_init_template = args['provisioning']['ci-template']
-        if cloud_init_template not in cfme_data['customization_templates'].keys():
+        if cloud_init_template not in cfme_data.get('customization_templates', {}).keys():
             continue
 
         argvalues[i].append(get_template_from_config(cloud_init_template))

--- a/cfme/tests/infrastructure/test_datastore_analysis.py
+++ b/cfme/tests/infrastructure/test_datastore_analysis.py
@@ -54,7 +54,7 @@ def pytest_generate_tests(metafunc):
 
 
 def get_host_data_by_name(provider_key, host_name):
-    for host_obj in conf.cfme_data['management_systems'][provider_key].get('hosts', []):
+    for host_obj in conf.cfme_data.get('management_systems', {})[provider_key].get('hosts', []):
         if host_name == host_obj['name']:
             return host_obj
     return None

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -16,7 +16,7 @@ def pytest_generate_tests(metafunc):
     arg_names = "provider", "provider_data", "original_provider_key"
     arg_values = []
     arg_ids = []
-    for provider_key, provider in cfme_data["management_systems"].iteritems():
+    for provider_key, provider in cfme_data.get("management_systems", {}).iteritems():
         if provider["type"] != "virtualcenter":
             continue
         hosts = provider.get("hosts", [])

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -40,7 +40,7 @@ def pytest_generate_tests(metafunc):
 
 
 def get_host_data_by_name(provider_key, host_name):
-    for host_obj in conf.cfme_data['management_systems'][provider_key].get('hosts', []):
+    for host_obj in conf.cfme_data.get('management_systems', {})[provider_key].get('hosts', []):
         if host_name == host_obj['name']:
             return host_obj
     return None

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -29,7 +29,7 @@ def pytest_generate_tests(metafunc):
 
 
 def get_host_data_by_name(provider_key, host_name):
-    for host_obj in conf.cfme_data['management_systems'][provider_key].get('hosts', []):
+    for host_obj in conf.cfme_data.get('management_systems', {})[provider_key].get('hosts', []):
         if host_name == host_obj['name']:
             return host_obj
     return None

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -46,7 +46,7 @@ def pytest_generate_tests(metafunc):
             continue
 
         pxe_cust_template = args['host_provisioning']['pxe_kickstart']
-        if pxe_cust_template not in cfme_data['customization_templates'].keys():
+        if pxe_cust_template not in cfme_data.get('customization_templates', {}).keys():
             continue
 
         argvalues[i].append(get_pxe_server_from_config(pxe_server_name))

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -29,7 +29,7 @@ def pytest_generate_tests(metafunc):
         if args['provider_type'] == "scvmm":
             continue
 
-        provider_data = cfme_data['management_systems'][
+        provider_data = cfme_data.get('management_systems', {})[
             argvalue_tuple[argnames.index('provider_key')]]
         if not provider_data.get('iso_datastore', False):
             continue
@@ -43,7 +43,7 @@ def pytest_generate_tests(metafunc):
             continue
 
         iso_cust_template = args['provisioning']['iso_kickstart']
-        if iso_cust_template not in cfme_data['customization_templates'].keys():
+        if iso_cust_template not in cfme_data.get('customization_templates', {}).keys():
             continue
 
         argvalues[i].append(get_template_from_config(iso_cust_template))

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -44,7 +44,7 @@ def pytest_generate_tests(metafunc):
             continue
 
         pxe_cust_template = args['provisioning']['pxe_kickstart']
-        if pxe_cust_template not in cfme_data['customization_templates'].keys():
+        if pxe_cust_template not in cfme_data.get('customization_templates', {}).keys():
             continue
 
         argvalues[i].append(get_pxe_server_from_config(pxe_server_name))

--- a/cfme/tests/integration/test_ipa_external.py
+++ b/cfme/tests/integration/test_ipa_external.py
@@ -15,7 +15,7 @@ def setup_first_provider():
 @pytest.mark.ignore_stream("5.2")  # Old version can't do IPA
 def test_external_auth_ipa(request, setup_first_provider, configure_external_auth_ipa_module):
     try:
-        data = cfme_data["ipa_test"]
+        data = cfme_data.get("ipa_test", {})
     except KeyError:
         pytest.skip("No ipa_test section in yaml")
     group = Group(description='cfme', role="EvmRole-user")

--- a/cfme/tests/integration/test_openldap_auth.py
+++ b/cfme/tests/integration/test_openldap_auth.py
@@ -14,7 +14,7 @@ def setup_first_provider():
 
 def test_openldap_auth(request, setup_first_provider, configure_openldap_auth_mode):
     try:
-        data = cfme_data["openldap_test"]
+        data = cfme_data.get("openldap_test", {})
     except KeyError:
         pytest.skip("No openldap_test section in yaml")
     group = Group(description='cfme', role="EvmRole-user")

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -32,7 +32,7 @@ def pytest_generate_tests(metafunc):
             # No provisioning data available
             continue
 
-        provider_data = cfme_data['management_systems'][
+        provider_data = cfme_data.get('management_systems', {})[
             argvalue_tuple[argnames.index('provider_key')]]
         if not provider_data.get('iso_datastore', False):
             continue
@@ -46,7 +46,7 @@ def pytest_generate_tests(metafunc):
             continue
 
         iso_cust_template = args['provisioning']['iso_kickstart']
-        if iso_cust_template not in cfme_data['customization_templates'].keys():
+        if iso_cust_template not in cfme_data.get('customization_templates', {}).keys():
             continue
 
         argvalues[i].append(get_template_from_config(iso_cust_template))

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -50,7 +50,7 @@ def pytest_generate_tests(metafunc):
             continue
 
         pxe_cust_template = args['provisioning']['pxe_kickstart']
-        if pxe_cust_template not in cfme_data['customization_templates'].keys():
+        if pxe_cust_template not in cfme_data.get('customization_templates', {}).keys():
             continue
 
         argvalues[i].append(get_pxe_server_from_config(pxe_server_name))

--- a/cfme/tests/test_utilization.py
+++ b/cfme/tests/test_utilization.py
@@ -42,7 +42,7 @@ def test_metrics_collection(handle_provider, provider_key, provider_crud, enable
 
     # the id for the provider we're testing
     mgmt_system_id = db.cfmedb().session.query(mgmt_systems_tbl).filter(
-        mgmt_systems_tbl.name == conf.cfme_data['management_systems'][provider_key]['name']
+        mgmt_systems_tbl.name == conf.cfme_data.get('management_systems', {})[provider_key]['name']
     ).first().id
 
     start_time = time.time()

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -502,7 +502,7 @@ class IPAppliance(object):
         log_callback('Fixing appliance clock')
         client = self.ssh_client()
         try:
-            ntp_server = random.choice(conf.cfme_data['clock_servers'])
+            ntp_server = random.choice(conf.cfme_data.get('clock_servers', {}))
         except IndexError:
             msg = 'No clock servers configured in cfme_data.yaml'
             log_callback(msg)
@@ -726,9 +726,9 @@ class IPAppliance(object):
         If the env var is not set, URLs will be pulled from cfme_data.
         If the env var is set, it is the only source for update URLs.
 
-        Generic rhel update URLs cfme_data['basic_info']['rhel_updates_urls'] (yaml list)
+        Generic rhel update URLs cfme_data.get('basic_info', {})['rhel_updates_urls'] (yaml list)
         On downstream builds, an additional RH SCL updates url can be inserted at
-        cfme_data['basic_info']['rhscl_updates_urls'].
+        cfme_data.get('basic_info', {})['rhscl_updates_urls'].
 
 
         """
@@ -1500,12 +1500,12 @@ def provision_appliance(version=None, vm_name_prefix='cfme', template=None, prov
         return template_data.get('latest_template', None)
 
     if provider_name is None:
-        provider_name = conf.cfme_data['appliance_provisioning']['default_provider']
+        provider_name = conf.cfme_data.get('appliance_provisioning', {})['default_provider']
 
     if template is not None:
         template_name = template
     elif version is not None:
-        templates_by_version = conf.cfme_data['appliance_provisioning'].get('versions', dict())
+        templates_by_version = conf.cfme_data.get('appliance_provisioning', {}).get('versions', {})
         try:
             template_name = templates_by_version[version]
         except KeyError:
@@ -1522,7 +1522,7 @@ def provision_appliance(version=None, vm_name_prefix='cfme', template=None, prov
     else:
         raise ApplianceException('Either version or template name must be specified')
 
-    prov_data = conf.cfme_data['management_systems'][provider_name]
+    prov_data = conf.cfme_data.get('management_systems', {})[provider_name]
 
     provider = provider_factory(provider_name)
     if not vm_name:

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -12,7 +12,7 @@ import socket
 
 
 def get_host_data_by_name(provider_key, host_name):
-    for host_obj in conf.cfme_data['management_systems'][provider_key].get('hosts', []):
+    for host_obj in conf.cfme_data.get('management_systems', {})[provider_key].get('hosts', []):
         if host_name == host_obj['name']:
             return host_obj
     return None
@@ -46,14 +46,14 @@ def setup_host_creds(provider_key, host_name, ignore_errors=False):
 
 
 def setup_all_provider_hosts_credentials():
-    for provider_key in conf.cfme_data['management_systems']:
-        if 'hosts' in conf.cfme_data['management_systems'][provider_key]:
-            for yamlhost in conf.cfme_data['management_systems'][provider_key]['hosts']:
+    for provider_key in conf.cfme_data.get('management_systems', {}):
+        if 'hosts' in conf.cfme_data.get('management_systems', {})[provider_key]:
+            for yamlhost in conf.cfme_data.get('management_systems', {})[provider_key]['hosts']:
                 setup_host_creds(provider_key, yamlhost['name'])
 
 
 def setup_providers_hosts_credentials(provider_key, ignore_errors=False):
-    if provider_key in conf.cfme_data['management_systems']:
-        if 'hosts' in conf.cfme_data['management_systems'][provider_key]:
-            for yamlhost in conf.cfme_data['management_systems'][provider_key]['hosts']:
+    if provider_key in conf.cfme_data.get('management_systems', {}):
+        if 'hosts' in conf.cfme_data.get('management_systems', {})[provider_key]:
+            for yamlhost in conf.cfme_data.get('management_systems', {})[provider_key]['hosts']:
                 setup_host_creds(provider_key, yamlhost['name'], ignore_errors=ignore_errors)

--- a/utils/miq_soap.py
+++ b/utils/miq_soap.py
@@ -247,7 +247,7 @@ class MiqEms(HasManyDatastores, HasManyHosts, HasManyVMs, HasManyResourcePools):
         elif ptype == "emsopenstack":
             from utils.mgmt_system import OpenstackSystem
             credentials.update(
-                {"auth_url": cfme_data["management_systems"][provider_id]["auth_url"]}
+                {"auth_url": cfme_data.get("management_systems", {})[provider_id]["auth_url"]}
             )
             return OpenstackSystem(**credentials)
         else:

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -42,7 +42,7 @@ def list_providers(allowed_types):
     @type allowed_types: dict, list, set, tuple
     """
     providers = []
-    for provider, data in conf.cfme_data["management_systems"].iteritems():
+    for provider, data in conf.cfme_data.get("management_systems", {}).iteritems():
         provider_type = data.get("type", None)
         if provider not in filtered:
             continue
@@ -77,7 +77,7 @@ def provider_factory(provider_key, providers=None, credentials=None):
         subclass
     """
     if providers is None:
-        providers = conf.cfme_data['management_systems']
+        providers = conf.cfme_data.get('management_systems', {})
     if isinstance(provider_key, Mapping):
         provider = provider_key
     else:
@@ -123,7 +123,7 @@ def setup_a_provider(prov_class=None, prov_type=None, validate=True, check_exist
         prov_type: "infra" or "cloud"
 
     """
-    providers_data = conf.cfme_data['management_systems']
+    providers_data = conf.cfme_data.get('management_systems', {})
     if prov_class == "infra":
         potential_providers = list_infra_providers()
         if prov_type:
@@ -257,7 +257,7 @@ def _setup_providers(cloud_or_infra, validate, check_existing):
         sel.force_navigate(options_map[cloud_or_infra]['navigate'])
         add_providers = []
         for provider_key in options_map[cloud_or_infra]['list']():
-            provider_name = conf.cfme_data['management_systems'][provider_key]['name']
+            provider_name = conf.cfme_data.get('management_systems', {})[provider_key]['name']
             quad = Quadicon(provider_name, options_map[cloud_or_infra]['quad'])
             for page in paginator.pages():
                 if sel.is_displayed(quad):

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -169,7 +169,7 @@ def fixture_filter(metafunc, argnames, argvalues):
 
 
 def provider_by_type(metafunc, provider_types, *fields, **options):
-    """Get the values of the named field keys from ``cfme_data['management_systems']``
+    """Get the values of the named field keys from ``cfme_data.get('management_systems', {})``
 
     Args:
         provider_types: A list of provider types to include. If None, all providers are considered
@@ -185,7 +185,7 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
             the entire provider data dict from cfme_data.
 
         ``provider_key``
-            the provider's key in ``cfme_data['management_systems']``
+            the provider's key in ``cfme_data.get('management_systems', {})``
 
         ``provider_crud``
             the provider's CRUD object, either a :py:class:`cfme.cloud.provider.Provider`
@@ -239,7 +239,7 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
         if argname in metafunc.fixturenames and argname not in argnames:
             argnames.append(argname)
 
-    for provider, data in cfme_data['management_systems'].iteritems():
+    for provider, data in cfme_data.get('management_systems', {}).iteritems():
         skip = False
         prov_type = data['type']
         if provider_types is not None and prov_type not in provider_types:
@@ -375,7 +375,7 @@ def auth_groups(metafunc, auth_mode):
 
     Args:
 
-        auth_mode: One of the auth_modes specified in ``cfme_data['auth_modes']``
+        auth_mode: One of the auth_modes specified in ``cfme_data.get('auth_modes', {})``
 
     """
     argnames = ['group_name', 'group_data']

--- a/utils/virtual_machines.py
+++ b/utils/virtual_machines.py
@@ -11,7 +11,7 @@ from utils.providers import infra_provider_type_map
 
 def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **deploy_args):
 
-    provider_type = conf.cfme_data['management_systems'][provider_key]['type']
+    provider_type = conf.cfme_data.get('management_systems', {})[provider_key]['type']
     if provider_type in infra_provider_type_map:
         provider_crud = get_infra_from_config(provider_key)
     else:


### PR DESCRIPTION
Most of the changes were made witha  gnarly sed line, but there were
some uncollect improvements to be made in a few places. There is much more
that we can do on the uncollecting front, but this gets rid of all collection
errors related to missing keys in cfme_data.

{pytest: --collect-only}}