### PR TITLE
Ignore jQuery errors

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -269,7 +269,14 @@ def wait_for_ajax():
         """
         prev_log_msg = _thread_local.ajax_log_msg
 
-        running = in_flight()
+        try:
+            running = in_flight()
+        except Exception as e:
+            # if jQuery in error message, a non-cfme page (proxy error) is displayed
+            # should be handled by something else
+            if "jquery" not in str(e).lower():
+                raise
+            return True
         anything_in_flight = False
         anything_in_flight |= running["jquery"] > 0
         anything_in_flight |= running["prototype"] > 0


### PR DESCRIPTION
I will try to recreate the conditions by using this very ugly meta data:

{{pytest: -v -k 'test_vm_control_policy_crud or test_delete_cluster or test_edit_storage_chargeback or test_add_delete_service_catalog or test_list_page_per_item or test_compressed_view or test_add_new_compute_chargeback or test_checkbox_dialog_element or test_service_dialog_duplicate_name or test_delete_compute_chargeback or test_set_retirement_date or test_provision_approval or test_rh_creds_validation or test_vm_compliance_policy_crud or test_assign_events_to_host_control_policy or test_collect_log_depot or test_radiobutton_dialog_element or test_tile_defaultview or test_delete_host or test_provider_refresh or test_vm_condition_crud or test_reorder_elements or test_expanded_view or test_list_defaultview or test_textareabox_dialog_element or test_create_service_dialog or test_add_delete_multiple_service_catalogs or test_delete_template or test_tile_page_per_item or test_action_crud or test_group_roles or test_datecontrol_dialog_element or test_assign_events_to_vm_control_policy or test_provision_from_template or test_add_new_storage_chargeback or test_delete_resource_pool or test_delete_storage_chargeback or test_edit_compute_chargeback or test_assign_vm_condition_to_vm_policy or test_grid_page_per_item or test_provider_edit or test_running_vm or test_unset_retirement_date or test_delete_service_dialog or test_rh_registration or test_openldap_auth or test_host_compliance_policy_crud or test_dropdownlist_dialog_element or test_rhev_iso_servicecatalog or test_policy_profile_crud or test_alert_crud or test_services_request_direct_url or test_provisioning_dialogs_sorting or test_update_service_dialog or test_delete_datastore or test_host_control_policy_crud or test_copy_request or test_retirement_now or test_grid_defaultview or test_tagcontrol_dialog_element or test_delete_vm or test_assign_host_condition_to_host_policy or test_compute_chargeback_duplicate_disallowed or test_host_condition_crud' --long-running --use-provider vsphere55 --use-provider rhevm33 --use-provider rhos4 }}