### PR TITLE
[WIP] Sprout - show slots at the My Appliances display

### DIFF
--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -110,6 +110,13 @@ class Provider(MetadataMixin):
         return result
 
     @property
+    def remaining_appliance_slots(self):
+        result = self.appliance_limit - self.num_currently_managing
+        if result < 0:
+            return 0
+        return result
+
+    @property
     def num_currently_managing(self):
         return len(Appliance.objects.filter(template__provider=self))
 

--- a/sprout/appliances/templates/appliances/_providers.html
+++ b/sprout/appliances/templates/appliances/_providers.html
@@ -1,4 +1,4 @@
-<option value="any">Any provider (recommended option!)</option>
+<option value="any">Any provider (recommended option!) ({{ total_provisioning_slots }}:{{ total_appliance_slots }})</option>
 {% for provider in providers %}
-<option value="{{ provider }}">{{ provider }}</option>
+<option value="{{ provider.id }}">{{ provider.id }} ({{ provider.remaining_provisioning_slots }}:{{ provider.remaining_appliance_slots }})</option>
 {% endfor %}

--- a/sprout/appliances/templates/appliances/my_appliances.html
+++ b/sprout/appliances/templates/appliances/my_appliances.html
@@ -158,7 +158,7 @@
       </select>
     </div>
     <div class="form-group">
-      <label for="date">Select specific provider (if you know what you do):</label>
+      <label for="date">Select specific provider (if you know what you do) (remaining provisioning slots:remaining appliance slots):</label>
       <select class="form-control" id="provider" name="provider">
         <option value="any">Any provider (recommended option!)</option>
       </select>
@@ -169,6 +169,7 @@
     </div>
     <button class="btn btn-primary btn-lg" onclick="return confirm('Are you sure?')"><span class="glyphicon glyphicon-star-empty"></span> Gimme one!</button>
 </form>
+<p>The numbers at the provider are sort of hint how much space is left. This does not take shepherd into the account, so although the select might tell you there is no more space, shepherd might have some appliances running that you can take. This will be modified later.</p>
 <script type="text/javascript">
 $(document).ready(function() {
     $('select#stream').change(function(){

--- a/sprout/appliances/views.py
+++ b/sprout/appliances/views.py
@@ -103,6 +103,8 @@ def date_for_group_and_version(request):
 
 
 def providers_for_date_group_and_version(request):
+    total_provisioning_slots = 0
+    total_appliance_slots = 0
     group_id = request.POST.get("stream")
     if group_id == "<None>":
         providers = []
@@ -138,6 +140,10 @@ def providers_for_date_group_and_version(request):
                 filters["date"] = parser.parse(date)
             providers = Template.objects.filter(**filters).values("provider").distinct()
             providers = sorted([p.values()[0] for p in providers])
+            providers = [Provider.objects.get(id=provider) for provider in providers]
+            for provider in providers:
+                total_appliance_slots += provider.remaining_appliance_slots
+                total_provisioning_slots += provider.remaining_provisioning_slots
     return render(request, 'appliances/_providers.html', locals())
 
 


### PR DESCRIPTION
**wip for not testing**

This will prevent people asking me *"why sprout does not give me an appliance?"* when they ask for them in the worst constellations when all providers that contain desired templates are full.

This will be updated in the future to take the shepherd into account.