### PR TITLE
wait_for dumps last result

### DIFF
--- a/utils/tests/test_wait.py
+++ b/utils/tests/test_wait.py
@@ -51,3 +51,11 @@ def test_partial():
     with pytest.raises(TimedOutError):
         wait_for(func,
                  num_sec=2, delay=1)
+
+
+def test_callable_fail_condition():
+    incman = Incrementor()
+    with pytest.raises(TimedOutError):
+        wait_for(
+            incman.i_sleep_a_lot,
+            fail_condition=lambda value: value <= 10, num_sec=2, delay=1)

--- a/utils/wait.py
+++ b/utils/wait.py
@@ -97,18 +97,20 @@ def wait_for(func, func_args=[], func_kwargs={}, **kwargs):
         else:
             duration = time.time() - st_time
             if not quiet:
-                logger.trace('Took %f to do %s' % (duration, message))
+                logger.trace('Took {:0.2f} to do {}'.format(duration, message))
             logger.trace('Finished {} at {}'.format(message, st_time + t_delta))
             return WaitForResult(out, duration)
         t_delta = time.time() - st_time
     logger.trace('Finished at {}'.format(st_time + t_delta))
     if not silent_fail:
-        logger.error('Could not complete {} at {}:{} in time, took {}'.format(message,
+        logger.error('Could not complete {} at {}:{} in time, took {:0.2f}'.format(message,
             filename, line_no, t_delta))
+        logger.error('The last result of the call was: {}'.format(str(out)))
         raise TimedOutError("Could not do {} at {}:{} in time".format(message, filename, line_no))
     else:
         logger.warning("Could not do {} at {}:{} in time but ignoring".format(message,
             filename, line_no))
+        logger.warning('The last result of the call was: {}'.format(str(out)))
 
 
 class TimedOutError(Exception):


### PR DESCRIPTION
Result should be like:
```
2015-03-18 11:35:01,694 [E] Could not complete function i_sleep_a_lot() at /home/mfalesni/git/cfme_tests/utils/tests/test_wait.py:17 in time, took 2.21 (utils/wait.py:107)
2015-03-18 11:35:01,702 [E] The last result of the call was: 2 (utils/wait.py:108)
```
{{pytest: utils/tests/test_wait.py -v}}