### PR TITLE
Wait for instance to disappear + longer volume delete timeout

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -9,6 +9,7 @@ from cfme.fixtures import pytest_selenium as sel
 from utils import testgen
 from utils.randomness import generate_random_string
 from utils.update import update
+from utils.wait import wait_for
 
 pytestmark = [pytest.mark.meta(server_roles="+automate")]
 
@@ -151,3 +152,4 @@ def test_provision_from_template_with_attached_disks(
         for volume, device in device_mapping:
             soft_assert(provider_mgmt.volume_attachments(volume)[vm_name] == device_mapping)
         instance.delete_from_provider()  # To make it possible to delete the volume
+        wait_for(lambda: not instance.does_vm_exist_on_provider(), num_sec=180, delay=5)

--- a/utils/mgmt_system/openstack.py
+++ b/utils/mgmt_system/openstack.py
@@ -239,12 +239,15 @@ class OpenstackSystem(MgmtSystemAPIBase):
 
     def delete_volume(self, *ids, **kwargs):
         wait = kwargs.get("wait", True)
+        timeout = kwargs.get("timeout", 180)
         for id in ids:
             self.capi.volumes.find(id=id).delete()
         if not wait:
             return
         # Wait for them
-        wait_for(lambda: all(map(lambda id: not self.volume_exists(id), ids)), delay=0.5)
+        wait_for(
+            lambda: all(map(lambda id: not self.volume_exists(id), ids)),
+            delay=0.5, num_sec=timeout)
 
     def volume_exists(self, id):
         try:


### PR DESCRIPTION
The volume provisioning tests seem to need some hardening.