### PR TITLE
Close browser after each test to prevent session timeout glitches

### DIFF
--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -104,6 +104,12 @@ def pytest_sessionfinish(session, exitstatus):
         outfile.write(failed_tests_report)
 
 
+@pytest.mark.trylast
+def pytest_runtest_teardown(item, nextitem):
+    """To prevent glitches caused by session timeout spreading over tests."""
+    utils.browser.quit()
+
+
 @pytest.fixture(scope='session')
 def browser():
     return utils.browser.browser


### PR DESCRIPTION
I know this definitely is not the optimal solution, it causes some slowdown, but it should stop the session timeout spreading in multiple tests. And it will possible show us which parts of code use navigation wrong, if such code exists.

{{pytest: -v -k 'test_instance_power_control or test_appliance' --use-provider rhos3 --long-running}}