### PR TITLE
Templateloader for test collection

### DIFF
--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -20,7 +20,8 @@ pytestmark = [
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []
@@ -56,7 +57,7 @@ def vm_name():
 
 
 @pytest.fixture(scope="function")
-def testing_vm(request, vm_name, provider_init, provider_crud, provisioning):
+def testing_vm(request, vm_name, provider_init, provider_crud, provider_mgmt, provisioning):
     vm_obj = Vm(vm_name, provider_crud, provisioning["template"])
     request.addfinalizer(
         lambda: vm_obj.delete_from_provider() if vm_obj.does_vm_exist_on_provider() else None)

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -54,7 +54,7 @@ class VMWrapper(Pretty):
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
     argnames, argvalues, idlist = testgen.infra_providers(metafunc,
-        'small_template', scope="module")
+        'small_template', scope="module", template_location=["small_template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/infrastructure/test_genealogy.py
+++ b/cfme/tests/infrastructure/test_genealogy.py
@@ -14,7 +14,8 @@ pytestmark = [
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -16,7 +16,8 @@ pytestmark = [
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -35,7 +35,8 @@ def cleanup_vm(vm_name, provider_key, provider_mgmt):
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/infrastructure/test_retirement.py
+++ b/cfme/tests/infrastructure/test_retirement.py
@@ -11,7 +11,8 @@ from functools import partial
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -23,7 +23,8 @@ pytestmark = [
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -52,7 +52,8 @@ add_to_service
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -26,7 +26,8 @@ pytestmark = [
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -25,7 +25,8 @@ pytestmark = [
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, 'provisioning')
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc, 'provisioning', template_location=["provisioning", "template"])
 
     new_idlist = []
     new_argvalues = []

--- a/fixtures/templateloader.py
+++ b/fixtures/templateloader.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Preloads all templates on all providers that were selected for testing. Useful for test collect.
+"""
+import pytest
+
+from fixtures.prov_filter import filtered
+from fixtures.pytest_store import write_line
+from utils.providers import provider_factory
+
+TEMPLATES = {}
+
+
+@pytest.mark.trylast
+def pytest_configure(config):
+    write_line("Loading templates from providers (this may take some time)")
+    for provider in filtered.providers:
+        try:
+            p = provider_factory(provider)
+            TEMPLATES[provider] = set(map(str, p.list_template()))
+        except Exception as e:
+            write_line("-> Error: {}({})\n".format(type(e).__name__, str(e)), red=True)
+            TEMPLATES[provider] = None
+    write_line("Template retrieval finished")


### PR DESCRIPTION
We can safeguard against missing tempaltes in providers by scavenging them and then taking it into account during parametrization phase. To save the load, the provider templates get loaded in the beginning.

{{pytest: -v --collect-only --use-provider complete --long-running --perf}}