### PR TITLE
Adding sauce markers to a bunch of configuration tests.

### DIFF
--- a/cfme/tests/automate/test_buttons.py
+++ b/cfme/tests/automate/test_buttons.py
@@ -33,6 +33,7 @@ def dialog():
     yield service_dialog
 
 
+@pytest.mark.sauce
 def test_button_group_crud(request):
     buttongroup = ButtonGroup(
         text=fauxfactory.gen_alphanumeric(), hover="btn_hvr", type=ButtonGroup.SERVICE)

--- a/cfme/tests/configure/test_about_links.py
+++ b/cfme/tests/configure/test_about_links.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 
 
+@pytest.mark.sauce
 def test_about_links():
     sel.force_navigate('about')
     for link_key, link_loc in about.product_assistance.locators.items():

--- a/cfme/tests/configure/test_docs.py
+++ b/cfme/tests/configure/test_docs.py
@@ -31,6 +31,7 @@ def docs_info():
     ]
 
 
+@pytest.mark.sauce
 def test_links(guides, soft_assert):
     """Test whether the PDF documents are present."""
     pytest.sel.force_navigate("about")
@@ -70,6 +71,7 @@ def test_contents(guides, soft_assert):
             soft_assert(exp_str in pdf_title_low, "{} not in {}".format(exp_str, pdf_title_low))
 
 
+@pytest.mark.sauce
 @pytest.mark.meta(blockers=[1026939])
 def test_info(guides, soft_assert):
     pytest.sel.force_navigate("about")

--- a/cfme/tests/configure/test_server_roles.py
+++ b/cfme/tests/configure/test_server_roles.py
@@ -30,6 +30,7 @@ def roles(request, all_possible_roles):
     return result
 
 
+@pytest.mark.sauce
 @pytest.sel.go_to('dashboard')
 @pytest.mark.uncollectif(lambda: not server_roles_conf["all"])
 def test_server_roles_changing(request, roles):

--- a/cfme/tests/configure/test_session_timeout.py
+++ b/cfme/tests/configure/test_session_timeout.py
@@ -8,6 +8,7 @@ from utils.browser import ensure_browser_open, quit
 from utils.wait import wait_for
 
 
+@pytest.mark.sauce
 def test_session_timeout(request):
     """Sets the timeout to shortest possible time and waits if it really times out."""
     @request.addfinalizer  # Wow, why we did not figure this out before?!

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 from cfme.configure.configuration import Category
+import pytest
 from utils.update import update
 
 
+@pytest.mark.sauce
 def test_category_crud():
     cg = Category(name=fauxfactory.gen_alphanumeric(8).lower(),
                   description=fauxfactory.gen_alphanumeric(32),

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import cfme.configure.settings as st
+import pytest
 import utils.error as error
 from utils.update import update
 
@@ -13,6 +14,7 @@ def new_timeprofile():
                    timezone="(GMT-10:00) Hawaii")
 
 
+@pytest.mark.sauce
 def test_timeprofile_crud():
     timeprofile = new_timeprofile()
     timeprofile.create()
@@ -23,6 +25,7 @@ def test_timeprofile_crud():
     timeprofile.delete()
 
 
+@pytest.mark.sauce
 def test_timeprofile_duplicate_name():
     nt = new_timeprofile()
     nt.create()
@@ -32,6 +35,7 @@ def test_timeprofile_duplicate_name():
     nt. delete()
 
 
+@pytest.mark.sauce
 def test_timeprofile_name_max_character_validation():
     tp = st.Timeprofile(
         description=fauxfactory.gen_alphanumeric(50),
@@ -41,6 +45,7 @@ def test_timeprofile_name_max_character_validation():
     tp.delete()
 
 
+@pytest.mark.sauce
 def test_days_required_error_validation():
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
@@ -52,6 +57,7 @@ def test_days_required_error_validation():
         tp.create()
 
 
+@pytest.mark.sauce
 def test_hours_required_error_validation():
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
@@ -63,6 +69,7 @@ def test_hours_required_error_validation():
         tp.create()
 
 
+@pytest.mark.sauce
 def test_description_required_error_validation():
     tp = st.Timeprofile(
         description=None,

--- a/cfme/tests/configure/test_version.py
+++ b/cfme/tests/configure/test_version.py
@@ -4,6 +4,7 @@ from cfme.configure.about import product_assistance as about
 from utils.ssh import SSHClient
 
 
+@pytest.mark.sauce
 def test_version():
     """Check version presented in UI against version retrieved directly from the machine.
 

--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -4,6 +4,7 @@ import pytest
 from cfme.configure import configuration
 
 
+@pytest.mark.sauce
 @pytest.mark.nondestructive
 @pytest.sel.go_to('dashboard')
 def test_restart_workers():

--- a/cfme/tests/configure/test_zones.py
+++ b/cfme/tests/configure/test_zones.py
@@ -7,6 +7,7 @@ import cfme.configure.configuration as conf
 from utils.update import update
 
 
+@pytest.mark.sauce
 @pytest.mark.meta(blockers=[1216224])
 @pytest.mark.smoke
 def test_zone_crud(soft_assert):
@@ -32,6 +33,7 @@ def test_zone_crud(soft_assert):
     ))
 
 
+@pytest.mark.sauce
 def test_zone_add_cancel_validation():
     zone = conf.Zone(
         name=fauxfactory.gen_alphanumeric(5),
@@ -40,6 +42,7 @@ def test_zone_add_cancel_validation():
     flash.assert_message_match('Add of new Miq Zone was cancelled by the user')
 
 
+@pytest.mark.sauce
 @pytest.mark.meta(blockers=[1216224])
 def test_zone_change_appliance_zone(request):
     """ Tests that an appliance can be changed to another Zone """

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -9,6 +9,7 @@ import cfme.tests.configure.test_access_control as tac
 pytestmark = [pytest.mark.usefixtures("logged_in")]
 
 
+@pytest.mark.sauce
 def test_catalog_crud():
     cat = Catalog(name=fauxfactory.gen_alphanumeric(),
                   description="my catalog")
@@ -18,6 +19,7 @@ def test_catalog_crud():
     cat.delete()
 
 
+@pytest.mark.sauce
 def test_catalog_duplicate_name():
     cat = Catalog(name=fauxfactory.gen_alphanumeric(),
                   description="my catalog")
@@ -27,6 +29,7 @@ def test_catalog_duplicate_name():
     cat.delete()
 
 
+@pytest.mark.sauce
 @pytest.mark.meta(blockers=[1130301])
 def test_permissions_catalog_add(setup_cloud_providers):
     """ Tests that a catalog can be added only with the right permissions"""

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -27,6 +27,7 @@ def test_login(method):
     assert login.page.is_displayed()
 
 
+@pytest.mark.sauce
 def test_bad_password():
     """ Tests logging in with a bad password. """
     pytest.sel.get(pytest.sel.base_url())


### PR DESCRIPTION
This PR adds the @pytest.mark.sauce marker to a number of tests that don't require a provider be added to the appliance. This is intended to expand the coverage of the nightly sauce tests. 