### PR TITLE
Adding strange detection for already logged in

### DIFF
--- a/cfme/fixtures/login.py
+++ b/cfme/fixtures/login.py
@@ -3,6 +3,12 @@ from utils.browser import ensure_browser_open, quit
 from cfme.login import login_admin
 
 
+def recycle():
+    quit()
+    ensure_browser_open()
+    login_admin()
+
+
 @pytest.yield_fixture(scope='function')
 def logged_in(browser):
     """
@@ -17,10 +23,14 @@ def logged_in(browser):
     try:
         login_admin()
     except pytest.sel.WebDriverException as e:
+        # If we find a web driver exception, we can recycle the browser as long
+        # as it is a jquery error as we know about those
         if "jquery" not in str(e).lower():
-            raise  # Something we don't know yet
-        quit()
-        ensure_browser_open()
-        # And try again
-        login_admin()
+            raise
+        recycle()
+    except pytest.sel.NoSuchElementException as e:
+        # We have also seen instances where the page gets stuck on something other
+        # than the login page, and gobbles tests, this is an attempt to fix that
+        recycle()
+
     yield browser()


### PR DESCRIPTION
Have seen that for some reason there was an issue where the browser was already logged in, but the logged_in fixture didn't detect it and raise a NoSuchElementException. This PR takes care of cases where jquery is present on the page, but where the login boxes are absent for some reason. In this case, we just recycle the browser.

{{pytest: -k test_login}}