### PR TITLE
Fixed Repository test

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2023,6 +2023,11 @@ class Quadicon(Pretty):
       * c. **no_host** - Number of hosts
       * d. **avail_space** - Available space
 
+    * **repository** - *from the infra/repositories page* - has no quads
+    * **cluster** - *from the infra/cluster page* - has no quads
+    * **resource_pool** - *from the infra/resource_pool page* - has no quads
+    * **stack** - *from the clouds/stacks page* - has no quads
+
     Returns: A :py:class:`Quadicon` object.
     """
 
@@ -2068,6 +2073,7 @@ class Quadicon(Pretty):
             "avail_space": ("d", 'img'),
         },
         "cluster": {},
+        "repository": {},
         "resource_pool": {},
         "template": {
             "os": ("a", 'img'),


### PR DESCRIPTION
* This test has changed from 5.3, 5.4 with the basic view now being
  Quads instead of list based. I took the approach of working with what
  is provided as the default, as opposed to changing the view to suit
  the automation. This meant introducing some version sensitive lines
  into the code base which are ugly, but unfortunately necessary.
* Added a new Quadicon dummy for repository
* Added docs for other undoc'd quads

{{pytest: -k cfme/tests/infrastructure/test_repositories.py}}