### PR TITLE
Remove old BZ

### DIFF
--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -159,7 +159,6 @@ def test_quadicon_terminate_cancel(setup_provider_funcscope, provider_type, prov
 
 
 @pytest.mark.long_running
-@pytest.mark.meta(blockers=[1122039])
 def test_quadicon_terminate(setup_provider_funcscope, provider_type, provider_mgmt,
                             test_instance, verify_vm_running, soft_assert):
     """ Tests terminate instance


### PR DESCRIPTION
This is an old BZ that's no longer relevant.

@mfalesni In any case, this shouldn't be skipping in 54z - not sure what's going on:
```
Skipped: Skipping due to these blockers:
- Bugzilla bug https://bugzilla.redhat.com/show_bug.cgi?id=1122039 (or one of its copies)
```

This BZ is closed in 530 and there are no clones.