### PR TITLE
[WIP] Sprout - try using incomplete pool if something happened

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -51,7 +51,7 @@ from utils.appliance import IPAppliance
 from utils.log import create_sublogger
 from utils.path import project_path
 from utils.sprout import SproutClient, SproutException
-from utils.wait import wait_for
+from utils.wait import wait_for, TimedOutError
 
 
 _appliance_help = '''specify appliance URLs to use for distributed testing.
@@ -86,6 +86,8 @@ def pytest_addoption(parser):
         '--sprout-date', dest='sprout_date', default=None, help="Which date to use.")
     group._addoption(
         '--sprout-desc', dest='sprout_desc', default=None, help="Set description of the pool.")
+    group._addoption('--sprout-permissive', dest='sprout_permissive', type=int,
+        default=100, help="Specifies how many appliances are required to be ready.")
 
 
 @pytest.mark.tryfirst
@@ -100,6 +102,7 @@ def pytest_configure(config, __multicall__):
 
 def dump_pool_info(printf, pool_data):
     printf("Fulfilled: {}".format(pool_data["fulfilled"]))
+    printf("Partially fulfilled: {}".format(pool_data["partially_fulfilled"]))
     printf("Progress: {}%".format(pool_data["progress"]))
     printf("Appliances:")
     for appliance in pool_data["appliances"]:
@@ -155,12 +158,30 @@ class ParallelSession(object):
                     delay=5,
                     message="requesting appliances was fulfilled"
                 )
-            except:
+            except TimedOutError:
                 pool = self.sprout_client.request_check(self.sprout_pool)
                 dump_pool_info(lambda x: self.terminal.write("{}\n".format(x)), pool)
-                self.terminal.write("Destroying the pool on error.\n")
-                self.sprout_client.destroy_pool(pool_id)
-                raise
+                if (not pool["partially_fulfilled"]) or self.config.option.sprout_permissive >= 100:
+                    # This is clear, failed
+                    self.terminal.write("Destroying the pool on error.\n")
+                    self.sprout_client.destroy_pool(pool_id)
+                    raise
+                percent_appls = int(round((
+                    float(len(pool["appliances"])) / float(self.config.option.sprout_appliances)
+                ) * 100.0))
+                if percent_appls >= self.config.option.sprout_permissive:
+                    # We can continue
+                    self.terminal.write(
+                        "We have only {}% of appliances but that is over threshold".format(
+                            percent_appls))
+                    self.sprout_client.pool_drop_remaining_provisioning_requests(self.sprout_pool)
+                else:
+                    # Under threshold
+                    self.terminal.write(
+                        "{}% is under limit so destroying the pool on error.\n".format(
+                            percent_appls))
+                    self.sprout_client.destroy_pool(pool_id)
+                    raise
             else:
                 pool = self.sprout_client.request_check(self.sprout_pool)
                 dump_pool_info(lambda x: self.terminal.write("{}\n".format(x)), pool)

--- a/sprout/appliances/api.py
+++ b/sprout/appliances/api.py
@@ -221,6 +221,7 @@ def request_check(user, request_id):
     return {
         "fulfilled": request.fulfilled,
         "preconfigured": request.preconfigured,
+        "partially_fulfilled": request.partially_fulfilled,
         "progress": int(round(request.percent_finished * 100)),
         "appliances": [
             appliance.serialized
@@ -228,6 +229,15 @@ def request_check(user, request_id):
             in request.appliances
         ],
     }
+
+
+@jsonapi.authenticated_method
+def pool_drop_remaining_provisioning_requests(user, request_id):
+    """Remove all provisioning requests that are to be executed on the pool"""
+    request = AppliancePool.objects.get(id=request_id)
+    if user != request.owner and not user.is_staff:
+        raise Exception("This pool belongs to a different user!")
+    return request.drop_remaining_provisioning_tasks()
 
 
 @jsonapi.authenticated_method

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -733,6 +733,7 @@ class AppliancePool(MetadataMixin):
 
     @property
     def fulfilled(self):
+        """Like partially_fulfilled, but also count of applinces must match the total_count."""
         try:
             return len(self.appliance_ips) == self.total_count\
                 and all(a.ready for a in self.appliances)
@@ -740,8 +741,21 @@ class AppliancePool(MetadataMixin):
             return False
 
     @property
+    def partially_fulfilled(self):
+        """All appliances that are in the pool are ready."""
+        try:
+            return all(a.ready for a in self.appliances)
+        except ObjectDoesNotExist:
+            return False
+
+    @property
     def queued_provision_tasks(self):
         return DelayedProvisionTask.objects.filter(pool=self)
+
+    def drop_remaining_provisioning_tasks(self):
+        with transaction.atomic():
+            for task in self.queued_provision_tasks:
+                task.delete()
 
     def prolong_lease(self, time=60):
         for appliance in self.appliances:


### PR DESCRIPTION
Now if we request eg. 15 appliances and specify 80% "grace" threshold, then if the pool has at least 80% of appliances and all are ready, it is used. That can happen sometimes when the providers are really pissy. Eg. run 621 on jenkins.

WIP for not testing it, it has no point in PR tester.