### PR TITLE
Fix runtime config - fixes vddk_url problem

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -172,6 +172,7 @@ class ParallelSession(object):
             conf.runtime["env"]["base_url"] = self.appliances[0]
             # Retrieve and print the template_name for Jenkins to pick up
             template_name = request["appliances"][0]["template_name"]
+            conf.runtime["cfme_data"]["basic_info"] = conf.cfme_data["basic_info"]
             conf.runtime["cfme_data"]["basic_info"]["appliance_template"] = template_name
             self.terminal.write("appliance_template=\"{}\";\n".format(template_name))
             self.terminal.write("Parallelized Sprout setup finished.\n")

--- a/fixtures/single_appliance_sprout.py
+++ b/fixtures/single_appliance_sprout.py
@@ -71,13 +71,14 @@ def pytest_configure(config, __multicall__):
         appliance = IPAppliance(address=ip_address)
         # Retrieve and print the template_name for Jenkins to pick up
         template_name = request["appliances"][0]["template_name"]
-        conf.cfme_data["basic_info"]["appliance_template"] = template_name
+        conf.runtime["cfme_data"]["basic_info"] = conf.cfme_data["basic_info"]
+        conf.runtime["cfme_data"]["basic_info"]["appliance_template"] = template_name
         terminal.write("appliance_template=\"{}\";\n".format(template_name))
         terminal.write("Single appliance Sprout setup finished.\n")
         # And set also the appliances_provider
         provider = request["appliances"][0]["provider"]
         terminal.write("appliance_provider=\"{}\";\n".format(provider))
-        conf.cfme_data["basic_info"]["appliances_provider"] = provider
+        conf.runtime["cfme_data"]["basic_info"]["appliances_provider"] = provider
 
 
 @pytest.mark.tryfirst


### PR DESCRIPTION
* pull the cfme_data's basic_info to runtime in multi appliance sprout
* use conf.runtime in single appliance sprout

{{pytest: -v -k vm_analysis --long-running}}