### PR TITLE
A few fixes

### DIFF
--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -156,6 +156,7 @@ def pytest_unconfigure():
     art_client.fire_hook('teardown_merkyl', ip=appliance_ip_address)
     if not SLAVEID:
         art_client.terminate()
+        proc.wait()
 
 
 if not SLAVEID:

--- a/scripts/dockerbot/dockerbot.py
+++ b/scripts/dockerbot/dockerbot.py
@@ -134,6 +134,8 @@ class DockerBot(object):
         self.pytest_bindings = self.create_pytest_bindings()
 
         if self.args['dry_run']:
+            for i in self.env_details:
+                print 'export {}="{}"'.format(i, self.env_details[i])
             print self.env_details
 
         pytest = PytestDocker(name=self.pytest_name, bindings=self.pytest_bindings,
@@ -383,9 +385,9 @@ class DockerBot(object):
             print "  WHARF: {}".format(self.args['wharf'])
         if self.args['prtester']:
             print "  PRTESTING: Enabled"
-            self.env_details['TRACKERBOT'] = self.args['trackerbot']
-            print "  TRACKERBOT: {}".format(self.env_details['TRACKERBOT'])
             self.env_details['POST_TASK'] = self.pytest_name
+        self.env_details['TRACKERBOT'] = self.args['trackerbot']
+        print "  TRACKERBOT: {}".format(self.env_details['TRACKERBOT'])
         print "  REPO: {}".format(self.args['cfme_repo'])
         print "  BROWSER: {}".format(self.args['browser'])
         if self.args['update_pip']:


### PR DESCRIPTION
* We need a blank setup.py file to ensure that the project root is
  recognised by pytest as the project root, else it messes up the
  project locations for test naming.
* In PRT, Artifactor wasn't having a chance to finish before it was
  killed so for short tests, this led to some tests never being
  reported.
* Dockerbot didn't handle the TRACKERBOT environment variable outside of
  the prtester mode. This was never normally needed but with the onset
  of template loading from trackerbot at the start of the test run. This
  became necessary.