### PR TITLE
[WIPTEST] Stable power state of a suspended RHOS instance is OFF

### DIFF
--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -304,7 +304,7 @@ def test_resume(openstack_only, setup_provider_funcscope,
         test_flag: power_control, provision
     """
     test_instance.wait_for_vm_state_change(
-        desired_state=test_instance.STATE_SUSPENDED, timeout=720, from_details=True)
+        desired_state=test_instance.STATE_OFF, timeout=720, from_details=True)
     check_power_options(soft_assert, test_instance, 'off')
     test_instance.power_control_from_cfme(
         option=test_instance.START, cancel=False, from_details=True)


### PR DESCRIPTION
Stable power state of a suspended RHOS instance is OFF (after power states refresh), not SUSPENDED

(It is hardcoded to change to `suspended` for a moment before a power state refresh occurs)

**dont merge yet, please**