### PR TITLE
Artifactor report - escape the error messages

### DIFF
--- a/data/templates/test_report.html
+++ b/data/templates/test_report.html
@@ -181,7 +181,7 @@ $(function() {
             <p>{{test.file}}</p>
             {% if test.short_tb %}
 	        <h4>Short Traceback</h4>
-                <pre class="well">{{test.short_tb}}</pre>
+                <pre class="well">{{test.short_tb|e}}</pre>
             {% endif %}
 	    {% if test.softassert %}
                 <div>


### PR DESCRIPTION
Things like `<lambda>` were making the output unreadable. This should fix it

{{pytest: -v -k test_provision_from_template_with_attached_disks --long-running --use-provider rhos5 }}