### PR TITLE
Timelines fix

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -85,6 +85,7 @@ def count_events(instance_name, nav_step):
             events.append(event)
             if len(events) > 0:
                 return len(events)
+    return 0
 
 
 def test_provider_event(setup_provider, provider_crud, gen_events, test_instance):

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -74,9 +74,12 @@ def count_events(vm_name, nav_step):
         return 0
     events = []
     for event in prov_timeline.events():
-        if event.text == vm_name:
+        data = event.block_info()
+        if vm_name in data.values():
             events.append(event)
-    return len(events)
+            if len(events) > 0:
+                return len(events)
+    return 0
 
 
 def test_provider_event(provider_crud, gen_events, test_vm):


### PR DESCRIPTION
* Timelines tests continue to be problematic
* Recent change to cloud timelines test meant that if there were no
  events, False was returned instead of 0. As a result, the wait_for
  fail condition did not match as Falde != 0 and hence it believed an
  event had been detected.
* Update infra timelines tests to follow same methodology, potentially
  hardening them slightly