### PR TITLE
[Bugzilla] List blockers on startup

### DIFF
--- a/fixtures/blockers.py
+++ b/fixtures/blockers.py
@@ -10,7 +10,8 @@ instances
 """
 import pytest
 
-from utils.blockers import Blocker
+from fixtures.pytest_store import store
+from utils.blockers import Blocker, BZ, GH
 
 
 @pytest.fixture(scope="function")
@@ -49,3 +50,50 @@ def bug(blocker):
         Instance of :py:class:`utils.bz.BugWrapper` or :py:class:`NoneType` if the bug is closed.
     """
     return lambda bug_id: blocker("BZ#{}".format(bug_id)).bugzilla_bug
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup('Blockers options')
+    group.addoption('--list-blockers',
+                    action='store_true',
+                    default=False,
+                    dest='list_blockers',
+                    help='Specify to list the blockers (takes some time though).')
+
+
+@pytest.mark.trylast
+def pytest_collection_modifyitems(session, config, items):
+    if not config.getvalue("list_blockers"):
+        return
+    store.terminalreporter.write("Loading blockers ...\n", bold=True)
+    blocking = set([])
+    for item in items:
+        if "blockers" not in item._metadata:
+            continue
+        for blocker in item._metadata["blockers"]:
+            if isinstance(blocker, int):
+                # TODO: DRY
+                blocker_object = Blocker.parse("BZ#{}".format(blocker))
+            else:
+                blocker_object = Blocker.parse(blocker)
+            if blocker_object.blocks:
+                blocking.add(blocker_object)
+    if blocking:
+        store.terminalreporter.write("Known blockers:\n", bold=True)
+        for blocker in blocking:
+            if isinstance(blocker, BZ):
+                bug = blocker.bugzilla_bug
+                store.terminalreporter.write("- #{} - {}\n".format(bug.id, bug.status))
+                store.terminalreporter.write("  {}\n".format(bug.summary))
+                store.terminalreporter.write(
+                    "  {} -> {}\n".format(str(bug.version), str(bug.target_release)))
+                store.terminalreporter.write(
+                    "  https://bugzilla.redhat.com/show_bug.cgi?id={}\n\n".format(bug.id))
+            elif isinstance(blocker, GH):
+                bug = blocker.data
+                store.terminalreporter.write("- {}\n".format(str(bug)))
+                store.terminalreporter.write("  {}\n".format(bug.title))
+            else:
+                store.terminalreporter.write("- {}\n".format(str(blocker.data)))
+    else:
+        store.terminalreporter.write("No blockers detected!\n", bold=True)

--- a/utils/blockers.py
+++ b/utils/blockers.py
@@ -140,7 +140,7 @@ class BZ(Blocker):
     def bugzilla_bug(self):
         if self.data is None:
             return None
-        return self.data[0]
+        return self.data
 
     @property
     def blocks(self):


### PR DESCRIPTION
I don't know how much will it like the fixture args (parametrized works), but it seems we don't use the ddynamic ones yet so it does not make troubles.

{{pytest: -v --long-running --list-blockers --collect-only }}