### PR TITLE
Fix Merkyl

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ import cfme.fixtures
 import fixtures
 import markers
 import metaplugins
+from fixtures.artifactor_plugin import art_client, appliance_ip_address
 from cfme.fixtures.rdb import Rdb
 from fixtures.pytest_store import store
 from utils.log import logger
@@ -60,12 +61,13 @@ def set_default_domain():
 def fix_merkyl_workaround():
     """Workaround around merkyl not opening an iptables port for communication"""
     ssh_client = SSHClient()
-    if ssh_client.run_command('test -f /etc/init.d/merkyl').rc == 0:
+    if ssh_client.run_command('test -s /etc/init.d/merkyl').rc != 0:
         logger.info('Rudely overwriting merkyl init.d on appliance;')
         local_file = data_path.join("bundles").join("merkyl").join("merkyl")
         remote_file = "/etc/init.d/merkyl"
         ssh_client.put_file(local_file.strpath, remote_file)
         ssh_client.run_command("service merkyl restart")
+        art_client.fire_hook('setup_merkyl', ip=appliance_ip_address)
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -31,6 +31,14 @@ from utils.path import project_path
 from utils.wait import wait_for
 
 
+# Create a list of all our passwords for use with the sanitize request later in this module
+words = []
+for cred in credentials:
+    word = credentials[cred].get('password', None)
+    if word:
+        words.append(word)
+
+
 def get_test_idents(item):
 
     if getattr(item, 'location', None):
@@ -103,11 +111,6 @@ def pytest_runtest_protocol(item):
 
 def pytest_runtest_teardown(item, nextitem):
     name, location = get_test_idents(item)
-    words = []
-    for cred in credentials:
-        word = credentials[cred].get('password', None)
-        if word:
-            words.append(word)
     art_client.fire_hook('finish_test', test_location=location, test_name=name,
                          slaveid=SLAVEID, ip=appliance_ip_address)
     art_client.fire_hook('sanitize', test_location=location, test_name=name,


### PR DESCRIPTION
Merkyl was not collecting logs and was returning Error 500 every
time. The following changes were made to get it working again:

* Merkyl was testing to see if the file existed. If it did, it would
  replace the file and restart Merkyl. At the risk of missing something,
  the setup now checks to see if the file is non-zero, and in that case,
  replaces it with the _good_ version.
* The Merkyl workaround fix was taking place as a fixture. The setting
  up of Merkyl was done as part of a pytest configure plugin. Hence the
  files started tailing during configure and then the fixer came and
  ironically broke everything by restarting Merkyl and ruining the
  accessibility of the logs. We now reset up merkyl after restarting it.