### PR TITLE
Extend actions/events testing with cloud providers

### DIFF
--- a/utils/mgmt_system/ec2.py
+++ b/utils/mgmt_system/ec2.py
@@ -264,6 +264,7 @@ class EC2System(MgmtSystemAPIBase):
         # strip out kwargs that ec2 doesn't understand
         timeout = kwargs.pop('timeout', 900)
         vm_name = kwargs.pop('vm_name', None)
+        power_on = kwargs.pop('power_on', True)
 
         # Make sure we only provision one VM
         kwargs.update({'min_count': 1, 'max_count': 1})
@@ -283,6 +284,8 @@ class EC2System(MgmtSystemAPIBase):
 
         if vm_name:
             self.set_name(instances[0].id, vm_name)
+        if power_on:
+            self.start_vm(instances[0].id)
         return instances[0].id
 
     def set_name(self, instance_id, new_name):

--- a/utils/mgmt_system/openstack.py
+++ b/utils/mgmt_system/openstack.py
@@ -412,6 +412,7 @@ class OpenstackSystem(MgmtSystemAPIBase):
         Note: If assign_floating_ip kwarg is present, then :py:meth:`OpenstackSystem.create_vm` will
             attempt to register a floating IP address from the pool specified in the arg.
         """
+        power_on = kwargs.pop("power_on", True)
         nics = []
         timeout = kwargs.pop('timeout', 900)
         if 'flavour_name' not in kwargs:
@@ -435,6 +436,9 @@ class OpenstackSystem(MgmtSystemAPIBase):
         if kwargs.get('floating_ip_pool', None):
             ip = self.api.floating_ips.create(kwargs['floating_ip_pool'])
             instance.add_floating_ip(ip)
+
+        if power_on:
+            self.start_vm(kwargs['vm_name'])
 
         return kwargs['vm_name']
 

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -64,6 +64,14 @@ list_cloud_providers = partial(list_providers, cloud_provider_type_map.keys())
 list_all_providers = partial(list_providers, provider_type_map.keys())
 
 
+def is_cloud_provider(provider_key):
+    return provider_key in list_cloud_providers()
+
+
+def is_infra_provider(provider_key):
+    return provider_key in list_infra_providers()
+
+
 def provider_factory(provider_key, providers=None, credentials=None):
     """
     Provides a :py:mod:`utils.mgmt_system` object, based on the request.

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -93,7 +93,8 @@ from cfme.roles import group_data
 from utils import version
 from utils.conf import cfme_data
 from utils.log import logger
-from utils.providers import cloud_provider_type_map, infra_provider_type_map, provider_factory
+from utils.providers import (
+    cloud_provider_type_map, infra_provider_type_map, provider_factory, provider_type_map)
 
 
 def generate(gen_func, *args, **kwargs):
@@ -392,6 +393,14 @@ def infra_providers(metafunc, *fields, **options):
 
     """
     return provider_by_type(metafunc, infra_provider_type_map, *fields, **options)
+
+
+def all_providers(metafunc, *fields, **options):
+    """Wrapper for :py:func:`provider_by_type` that pulls types from
+    :py:attr:`utils.providers.provider_type_map`
+
+    """
+    return provider_by_type(metafunc, provider_type_map, *fields, **options)
 
 
 def auth_groups(metafunc, auth_mode):


### PR DESCRIPTION
{{pytest: cfme/tests/control/test_actions.py -v --long-running --use-provider complete}}