### PR TITLE
Fix utilization tests

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -1820,22 +1820,24 @@ def _server_roles_cm(enable, *roles):
         enable: Whether to enable the roles.
         *roles: Role ids to set
     """
-    original_roles = get_server_roles()
-    set_roles = dict(original_roles)
-    for role in roles:
-        if role not in set_roles:
-            raise NameError("No such role {}".format(role))
-        set_roles[role] = enable
-    set_server_roles(**set_roles)
-    yield
-    set_server_roles(**original_roles)
+    try:
+        original_roles = get_server_roles()
+        set_roles = dict(original_roles)
+        for role in roles:
+            if role not in set_roles:
+                raise NameError("No such role {}".format(role))
+            set_roles[role] = enable
+        set_server_roles(**set_roles)
+        yield
+    finally:
+        set_server_roles(**original_roles)
 
 
-def with_server_roles(*roles):
+def server_roles_enabled(*roles):
     return _server_roles_cm(True, *roles)
 
 
-def without_server_roles(*roles):
+def server_roles_disabled(*roles):
     return _server_roles_cm(False, *roles)
 
 

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from cfme.configure.configuration import without_server_roles
+from cfme.configure.configuration import server_roles_disabled
 
 from utils import error, mgmt_system, testgen
 from utils.providers import setup_a_provider as _setup_a_provider, provider_factory
@@ -130,7 +130,7 @@ def test_provider_refresh(request, setup_a_provider, rest_api):
         pytest.skip("Refresh action is not implemented in this version")
     provider_mgmt = provider_factory(setup_a_provider.key)
     provider = rest_api.collections.providers.find_by(name=setup_a_provider.name)[0]
-    with without_server_roles("ems_inventory", "ems_operations"):
+    with server_roles_disabled("ems_inventory", "ems_operations"):
         vm_name = deploy_template(
             setup_a_provider.key,
             "test_rest_prov_refresh_{}".format(generate_random_string(size=4)))

--- a/cfme/tests/test_utilization.py
+++ b/cfme/tests/test_utilization.py
@@ -1,15 +1,11 @@
 import pytest
+import time
 from utils import db
 from utils import providers
 from utils import testgen
 from utils import conf
-import time
-from cfme.configure.configuration import candu
-
-pytestmark = [
-    pytest.mark.meta(
-        server_roles="+ems_metrics_coordinator +ems_metrics_collector +ems_metrics_processor")
-]
+from utils.log import logger
+from cfme.configure.configuration import server_roles_enabled, candu
 
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, None)
 
@@ -17,18 +13,24 @@ pytest_generate_tests = testgen.generate(testgen.provider_by_type, None)
 @pytest.yield_fixture(scope="module")
 def enable_candu():
     try:
-        candu.enable_all()
-        yield
+        with server_roles_enabled(
+                'ems_metrics_coordinator', 'ems_metrics_collector', 'ems_metrics_processor'):
+            candu.enable_all()
+            yield
     finally:
         candu.disable_all()
 
 
 # blow away all providers when done - collecting metrics for all of them is
 # too much
-@pytest.fixture
+@pytest.yield_fixture
 def handle_provider(provider_key):
-    providers.clear_providers()
-    providers.setup_provider(provider_key)
+    try:
+        providers.clear_providers()
+        providers.setup_provider(provider_key)
+        yield
+    finally:
+        providers.clear_providers()
 
 
 def test_metrics_collection(handle_provider, provider_key, provider_crud, enable_candu):
@@ -40,18 +42,19 @@ def test_metrics_collection(handle_provider, provider_key, provider_crud, enable
     metrics_tbl = db.cfmedb()['metrics']
     mgmt_systems_tbl = db.cfmedb()['ext_management_systems']
 
-    # the id for the provider we're testing
+    logger.info("Fetching provider ID for {}".format(provider_key))
     mgmt_system_id = db.cfmedb().session.query(mgmt_systems_tbl).filter(
         mgmt_systems_tbl.name == conf.cfme_data.get('management_systems', {})[provider_key]['name']
     ).first().id
 
+    logger.info("ID fetched; testing metrics collection now")
     start_time = time.time()
     metric_count = 0
     timeout = 900.0  # 15 min
     while time.time() < start_time + timeout:
         last_metric_count = metric_count
-        print "name: %s, id: %s, metrics: %s" % (provider_key,
-                                                mgmt_system_id, metric_count)
+        logger.info("name: {}, id: {}, metrics: {}".format(
+            provider_key, mgmt_system_id, metric_count))
         # count all the metrics for the provider we're testing
         metric_count = db.cfmedb().session.query(metrics_tbl).filter(
             metrics_tbl.parent_ems_id == mgmt_system_id


### PR DESCRIPTION
Always unset roles when using the CM
Test no longer prints to stdout and always clears providers and C&U roles

{{pytest: -v -k test_utilization}}