### PR TITLE
SSH connection reuse and pubkey auth support

### DIFF
--- a/fixtures/ssh_client.py
+++ b/fixtures/ssh_client.py
@@ -1,32 +1,28 @@
 import pytest
 
-from utils.ssh import SSHClient
+from fixtures.pytest_store import store
 
 
 @pytest.fixture(scope="function")
 def ssh_client(uses_ssh):
     """SSH Client Fixture
 
-    By default, it will connect to the host named in the mozwebqa baseurl on use,
-    using the 'ssh' credentials in your credentials file. The mozwebqa fixture is used
-    for this, which will open up a selenium browser by default. If this is undesired,
-    remember to use the skip_selenium mark.
-
     Usage:
 
-        @pytest.mark.skip_selenium
         def test_ssh(ssh_client):
             # Run a basic command
-            exit_status, output = ssh_client.run_command('ls -al')
-            # Exit status is the numeric return code from the called command,
+            result = ssh_client.run_command('ls -al')
+            # rc is the numeric return code from the called command,
             # so 0 means everything is OK.
-            assert exit_status == 0
+            assert result.rc == 0
+            # and the output is available, too
+            print result.output
 
             # Run a task using the CFME rails runner CLI
-            exit_status, output = ssh_client.run_rails_command('do stuff')
+            ssh_client.run_rails_command('do stuff')
 
             # More useful: Run a rake task using the correct invokation
-            exit_status, output = ssh_client.run_rake_command('evm:stop')
+            ssh_client.run_rake_command('evm:stop')
 
     Additionally, the ssh_client fixture can be used to create other ssh clients,
     if you need to connect to multiple hosts in a test run::
@@ -45,6 +41,5 @@ def ssh_client(uses_ssh):
             # Hint: **credentials['credentials_key'], e.g.
             ssh_client_4 = ssh_client(hostname='different.host', **credentials['ssh'])
 
-
     """
-    return SSHClient()
+    return store.current_appliance.ssh_client()

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -346,6 +346,8 @@ class IPAppliance(object):
         self.browser_steal = browser_steal
         # thing-toucher process, used for UI coverage
         self._thing_toucher_proc = None
+        # ssh client cache
+        self._ssh_client = None
 
     def __repr__(self):
         return '%s(%s)' % (type(self).__name__, repr(self.address))
@@ -434,13 +436,16 @@ class IPAppliance(object):
         """
         if not self.is_ssh_running:
             raise Exception('SSH is unavailable')
-        # IPAppliance.ssh_client only connects to its address
-        connect_kwargs['hostname'] = self.address
-        connect_kwargs['username'] = connect_kwargs.get(
-            'username', conf.credentials['ssh']['username'])
-        connect_kwargs['password'] = connect_kwargs.get(
-            'password', conf.credentials['ssh']['password'])
-        return SSHClient(**connect_kwargs)
+
+        if self._ssh_client is None:
+            # IPAppliance.ssh_client only connects to its address
+            connect_kwargs['hostname'] = self.address
+            connect_kwargs['username'] = connect_kwargs.get(
+                'username', conf.credentials['ssh']['username'])
+            connect_kwargs['password'] = connect_kwargs.get(
+                'password', conf.credentials['ssh']['password'])
+            self._ssh_client = SSHClient(**connect_kwargs)
+        return self._ssh_client
 
     def db_ssh_client(self, **connect_kwargs):
         if self.is_db_internal:


### PR DESCRIPTION
This does two major things:

- Pubkeys are supported
- Connection transports are reused

Those things provide two major benefits:

- SSH connections are made more quickly ones keys are installed
- Appliances using the same keys (parallel test run, for example) can easily SCP files *to each other*, which I need for speeding up UI Coverage reporting.

Additionally, the ssh_client gets its client from the pytest store now, and the IPAppliance class caches its ssh client in an attempt to support reusing the client.

Public key workflow, seen in `SSHClient.connect`, and `SSHClient.install_ssh_keys`:

1. When connecting, check to see if keys are installed (or currently being installed). If not, install them.
- Mark the keystate as installing so we don't try to install keys while we're installing keys (yo dawg)
- If we don't already have an SSH key to use, make one.
- If there is already an authorized_keys file on the server, this work has already been done
- If authorized_keys doesn't exist, then make the entire .ssh dir  (appliances don't even have a .ssh directory by default), complete with private key, public key, and authorized_keys
- after setting up authorized_keys (or detecting that it has already been set up), set the internal keystate to 'installed', preventing further checks/installations.

I ran a complete test run last night, including long-running, and the SSH connection kept working, so I don't think we need special code to handle transports dying on us.