### PR TITLE
[WIP][NO TEST] Sprout - more fair shepherd generator

### DIFF
--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -265,6 +265,19 @@ class Group(MetadataMixin):
     def templates(self):
         return Template.objects.filter(template_group=self).order_by("-date", "provider__id")
 
+    @property
+    def appliances(self):
+        return Appliance.objects.filter(template__template_group=self)
+
+    def get_fulfillment_percentage(self, preconfigured):
+        appliances_in_shepherd = len(
+            self.appliances.filter(template__preconfigured=preconfigured, appliance_pool=None))
+        wanted_pool_size = (
+            self.template_pool_size if preconfigured else self.unconfigured_template_pool_size)
+        if wanted_pool_size == 0:
+            return 100
+        return int(round((float(appliances_in_shepherd) / float(wanted_pool_size)) * 100.0))
+
     def __unicode__(self):
         return "{} {} (pool size={}/{})".format(
             self.__class__.__name__, self.id, self.template_pool_size,

--- a/sprout/sprout/settings.py
+++ b/sprout/sprout/settings.py
@@ -166,7 +166,7 @@ CELERYBEAT_SCHEDULE = {
 
     'free-appliance-shepherd': {
         'task': 'appliances.tasks.free_appliance_shepherd',
-        'schedule': timedelta(minutes=5),
+        'schedule': timedelta(minutes=1),
     },
 
     'kill-unused-appliances': {


### PR DESCRIPTION
* order the groups by their shepherd fulfillment status
* shepherd always provisions one appliance at time (per group), but runs more frequently
* shepherd now picks provider by its load

Also improved the `process_delayed_provisioning_tasks` which now looks in shepherd whether such appliance was provisioned on background.