### PR TITLE
Jenkins fixes

### DIFF
--- a/cfme/js.py
+++ b/cfme/js.py
@@ -14,3 +14,25 @@ return {
     document: document.readyState
 };
 """
+
+update_retirement_date_function_script = """\
+function updateDate(newValue) {
+    if(typeof $j == "undefined") {
+        var jq = $;
+    } else {
+        var jq = $j;
+    }
+    jq("#miq_date_1")[0].value = newValue;
+    miqSparkleOn();
+    jq.ajax({
+        type: 'POST',
+        url: '/vm_infra/retire_date_changed?miq_date_1='+newValue
+    }).done(
+        function(data){
+            eval(data);
+        }
+    )
+}
+
+"""
+# TODO: Get the url: directly from the attribute in the page?

--- a/cfme/tests/cloud/test_tag_cloud.py
+++ b/cfme/tests/cloud/test_tag_cloud.py
@@ -42,6 +42,6 @@ def test_tag_provider(setup_first_cloud_provider, tag):
 def test_tag_vm(setup_first_cloud_provider, tag):
     """Add a tag to a vm
     """
-    pytest.sel.force_navigate('clouds_instances')
+    pytest.sel.force_navigate('clouds_instances_by_provider')
     Quadicon.select_first_quad()
     mixins.add_tag(tag)

--- a/cfme/web_ui/search.py
+++ b/cfme/web_ui/search.py
@@ -18,7 +18,9 @@ search_box = Region(
         # The icon buttons for searching
         search_icon={
             "5.3": "//div[@id='searchbox']//*[@id='searchicon']",
-            "5.4": "//div[@id='searchbox']//div[contains(@class, 'form-group')]/a"},
+            "5.4":
+            "//div[@id='searchbox']//div[contains(@class, 'form-group')]"
+            "/*[self::a or (self::button and @type='submit')]"},
 
         # The arrow opening/closing the advanced search box
         toggle_advanced={


### PR DESCRIPTION
* Retirement date set using JS
* Fix search button locator
* test_tag_cloud used the toplevel locator which did not reset the view to the quadicons

{{pytest: -v -k '(vm_retire_extend or tag_cloud or search)' --long-running}}