### PR TITLE
[WIPTEST] style3 class has been (or will soon be) removed from tables

### DIFF
--- a/cfme/automate/explorer.py
+++ b/cfme/automate/explorer.py
@@ -613,7 +613,10 @@ class InstanceFieldsRow(pretty.Pretty):
     Args:
         row_id: Sequential id of the row (begins with 0)
     """
-    table = Table("//div[@id='form_div']//table[@class='style3']")
+    # REVIEW: This locator seems wrong. The instance field table in 53z and
+    # upstream appears to be a SplitTable under div#inst_grid_div
+    # On an instance's page, div#form_div doesn't seem to exist.
+    table = Table("//div[@id='form_div']//table")
     columns = ("value", "on_entry", "on_exit", "on_error", "collect")
     fields = (
         "inst_value_{}", "inst_on_entry_{}", "inst_on_exit_{}",
@@ -656,7 +659,7 @@ class InstanceFields(object):
         Requires to be on the page
         """
         names = []
-        for cell in sel.elements("//div[@id='form_div']//table[@class='style3']//td[img]"):
+        for cell in sel.elements(".//td[img]", root=InstanceFieldsRow.table):
             # The received text is something like u'  (blabla)' so we extract 'blabla'
             sel.move_to_element(cell)  # This is required in order to correctly read the content
             names.append(re.sub(r"^[^(]*\(([^)]+)\)[^)]*$", "\\1", sel.text(cell).encode("utf-8")))

--- a/cfme/automate/provisioning_dialogs.py
+++ b/cfme/automate/provisioning_dialogs.py
@@ -13,7 +13,7 @@ from utils.pretty import Pretty
 acc_tree = partial(accordion.tree, "Provisioning Dialogs")
 cfg_btn = partial(toolbar.select, "Configuration")
 
-dialog_table = SortTable("//div[@id='records_div']//table[contains(@class, 'style3')]")
+dialog_table = SortTable("//div[@id='records_div']/table")
 
 
 def get_dialog_name(o):

--- a/cfme/automate/service_dialogs.py
+++ b/cfme/automate/service_dialogs.py
@@ -12,8 +12,8 @@ from utils.pretty import Pretty
 accordion_tree = functools.partial(accordion.tree, "Service Dialogs")
 cfg_btn = functools.partial(tb.select, "Configuration")
 plus_btn = functools.partial(tb.select, "Add")
