### PR TITLE
deploy_template() shortcut allows for autoskip

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -125,6 +125,7 @@ def vm(request, provider_mgmt, provider_crud, provider_key, provider_data, small
             provider_key,
             vm_name,
             template_name=small_template,
+            allow_skip="default",
             **kwargs
         )
     except TimedOutError:

--- a/utils/virtual_machines.py
+++ b/utils/virtual_machines.py
@@ -1,8 +1,10 @@
 """Helper functions related to the creation and destruction of virtual machines and instances
 """
+import pytest
 
 from cfme.cloud.provider import get_from_config as get_cloud_from_config
 from cfme.infrastructure.provider import get_from_config as get_infra_from_config
+from ovirtsdk.infrastructure.errors import RequestError as RHEVRequestError
 from utils import conf
 from utils.log import logger
 from utils.mgmt_system import RHEVMSystem, VMWareSystem, EC2System, OpenstackSystem, SCVMMSystem
@@ -11,6 +13,16 @@ from utils.providers import infra_provider_type_map
 
 def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **deploy_args):
 
+    allow_skip = deploy_args.pop("allow_skip", ())
+    if isinstance(allow_skip, dict):
+        skip_exceptions = allow_skip.keys()
+        callable_mapping = allow_skip
+    elif allow_skip.lower() == "default":
+        skip_exceptions = (RHEVRequestError, )
+        callable_mapping = {}
+    else:
+        skip_exceptions = allow_skip
+        callable_mapping = {}
     provider_type = conf.cfme_data.get('management_systems', {})[provider_key]['type']
     if provider_type in infra_provider_type_map:
         provider_crud = get_infra_from_config(provider_key)
@@ -44,30 +56,36 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
     logger.info("Getting ready to deploy VM/instance %s from template %s on provider %s" %
         (vm_name, template_name, data['name']))
     try:
-        logger.debug("Deploy args: " + str(deploy_args))
-        vm_name = mgmt.deploy_template(template_name, timeout=timeout, **deploy_args)
-        logger.info("Provisioned VM/instance %s" % vm_name)  # instance ID in case of EC2
-    except Exception as e:
-        logger.error('Could not provisioning VM/instance %s (%s)', vm_name, e)
         try:
-            logger.info("VM/Instance status: {}".format(mgmt.vm_status(vm_name)))
-        except Exception as f:
-            logger.error(
-                "Could not retrieve VM/Instance status: {}: {}".format(type(f).__name__, str(f)))
-        logger.info('Attempting cleanup on VM/instance %s', vm_name)
-        try:
-            if mgmt.does_vm_exist(vm_name):
-                # Stop the vm first
-                logger.warning('Destroying VM/instance %s', vm_name)
-                if mgmt.delete_vm(vm_name):
-                    logger.info('VM/instance %s destroyed', vm_name)
-                else:
-                    logger.error('Error destroying VM/instance %s', vm_name)
-        except Exception as f:
-            logger.error(
-                'Could not destroy VM/instance {} ({}: {})'.format(
-                    vm_name, type(f).__name__, str(f)))
-        finally:
-            raise e
-
+            logger.debug("Deploy args: " + str(deploy_args))
+            vm_name = mgmt.deploy_template(template_name, timeout=timeout, **deploy_args)
+            logger.info("Provisioned VM/instance %s" % vm_name)  # instance ID in case of EC2
+        except Exception as e:
+            logger.error('Could not provisioning VM/instance %s (%s)', vm_name, e)
+            try:
+                logger.info("VM/Instance status: {}".format(mgmt.vm_status(vm_name)))
+            except Exception as f:
+                logger.error(
+                    "Could not retrieve VM/Instance status: {}: {}".format(
+                        type(f).__name__, str(f)))
+            logger.info('Attempting cleanup on VM/instance %s', vm_name)
+            try:
+                if mgmt.does_vm_exist(vm_name):
+                    # Stop the vm first
+                    logger.warning('Destroying VM/instance %s', vm_name)
+                    if mgmt.delete_vm(vm_name):
+                        logger.info('VM/instance %s destroyed', vm_name)
+                    else:
+                        logger.error('Error destroying VM/instance %s', vm_name)
+            except Exception as f:
+                logger.error(
+                    'Could not destroy VM/instance {} ({}: {})'.format(
+                        vm_name, type(f).__name__, str(f)))
+            finally:
+                raise e
+    except skip_exceptions as e:
+        e_c = type(e)
+        if e_c in callable_mapping and not callable_mapping[e_c](e):
+            raise
+        pytest.skip("{}: {}".format(e_c.__name__, str(e)))
     return vm_name


### PR DESCRIPTION
{{pytest: cfme/tests/control/test_actions.py -v --long-running}}