### PR TITLE
Don't care about slaves once they let us know they've finished.

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -416,7 +416,6 @@ class ParallelSession(object):
                     elif event_name == 'sessionfinish':
                         self.ack(slaveid, event_name)
                         slave = self.slaves.pop(slaveid)
-                        slave.wait()
 
                 # wait for all slave collections to arrive, then diff collections and ack
                 if slave_collections is not None:


### PR DESCRIPTION
We really *should* care, since this can potentially kill a slave in the
middle of its teardown, but for now this should address more (maybe all?)
of our weird jenkins stalls. I'll put proper shutdown handling in later.