### PR TITLE
Trying to mitigate some weirdness from BZ

### DIFF
--- a/utils/blockers.py
+++ b/utils/blockers.py
@@ -157,6 +157,9 @@ class BZ(Blocker):
             if bug.upstream_bug:
                 if not version.appliance_is_downstream() and bug.can_test_on_upstream:
                     result = False
+            if result is False and version.appliance_is_downstream():
+                if bug.fixed_in is not None:
+                    return version.current_version() < bug.fixed_in
             return result
         except xmlrpclib.Fault as e:
             code = e.faultCode

--- a/utils/version.py
+++ b/utils/version.py
@@ -204,6 +204,9 @@ class Version(object):
                 return False
         return series.version == self.version[:len(series.version)]
 
+    def series(self, n=2):
+        return ".".join(str(self).strip().split(".")[:n])
+
 # Taken from stdlib, just change classes to new-style and clean up
 # Interface for version-number classes -- must be implemented
 # by the following classes (the concrete ones -- Version should


### PR DESCRIPTION
It seems that with new version in release flags, it falls apart. This tries to incorporate the version fields once again. It now also takes fixed_in into account when testing.

*This is probably going to take a long time*

{{pytest: -v --collect-only --list-blockers}}