### PR TITLE
Paginator and Tabstrip input conversions

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1247,6 +1247,12 @@ class Input(Pretty):
     def locate(self):
         return '//input[@name="{}"]'.format(self.name)
 
+    def __add__(self, string):
+        return '//input[@name="{}"]{}'.format(self.name, string)
+
+    def __radd__(self, string):
+        return '{}//input[@name="{}"]'.format(string, self.name)
+
 
 class Radio(Input):
     """ A class for Radio button groups

--- a/cfme/web_ui/paginator.py
+++ b/cfme/web_ui/paginator.py
@@ -1,5 +1,5 @@
 """A set of functions for dealing with the paginator controls."""
-from cfme.web_ui import Select
+from cfme.web_ui import Select, Input
 import cfme.fixtures.pytest_selenium as sel
 import re
 from selenium.common.exceptions import NoSuchElementException
@@ -13,7 +13,7 @@ _last = '//img[@alt="Last"]'
 _num_results = '//select[@id="ppsetting" or @id="perpage_setting1"]'
 _sort_by = '//select[@id="sort_choice"]'
 _page_cell = '//td//td[contains(., " of ")]'
-_check_all = '//input[@id="masterToggle"]'
+_check_all = Input("masterToggle")
 
 
 def page_controls_exist():

--- a/cfme/web_ui/tabstrip.py
+++ b/cfme/web_ui/tabstrip.py
@@ -155,13 +155,13 @@ class TabStripForm(web_ui.Form):
         provisioning_form = web_ui.TabStripForm(
             tab_fields={
                 'Request': [
-                    ('email', '//input[@name="requester__owner_email"]'),
-                    ('first_name', '//input[@id="requester__owner_first_name"]'),
-                    ('last_name', '//input[@id="requester__owner_last_name"]'),
+                    ('email', Input("requester__owner_email")),
+                    ('first_name', Input("requester__owner_first_name")),
+                    ('last_name', Input("requester__owner_last_name")),
                     ('notes', '//textarea[@id="requester__request_notes"]'),
                 ],
                 'Catalog': [
-                    ('instance_name', '//input[@name="service__vm_name"]'),
+                    ('instance_name', Input("service__vm_name")),
                     ('instance_description', '//textarea[@id="service__vm_description"]'),
                 ]
             }


### PR DESCRIPTION
* Tabstrip needed docs changes
* Paginator updated
* Added __add__ and __radd__ so that XPath chains using input can be created

{{pytest: cfme/tests/configure/test_visual_cloud.py}}