### PR TITLE
Make it possible to override ajax timeout time

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -15,6 +15,7 @@ Members of this module are available in the the pytest.sel namespace, e.g.::
 from time import sleep, time
 from xml.sax.saxutils import quoteattr
 from collections import Iterable
+from contextlib import contextmanager
 from textwrap import dedent
 import json
 import re
@@ -42,6 +43,7 @@ from utils.pretty import Pretty
 
 from threading import local
 _thread_local = local()
+_thread_local.ajax_timeout = 30
 
 class_selector = re.compile(r"^(?:[a-zA-Z][a-zA-Z0-9]*)?(?:[#.][a-zA-Z0-9_-]+)+$")
 
@@ -269,7 +271,21 @@ def wait_for_ajax():
 
     wait_for(
         _nothing_in_flight,
-        num_sec=30, delay=0.1, message="wait for ajax", quiet=True, silent_failure=True)
+        num_sec=_thread_local.ajax_timeout, delay=0.1, message="wait for ajax", quiet=True,
+        silent_failure=True)
+
+
+@contextmanager
+def ajax_timeout(seconds):
+    """Change the AJAX timeout in this context. Useful when something takes a long time.
+
+    Args:
+        seconds: Numebr of seconnds to wait.
+    """
+    original = _thread_local.ajax_timeout
+    _thread_local.ajax_timeout = seconds
+    yield
+    _thread_local.ajax_timeout = original
 
 
 def is_displayed(loc, _deep=0):

--- a/cfme/login.py
+++ b/cfme/login.py
@@ -76,7 +76,8 @@ def _js_auth_fn():
 
 def logged_in():
     ensure_browser_open()
-    sel.wait_for_ajax()  # This is called almost everywhere, protects from spinner
+    with sel.ajax_timeout(90):
+        sel.wait_for_ajax()  # This is called almost everywhere, protects from spinner
     return sel.is_displayed(dashboard.page.user_dropdown)
 
 
@@ -110,7 +111,8 @@ def login(username, password, submit_method=_js_auth_fn):
 
         logger.debug('Logging in as user %s' % username)
         fill(form, {'username': username, 'password': password})
-        submit_method()
+        with sel.ajax_timeout(90):
+            submit_method()
         flash.assert_no_errors()
         thread_locals.current_user = User(username, password, _full_name())
 


### PR DESCRIPTION
I noticed we had a failure on test_login, this should help it.