### PR TITLE
Extend corner-case with instance navigation

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -283,7 +283,8 @@ class Instance(Updateable, Pretty):
         Raises: InstanceNotFound
         """
         if not do_not_navigate:
-            self.provider_crud.load_all_provider_instances()
+            if not self.provider_crud.load_all_provider_instances():
+                raise InstanceNotFound("No instances for the provider!")
             toolbar.set_vms_grid_view()
         elif refresh:
             sel.refresh()

--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -242,14 +242,30 @@ class Provider(Updateable, Pretty):
         client.disconnect()
 
     def load_all_provider_instances(self):
-        """ Loads the list of instances that are running under the provider. """
+        """ Loads the list of instances that are running under the provider.
+
+        If it could click through the link in infoblock, returns ``True``. If it sees that the
+        number of instances is 0, it returns ``False``.
+        """
         sel.force_navigate('clouds_provider', context={'provider': self})
-        sel.click(details_page.infoblock.element("Relationships", "Instances"))
+        if details_page.infoblock.text("Relationships", "Instances") == "0":
+            return False
+        else:
+            sel.click(details_page.infoblock.element("Relationships", "Instances"))
+            return True
 
     def load_all_provider_images(self):
-        """ Loads the list of images that are available under the provider. """
+        """ Loads the list of images that are available under the provider.
+
+        If it could click through the link in infoblock, returns ``True``. If it sees that the
+        number of images is 0, it returns ``False``.
+        """
         sel.force_navigate('clouds_provider', context={'provider': self})
-        sel.click(details_page.infoblock.element("Relationships", "Images"))
+        if details_page.infoblock.text("Relationships", "Images") == "0":
+            return False
+        else:
+            sel.click(details_page.infoblock.element("Relationships", "Images"))
+            return True
 
     def refresh_provider_relationships(self):
         """Clicks on Refresh relationships button in provider"""


### PR DESCRIPTION
The cloud provider code that navigates to the instance list did not count with instance count being zero. Now the nav function returns False when the number is zero so the code in instance module can react appropriately.

{{pytest: cfme/tests/cloud/test_cloud_timelines.py -v -k provider_event --long-running --use-provider rhos4-ga}}