-entry_table = Table("//div[@id='field_values_div']/form/fieldset/table[@class='style3']")
-text_area_table = Table("//div[@id='dialog_field_div']/fieldset/table[@class='style1']")
+entry_table = Table("//div[@id='field_values_div']/form/fieldset/table")
+text_area_table = Table("//div[@id='dialog_field_div']/fieldset/table")
 
 label_form = Form(fields=[
     ('label', Input("label")),

--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -132,10 +132,10 @@ zone_form = Form(
     ])
 
 
-records_table = Table("//div[@id='records_div']/table[@class='style3']")
-category_table = Table("//div[@id='settings_co_categories']//table[@class='style3']")
-classification_table = Table("//div[@id='classification_entries_div']//table[@class='style3']")
-zones_table = Table("//div[@id='settings_list']/table[@class='style3']")
+records_table = Table("//div[@id='records_div']/table")
+category_table = Table("//div[@id='settings_co_categories']//table")
+classification_table = Table("//div[@id='classification_entries_div']//table")
+zones_table = Table("//div[@id='settings_list']/table")
 
 
 def server_region():

--- a/cfme/configure/red_hat_updates.py
+++ b/cfme/configure/red_hat_updates.py
@@ -84,7 +84,7 @@ service_types = {
 }
 
 
-appliances_table = CheckboxTable("//div[@id='form_div']/table[@class='style3']")
+appliances_table = CheckboxTable("//div[@id='form_div']/table")
 
 
 def update_registration(service,

--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -16,7 +16,7 @@ from utils.update import Updateable
 details_page = Region(infoblock_type='detail')
 
 cfg_btn = partial(tb.select, 'Configuration')
-timeprofile_table = Table("//div[@id='main_div']//table[@class='style3']")
+timeprofile_table = Table("//div[@id='main_div']//table")
 
 
 nav.add_branch(

--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -44,8 +44,10 @@ filter_form = Form(
     ]
 )
 
+# REVIEW: I expect masterToggle is already wrapped up in mfalesni's
+# Input locator PR
 tasks_table = CheckboxTable(
-    table_locator='//div[@id="records_div"]/table[@class="style3"]',
+    table_locator='//div[@id="records_div"]/table',
     header_checkbox_locator="//div[@id='records_div']//input[@id='masterToggle']"
 )
 

--- a/cfme/control/explorer.py
+++ b/cfme/control/explorer.py
@@ -23,12 +23,12 @@ from utils.pretty import Pretty
 
 
 events_table = Table(
-    table_locator="//div[@id='event_list_div']//table[@class='style3']"
+    table_locator="//div[@id='event_list_div']/table"
 )
 EVENT_NAME_CELL = 1
 
 events_policies_table = Table(
-    table_locator="//div[@id='event_info_div']//table[@class='style3']"
+    table_locator="//div[@id='event_info_div']/table"
 )
 
 events_in_policy_table = Table(
@@ -36,29 +36,29 @@ events_in_policy_table = Table(
 )
 
 condition_folders_table = Table(
-    table_locator="//div[@id='condition_folders_div']//table[@class='style3']"
+    table_locator="//div[@id='condition_folders_div']/table"
 )
 CONDITION_FOLDERS_CELL = 1
 
 condition_list_table = Table(
-    table_locator="//div[@id='condition_list_div']//table[@class='style3']"
+    table_locator="//div[@id='condition_list_div']/table"
 )
 CONDITION_LIST_CELL = 1
 
 actions_table = Table(
-    table_locator="//div[@id='records_div']//table[@class='style3']"
+    table_locator="//div[@id='records_div']/table"
 )
 
 alerts_table = Table(
-    table_locator="//div[@id='records_div']//table[@class='style3']"
+    table_locator="//div[@id='records_div']/table"
 )
 
 alert_profiles_main_table = Table(
-    table_locator="//div[@id='alert_profile_folders_div']//table[@class='style3']"
+    table_locator="//div[@id='alert_profile_folders_div']/table"
 )
 
 alert_profiles_list_table = Table(
-    table_locator="//div[@id='alert_profile_list_div']//table[@class='style3']"
+    table_locator="//div[@id='alert_profile_list_div']/table"
 )
 ALERT_PROFILES_CELL = 1
 
@@ -67,17 +67,17 @@ visible_tree = Tree("//div[@class='dhxcont_global_content_area']"
                     "/ul[@class='dynatree-container']")
 
 policies_main_table = Table(
-    table_locator="//div[@id='main_div']//table[@class='style3']"
+    table_locator="//div[@id='main_div']/table"
 )
 POLICIES_MAIN_CELL = 1
 
 policy_profiles_table = Table(
-    table_locator="//div[@id='main_div']//table[@class='style3']"
+    table_locator="//div[@id='main_div']/table"
 )
 POLICY_PROFILES_CELL = 1
 
 policies_table = Table(
-    table_locator="//div[@id='records_div']//table[@class='style3']"
+    table_locator="//div[@id='records_div']/table"
 )
 
 cfg_btn = partial(tb.select, "Configuration")

--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -214,7 +214,7 @@ class RSSWidgetContent(BaseWidgetContent):
 class ReportWidgetContent(BaseWidgetContent):
     @property
     def data(self):
-        return Table(lambda: sel.element("./div/table[@class='style3']", root=self.root))
+        return Table(lambda: sel.element("./div/table", root=self.root))
 
 
 def get_csrf_token():

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -67,6 +67,7 @@ manage_policies_tree = CheckboxTree(
     }
 )
 
+# REVIEW: Need to find one of these, would love to have a div#id parent
 drift_table = CheckboxTable("//table[@class='style3']")
 
 host_add_btn = FormButton('Add this Host')

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -195,7 +195,7 @@ report_form = TabStripForm(
     order=["Columns", "Consolidation", "Formatting", "Styling", "Filter", "Summary", "Charts"]
 )
 
-records_table = Table("//div[@id='records_div']//table[contains(@class, 'style3')]")
+records_table = Table("//div[@id='records_div']/table")
 
 
 class CustomReport(Updateable):
@@ -286,7 +286,7 @@ class CustomSavedReport(Updateable, Pretty):
         datetime: Datetime of "Run At" of the report. That's what :py:func:`queue_canned_report`
             returns.
     """
-    _table_loc = "//div[@id='report_html_div']/table[@class='style3']"
+    _table_loc = "//div[@id='report_html_div']/table"
 
     pretty_attrs = ['report', 'datetime']
 

--- a/cfme/intelligence/reports/saved.py
+++ b/cfme/intelligence/reports/saved.py
@@ -23,7 +23,7 @@ nav.add_branch(
     }
 )
 
-reports_table = CheckboxTable("//div[@id='records_div']//table[contains(@class, 'style3')]")
+reports_table = CheckboxTable("//div[@id='records_div']/table")
 cfg_btn = partial(toolbar.select, "Configuration")
 
 

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -16,7 +16,7 @@ from utils.pretty import Pretty
 cfg_btn = partial(toolbar.select, "Configuration")
 
 
-schedules_table = CheckboxTable("//div[@id='records_div']//table[contains(@class, 'style3')]")
+schedules_table = CheckboxTable("//div[@id='records_div']/table")
 
 
 def get_sch_name(sch):

--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -14,7 +14,7 @@ policy_btn = partial(tb.select, "Policy")
 
 template_select_form = Form(
     fields=[
-        ('template_table', Table('//div[@id="prov_vm_div"]//table[@class="style3"]')),
+        ('template_table', Table('//div[@id="prov_vm_div"]/table')),
         ('add_button', form_buttons.add),
         ('cancel_button', form_buttons.cancel)
     ]

--- a/cfme/services/catalogs/cloud_catalog_item.py
+++ b/cfme/services/catalogs/cloud_catalog_item.py
@@ -23,7 +23,7 @@ catalog_item_tree = web_ui.Tree({
 
 template_select_form = Form(
     fields=[
-        ('template_table', Table('//div[@id="prov_vm_div"]//table[@class="style3"]')),
+        ('template_table', Table('//div[@id="prov_vm_div"]/table')),
         ('add_button', form_buttons.add),
         ('cancel_button', form_buttons.cancel)
     ]

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -977,10 +977,11 @@ def table_in_object(table_title):
         table_title: Text in `p` element preceeding the table
     Returns: XPath locator for the desired table.
     """
+    # REVIEW: What uses this? I wasn't able to test it.
     # Description     paragraph with the text       following element    which is the table
     return (
         "//p[@class='legend' and normalize-space(text())='{}']"
-        "/following-sibling::*[1][@class='style3']").format(table_title)
+        "/following-sibling::table").format(table_title)
 
 
 @multimethod(lambda loc, value: (sel.tag(loc), sel.get_attribute(loc, 'type')))

--- a/cfme/web_ui/mixins.py
+++ b/cfme/web_ui/mixins.py
@@ -7,7 +7,7 @@ tag_form = Form(
         ('tag', Select('//select[@id="tag_add"]'))
     ])
 
-tag_table = Table("//div[@id='assignments_div']//table[@class='style3']")
+tag_table = Table("//div[@id='assignments_div']/table")
 
 
 def add_tag(tag, single_value=False):


### PR DESCRIPTION
There are some review comments sprinked throughout the code, look for "REVIEW:"

Almost universally (the one possible exception needs review), the "style3" class wasn't necessary to locate data tables, since the next locatable table (whether the descendance is '//' or '/') is the table we want.

There were also a lot of instances where the xpath looked like `//div//table` when table was a direct descendant of the located div, so only a single slash is needed. I change those instances when I was sure that this is the case, so places where we still see `//div//table` are probably correct. I wouldn't mind a second look.