### PR TITLE
Force checking of ports in appliance policer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -74,7 +74,7 @@ def appliance_police():
         return
     try:
         ports = {'ssh': 22, 'https': 443, 'postgres': 5432}
-        port_results = {pn: net_check(pp) for pn, pp in ports.items()}
+        port_results = {pn: net_check(pp, force=True) for pn, pp in ports.items()}
         for port, result in port_results.items():
             if not result:
                 raise _AppliancePoliceException('Port {} was not contactable'.format(port), port)


### PR DESCRIPTION
Funny thing, if you don't erase the evidence, the Appliance Police
will keep on arresting you. :( This fix forces the Appliance Police to
make a new check of the port availability everytime. We hadn't seen this
issue crop up before because most failures had been happening due to the
UI worker dying. This meant that 443 was still contactable and hence the
cache that the utils.net keeps, did not affect the Police.

If a port is uncontactable, because of network issues for example, then
the fact the port is unreachable was cached in the utils.net module and
because the force flag was absent was never rechecked and the cached
result just served up again and again. Thus continuing slaves just led
to them getting pulled over by the Appliance Police again for crimes
they hadn't committed.