### PR TITLE
Test cloud expanded and compressed views

### DIFF
--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -4,7 +4,7 @@ import pytest
 import re
 from cfme.fixtures import pytest_selenium as sel
 import cfme.web_ui.toolbar as tb
-from cfme.web_ui import ButtonGroup, form_buttons
+from cfme.web_ui import ButtonGroup, form_buttons, Quadicon
 from utils.conf import cfme_data
 from utils.providers import setup_a_provider as _setup_a_provider
 from utils import version
@@ -21,10 +21,14 @@ def minimise_dict(item):
 try:
     gtl_params = cfme_data['defaultview_data']['gtl']['cloud']
     gtl_params = [minimise_dict(item) for item in gtl_params]
+    exp_comp_params = cfme_data['defaultview_data']['exp_comp']['cloud']
+    exp_comp_params = [minimise_dict(item) for item in exp_comp_params]
 except KeyError:
     gtl_params = []
+    exp_comp_params = []
 finally:
     gtl_parametrize = pytest.mark.parametrize('key', gtl_params, scope="module")
+    exp_comp_parametrize = pytest.mark.parametrize('key', exp_comp_params, scope="module")
 
 
 @pytest.fixture(scope="module")
@@ -82,6 +86,11 @@ def get_default_view(name):
     return default_view
 
 
+def select_second_quad():
+    checkbox = ("(.//input[@id='listcheckbox'])[2]")
+    sel.check(checkbox)
+
+
 @pytest.mark.parametrize('key', gtl_params, scope="module")
 def test_tile_defaultview(request, setup_a_provider, key):
     name = re.split(r"\/", key)
@@ -109,4 +118,30 @@ def test_grid_defaultview(request, setup_a_provider, key):
     set_grid_view(name[0])
     sel.force_navigate(name[1])
     assert tb.is_vms_grid_view(), "Grid Default view setting failed"
+    reset_default_view(name[0], default_view)
+
+
+@pytest.mark.parametrize('key', exp_comp_params, scope="module")
+def test_expanded_view(request, setup_a_provider, key):
+    name = re.split(r"\/", key)
+    default_view = get_default_view(name[0])
+    set_expanded_view(name[0])
+    sel.force_navigate(name[1])
+    Quadicon.select_first_quad()
+    select_second_quad()
+    tb.select(name[2], name[3])
+    assert tb.is_vms_expanded_view(), "Expanded view setting failed"
+    reset_default_view(name[0], default_view)
+
+
+@pytest.mark.parametrize('key', exp_comp_params, scope="module")
+def test_compressed_view(request, setup_a_provider, key):
+    name = re.split(r"\/", key)
+    default_view = get_default_view(name[0])
+    set_compressed_view(name[0])
+    sel.force_navigate(name[1])
+    Quadicon.select_first_quad()
+    select_second_quad()
+    tb.select(name[2], name[3])
+    assert tb.is_vms_compressed_view(), "Compressed view setting failed"
     reset_default_view(name[0], default_view)


### PR DESCRIPTION
{{pytest: -v -k 'test_expanded_view or test_compressed_view'}}