### PR TITLE
Use the datastore picking on (almost) everything in background

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -23,6 +23,7 @@ from utils.log import logger
 from utils.miq_soap import MiqVM
 from utils.providers import setup_provider
 from utils.randomness import generate_random_string
+from utils.virtual_machines import deploy_template
 from utils.wait import wait_for, TimedOutError
 from utils.pretty import Pretty
 
@@ -108,9 +109,10 @@ def vm(request, provider_mgmt, provider_crud, provider_key, provider_data, small
     if isinstance(provider_mgmt, mgmt_system.RHEVMSystem):
         # RHEV-M is sometimes overloaded, so a little protection here
         try:
-            provider_mgmt.deploy_template(
-                small_template,
-                vm_name=vm_name,
+            deploy_template(
+                provider_key,
+                vm_name,
+                template_name=small_template,
                 cluster=provider_data["default_cluster"]
             )
         except TimedOutError:
@@ -124,9 +126,10 @@ def vm(request, provider_mgmt, provider_crud, provider_key, provider_data, small
     elif isinstance(provider_mgmt, mgmt_system.VMWareSystem):
         # VMWare behaves correctly... usually, but we have to be sure! :)
         try:
-            provider_mgmt.deploy_template(
-                small_template,
-                vm_name=vm_name,
+            deploy_template(
+                provider_key,
+                vm_name,
+                template_name=small_template,
             )
         except TimedOutError:
             try:
@@ -138,9 +141,10 @@ def vm(request, provider_mgmt, provider_crud, provider_key, provider_data, small
                 pytest.skip("vSphere %s is probably overloaded! Check its status!" % provider_key)
     elif isinstance(provider_mgmt, mgmt_system.SCVMMSystem):
         try:
-            provider_mgmt.deploy_template(
-                small_template,
-                vm_name=vm_name,
+            deploy_template(
+                provider_key,
+                vm_name,
+                template_name=small_template,
                 host_group=provider_data.get("host_group", "All Hosts")
             )
         except TimedOutError:

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -288,8 +288,11 @@ def prepare_template_deploy(self, template_id):
     try:
         if not template.exists_in_provider:
             template.set_status("Deploying the template.")
-            kwargs = template.provider.provider_data["sprout"]
+            provider_data = template.provider.provider_data
+            kwargs = provider_data["sprout"]
             kwargs["power_on"] = True
+            if "allowed_datastores" not in kwargs and "allowed_datastores" in provider_data:
+                kwargs["allowed_datastores"] = provider_data["allowed_datastores"]
             logger().info("Deployment kwargs: {}".format(repr(kwargs)))
             template.provider_api.deploy_template(
                 template.original_name, vm_name=template.name, **kwargs)
@@ -539,8 +542,11 @@ def clone_template_to_appliance__clone_template(self, appliance_id, lease_time_m
     try:
         if not appliance.provider_api.does_vm_exist(appliance.name):
             appliance.set_status("Beginning template clone.")
-            kwargs = appliance.template.provider.provider_data["sprout"]
+            provider_data = appliance.template.provider.provider_data
+            kwargs = provider_data["sprout"]
             kwargs["power_on"] = False
+            if "allowed_datastores" not in kwargs and "allowed_datastores" in provider_data:
+                kwargs["allowed_datastores"] = provider_data["allowed_datastores"]
             logger().info("Deployment kwargs: {}".format(repr(kwargs)))
             appliance.provider_api.deploy_template(
                 appliance.template.name, vm_name=appliance.name,

--- a/utils/virtual_machines.py
+++ b/utils/virtual_machines.py
@@ -25,7 +25,8 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
         if 'default_cluster' not in deploy_args:
             deploy_args.update(cluster=data['default_cluster'])
     elif isinstance(mgmt, VMWareSystem):
-        pass
+        if "allowed_datastores" not in deploy_args and "allowed_datastores" in data:
+            deploy_args.update(allowed_datastores=data['allowed_datastores'])
     elif isinstance(mgmt, SCVMMSystem):
         if 'host_group' not in deploy_args:
             deploy_args.update(host_group=data.get("host_group", "All Hosts"))


### PR DESCRIPTION
This should make everything that does not provision VMs via CFME UI (+ sprout) pick the least used datastore for provision if it is vsphere and it has `allowed_datastores` in yaml.