### PR TITLE
Protect against other exception types

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -85,7 +85,8 @@ def appliance_police():
         if status_code != 200:
             raise Exception('Status code was {}, should be 200'.format(status_code), port)
     except Exception as e:
-        port = e.args[1]
+
+        port = e.args[1] if len(e.args) == 2 else None
         if port == 443:
             # if the web ui worker merely crashed, give it 15 minutes
             # to come back up


### PR DESCRIPTION
If the exception is not one that we explicitly generate then the second
argument may be missing. This caused issues in some runs and so to
mitigate we now check the length of the Exception arg to be 2 before
trying to access the port. If it's not present we just set port to None,
which doesn't harm anything.