### PR TITLE
Flash messages exception; skip broken providers

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -1,4 +1,7 @@
+# -*- coding: utf-8 -*-
 """Provides custom exceptions for the ``cfme`` module. """
+import pytest
+from utils.log import logger
 
 
 class CFMEException(Exception):
@@ -8,6 +11,14 @@ class CFMEException(Exception):
 
     """
     pass
+
+
+class FlashMessageException(CFMEException):
+    """Raised by functions in :py:mod:`cfme.web_ui.flash`"""
+
+    def skip_and_log(self, message="Skipping due to flash message"):
+        logger.error("Flash message error: {}".format(str(self)))
+        pytest.skip("{}: {}".format(message, str(self)))
 
 
 class CFMEExceptionOccured(CFMEException):

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -13,6 +13,7 @@ Required YAML keys:
 import fauxfactory
 import pytest
 from cfme.control import explorer
+from cfme.exceptions import FlashMessageException
 from cfme.infrastructure.provider import RHEVMProvider
 from cfme.infrastructure.virtual_machines import Vm
 from datetime import datetime
@@ -109,7 +110,10 @@ def vm_name(provider_key):
 
 @pytest.fixture(scope="module")
 def vm(request, provider_mgmt, provider_crud, provider_key, provider_data, small_template, vm_name):
-    setup_provider(provider_key)
+    try:
+        setup_provider(provider_key)
+    except FlashMessageException as e:
+        e.skip_and_log("Provider failed to set up")
 
     if isinstance(provider_mgmt, mgmt_system.RHEVMSystem):
         kwargs = {"cluster": provider_data["default_cluster"]}

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -4,6 +4,7 @@ import pytest
 import re
 from datetime import datetime, timedelta
 
+from cfme.exceptions import FlashMessageException
 from cfme.infrastructure.virtual_machines import Vm, details_page
 from cfme.provisioning import provisioning_form
 from cfme.services import requests
@@ -85,7 +86,10 @@ def template_name(provisioning):
 @pytest.fixture(scope="function")
 def provisioner(request, provider_key, provider_mgmt, provider_crud):
     if not provider_crud.exists:
-        setup_provider(provider_key)
+        try:
+            setup_provider(provider_key)
+        except FlashMessageException as e:
+            e.skip_and_log("Provider failed to set up")
 
     def _provisioner(template, provisioning_data, delayed=None):
         pytest.sel.force_navigate('infrastructure_provision_vms', context={

--- a/cfme/tests/test_utilization.py
+++ b/cfme/tests/test_utilization.py
@@ -6,6 +6,7 @@ from utils import testgen
 from utils import conf
 from utils.log import logger
 from cfme.configure.configuration import server_roles_enabled, candu
+from cfme.exceptions import FlashMessageException
 
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, None)
 
@@ -28,6 +29,9 @@ def handle_provider(provider_key):
     try:
         providers.clear_providers()
         providers.setup_provider(provider_key)
+    except FlashMessageException as e:
+        e.skip_and_log("Provider failed to set up")
+    else:
         yield
     finally:
         providers.clear_providers()

--- a/cfme/web_ui/flash.py
+++ b/cfme/web_ui/flash.py
@@ -4,7 +4,7 @@
 :var area: A :py:class:`cfme.web_ui.Region` object representing the flash region.
 """
 from functools import wraps
-from cfme.exceptions import CFMEExceptionOccured
+from cfme.exceptions import CFMEExceptionOccured, FlashMessageException
 from cfme.web_ui import Region
 import cfme.fixtures.pytest_selenium as sel
 from utils.log import logger
@@ -144,7 +144,7 @@ def assert_no_errors(messages=None):
     all_messages = messages or get_messages()
     errors = [error.message for error in filter(is_error, all_messages)]
     if errors:
-        raise Exception(', '.join(errors))
+        raise FlashMessageException(', '.join(errors))
     else:
         return all_messages
 
@@ -155,14 +155,14 @@ def assert_message_match(m):
     logger.debug('Asserting flash message match for "{}"'.format(m))
     if not any([fm.message == m for fm in get_messages()]):
         logger.debug(' No match found in...{}'.format(get_messages()))
-        raise Exception("No matching flash message for '%s'" % m)
+        raise FlashMessageException("No matching flash message for '%s'" % m)
 
 
 @verify_rails_error
 def assert_message_contain(m):
     """ Asserts that a message contains a specific string """
     if not any([m in fm.message for fm in get_messages()]):
-        raise Exception("No flash message contains '%s'" % m)
+        raise FlashMessageException("No flash message contains '%s'" % m)
 
 
 @verify_rails_error
@@ -175,4 +175,5 @@ def assert_success_message(m):
             (fm.message == m and (fm.level in {"info", "success"}))
             for fm
             in messages]):
-        raise Exception("No matching info flash message for '%s', instead got %s" % (m, messages))
+        raise FlashMessageException(
+            "No matching info flash message for '{}', instead got {}".format(m, messages))


### PR DESCRIPTION
* flash module now raises its own type of exceptions
* some tests converted to skip on providers that fail to set up

{{pytest: cfme/tests/control/test_actions.py cfme/tests/infrastructure/test_provisioning_dialog.py cfme/tests/test_utilization.py -v --long-running --use-provider rhevm35 --use-provider vsphere55 }}