### PR TITLE
explicit update_urls handling outside of appliance configuration

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -90,14 +90,23 @@ def pytest_addoption(parser):
         '--sprout-desc', dest='sprout_desc', default=None, help="Set description of the pool.")
 
 
+def pytest_addhooks(pluginmanager):
+    import hooks
+    pluginmanager.addhooks(hooks)
+
+
 @pytest.mark.hookwrapper
 def pytest_configure(config):
+    # configures the parallel session, then fires pytest_parallel_configured
     yield
     if (config.option.appliances or (config.option.use_sprout and
             config.option.sprout_appliances > 1)):
         session = ParallelSession(config)
         config.pluginmanager.register(session, "parallel_session")
         store.parallelizer_role = 'master'
+        config.hook.pytest_parallel_configured(parallel_session=session)
+    else:
+        config.hook.pytest_parallel_configured(parallel_session=None)
 
 
 def dump_pool_info(printf, pool_data):

--- a/fixtures/parallelizer/hooks.py
+++ b/fixtures/parallelizer/hooks.py
@@ -1,0 +1,15 @@
+"""parallelizer hooks
+
+Custom hooks to help keep runtime ordering straight with regard to the parallelizer's state
+
+"""
+
+
+def pytest_parallel_configured(parallel_session):
+    """called after the parallel session is configured
+
+    This is *always* called, whether running parallel or not.
+
+    If running standalone, ``parallel_session`` will be None.
+
+    """

--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -144,6 +144,8 @@ class Store(object):
             # address is
             return self.current_appliance.ssh_client().client_address()
 
+    def write_line(self, line, **kwargs):
+        return write_line(line, **kwargs)
 
 store = Store()
 

--- a/fixtures/update_appliance.py
+++ b/fixtures/update_appliance.py
@@ -1,0 +1,15 @@
+"""Appliance update plugin
+
+If update_urls is set in the env, re-trigger the update_rhel configuration
+step to update the appliance with the new URLs
+
+"""
+import os
+
+import pytest
+
+
+def pytest_parallel_configured():
+    if pytest.store.parallelizer_role != 'master' and 'update_urls' in os.environ:
+        pytest.store.write_line('updating appliance before testing')
+        pytest.store.current_appliance.update_rhel(*str(os.environ['update_urls']).split())


### PR DESCRIPTION
This allows us to bring in additional update urls on an already configured appliance for testing.

This commit includes the beginnings of a parallelizer hooks system, which I'll likely be expanding over
time to keep myself sane.