### PR TITLE
[WIP][NO TEST] Tweak ESX direct host test parametrizing

### DIFF
--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -9,6 +9,7 @@ import random
 from cfme.infrastructure.provider import VMwareProvider, get_from_config, wait_for_provider_delete
 from utils.conf import cfme_data, credentials
 from utils.net import resolve_hostname
+from utils.version import LooseVersion
 from utils.wait import wait_for
 
 
@@ -21,6 +22,14 @@ def pytest_generate_tests(metafunc):
             continue
         hosts = provider.get("hosts", [])
         if not hosts:
+            continue
+
+        version = provider.get("version", None)
+        if version is None:
+            # No version, no test
+            continue
+        if LooseVersion(version) < "5.0":
+            # Ignore lesser than 5
             continue
 
         host = random.choice(hosts)

--- a/utils/version.py
+++ b/utils/version.py
@@ -154,7 +154,17 @@ class Version(object):
     seem to be the same for all version numbering classes.
     """
 
+    @classmethod
+    def _parse_vstring(cls, vstring):
+        if vstring is None:
+            return None
+        elif isinstance(vstring, (list, tuple)):
+            return ".".join(map(str, vstring))
+        else:
+            return str(vstring)
+
     def __init__(self, vstring=None):
+        vstring = self._parse_vstring(vstring)
         if vstring:
             self.parse(vstring)
 
@@ -416,6 +426,7 @@ class LooseVersion (Version):
 
     def __init__(self, vstring=None, latest=False, oldest=False):
         self.version = None
+        vstring = self._parse_vstring(vstring)
         if latest and oldest:
             raise ValueError('Cannot be both latest and oldest')
         if latest:


### PR DESCRIPTION
It now ignores vSphere providers with version lesser than 5 and also if the version is not stated in the YAML at all.