### PR TITLE
Parallelizer doesn't block on slave shutdown, has better logging

### DIFF
--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -114,14 +114,6 @@ class SlaveManager(object):
         self.log.error(msg)
         self.message(msg)
 
-    def pytest_sessionfinish(self, exitstatus):
-        """pytest session finish hook
-
-        - reports exit status to master
-
-        """
-        self.send_event('sessionfinish', exit=exitstatus)
-
     def pytest_runtestloop(self, session):
         """pytest runtest loop
 
@@ -139,6 +131,7 @@ class SlaveManager(object):
                 self.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
 
         self.message('no more tests, shutting down')
+        self.send_event('shutdown')
         return True
 
     def _test_generator(self):

--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -18,8 +18,7 @@ from urlparse import urlparse
 from _pytest.terminal import TerminalReporter
 from py.io import TerminalWriter
 
-from utils import property_or_none
-from utils import conf
+from utils import conf, diaper, property_or_none
 from utils.randomness import generate_random_string
 
 
@@ -159,8 +158,7 @@ def write_line(line, **kwargs):
         store.slave_manager.message(line)
     else:
         # If py.test is supressing stdout/err, turn that off for a moment
-        if store.capturemanager:
-            store.capturemanager.suspendcapture()
+        diaper(store.capturemanager.suspendcapture)
 
         # terminal reporter knows whether or not to write a newline based on currentfspath
         # so stash it, then use rewrite to blow away the line that printed the current
@@ -174,5 +172,4 @@ def write_line(line, **kwargs):
         store.terminalreporter.write_ensure_prefix(cfp)
 
         # resume capturing
-        if store.capturemanager:
-            store.capturemanager.resumecapture()
+        diaper(store.capturemanager.resumecapture)


### PR DESCRIPTION
The master will wait a polite amount of time for a slave to shut down,
set at 10 minutes for now. If more time than that goes by, the slave is
killed. Additionally, py.test will log not only that a slave is shutting down,
but that it has, in fact, shut down (or died).

I also got to remove some vestigial event ordering functionality that became
useless when we got everything parallel happening in master's runtestloop.