### PR TITLE
[WIP][NO TEST] Sprout - Care about template age.

### DIFF
--- a/sprout/appliances/migrations/0019_auto_20150430_1546.py
+++ b/sprout/appliances/migrations/0019_auto_20150430_1546.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('appliances', '0018_mismatchversionmailer'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='group',
+            name='template_obsolete_days',
+            field=models.IntegerField(
+                help_text=b"Templates older than X days won't be loaded into sprout",
+                null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='group',
+            name='template_obsolete_days_delete',
+            field=models.BooleanField(
+                default=False,
+                help_text=b'If template_obsolete_days set, this will enable deletion of obsolete '
+                'templates using that metric. WARNING! Use with care. Best use for upstream '
+                'templates.'),
+        ),
+    ]

--- a/sprout/sprout/settings.py
+++ b/sprout/sprout/settings.py
@@ -212,6 +212,11 @@ CELERYBEAT_SCHEDULE = {
         'task': 'appliances.tasks.mailer_version_mismatch',
         'schedule': timedelta(minutes=60),
     },
+
+    'obsolete-template-deleter': {
+        'task': 'appliances.tasks.obsolete_template_deleter',
+        'schedule': timedelta(days=1),
+    },
 }
 
 try:


### PR DESCRIPTION
Groups can now be configured with an 'age' of template to be considered obsolete. If the template is older than that number of days, it won't be pulled from trackerbot. If the option for deleting is on, it will also delete such templates if they are not the latest (therefore the only) ones.

*This is the first (simpler) option of automatic deletion*