### PR TITLE
Set timeout of the provisioned appliance and ensure we have browser_steal

### DIFF
--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -62,7 +62,8 @@ def compliance_vm(request, provider_key, provider_crud):
         appliance.configure(setup_fleece=True)
         vm = Vm(appliance.vm_name, provider_crud)
     # Do the final touches
-    with appliance.ipapp:
+    with appliance.ipapp(browser_steal=True) as appl:
+        appl.set_session_timeout(86400)
         provider_crud.refresh_provider_relationships()
         vm.wait_to_appear()
         vm.load_details()

--- a/conftest.py
+++ b/conftest.py
@@ -39,16 +39,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session", autouse=True)
 def set_session_timeout():
-    try:
-        vmdb_config = store.current_appliance.get_yaml_config("vmdb")
-        if vmdb_config["session"]["timeout"] < 86400:
-            vmdb_config["session"]["timeout"] = 86400
-            store.current_appliance.set_yaml_config("vmdb", vmdb_config)
-    except Exception as ex:
-        # Definitely need to implement retries or something, this is
-        # just a bandaid
-        logger.error('Setting session timout failed')
-        logger.exception(ex)
+    store.current_appliance.set_session_timeout(86400)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -358,6 +358,17 @@ class IPAppliance(object):
     def pop(self):
         _pop_appliance(self)
 
+    def __call__(self, **kwargs):
+        """Syntactic sugar for overriding certain instance variables for context managers.
+
+        Currently possible variables are:
+
+        * `browser_steal`
+        """
+        if "browser_steal" in kwargs:
+            self.browser_steal = kwargs["browser_steal"]
+        return self
+
     def __enter__(self):
         """ This method will replace the current appliance in the store """
         self.push()
@@ -1363,6 +1374,24 @@ class IPAppliance(object):
 
     def set_yaml_config(self, config_name, data_dict):
         return db.set_yaml_config(config_name, data_dict, self.address)
+
+    def set_session_timeout(self, timeout=86400, quiet=True):
+        """Sets the timeout of UI timeout.
+
+        Args:
+            timeout: Timeout in seconds
+            quiet: Whether to ignore any errors
+        """
+        try:
+            vmdb_config = self.get_yaml_config("vmdb")
+            if vmdb_config["session"]["timeout"] != timeout:
+                vmdb_config["session"]["timeout"] = timeout
+                self.set_yaml_config("vmdb", vmdb_config)
+        except Exception as ex:
+            logger.error('Setting session timeout failed:')
+            logger.exception(ex)
+            if not quiet:
+                raise
 
 
 class ApplianceSet(object):


### PR DESCRIPTION
{{pytest: cfme/tests/control/test_compliance.py -v --long-running --use-provider vsphere55 --use-provider rhevm33 }}