### PR TITLE
Quit the browser on the rails exception to forget the session

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -909,6 +909,8 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
         logger.debug('Managed Providers:')
         logger.debug(store.current_appliance.managed_providers)
         kwargs.pop("start", None)
+        quit()  # Refresh the session, forget loaded summaries, ...
+        kwargs.pop("start", None)
         ensure_browser_open()
         menu.nav.go_to("dashboard")
         # If there is a rails error past this point, something is really awful


### PR DESCRIPTION
{{pytest: -v -k "delete_infra_object or group_roles" --long-running }}