### PR TITLE
Bugzilla correct handling upstream

### DIFF
--- a/utils/bz.py
+++ b/utils/bz.py
@@ -71,7 +71,7 @@ class Bugzilla(object):
     @property
     def default_product(self):
         if self.__product is None:
-            raise ValueError("No product specified!")
+            return None
         return self.product(self.__product)
 
     @classmethod
@@ -101,7 +101,10 @@ class Bugzilla(object):
 
     @lazycache
     def upstream_version(self):
-        return LooseVersion(cfme_data.get("bugzilla", {}).get("upstream_version", "9.9"))
+        if self.default_product is not None:
+            return self.default_product.latest_version
+        else:
+            return LooseVersion(cfme_data.get("bugzilla", {}).get("upstream_version", "9.9"))
 
     def get_bug(self, id):
         id = int(id)

--- a/utils/bz.py
+++ b/utils/bz.py
@@ -5,7 +5,8 @@ from collections import Sequence
 
 from utils import lazycache
 from utils.conf import cfme_data, credentials
-from utils.version import LATEST, LooseVersion, current_version, appliance_build_datetime
+from utils.version import (
+    LATEST, LooseVersion, current_version, appliance_build_datetime, appliance_is_downstream)
 
 NONE_FIELDS = {"---", "undefined", "unspecified"}
 
@@ -277,7 +278,7 @@ class BugWrapper(object):
 
     @property
     def is_opened(self):
-        if self.is_upstream_bug:
+        if self.is_upstream_bug and not appliance_is_downstream():
             states = self._bugzilla.open_states
         else:
             states = self._bugzilla.open_states + ["POST"]


### PR DESCRIPTION
* If we don't have upstream appliance, do not evaluate the upstream part of the `is_opened` (@jkrocil found this)
* Scavenge the "upstream version" from the bugzilla itself. Needs `product:` in yaml. Compatible with the older `upstream_version:` value in yaml.