### PR TITLE
Removed default domain dependance for test

### DIFF
--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
-from cfme.automate.explorer import Namespace, Class, Method
+from cfme.automate.explorer import Namespace, Class, Method, Domain
 from utils.update import update
 import utils.error as error
 
@@ -9,25 +9,33 @@ import utils.error as error
 pytestmark = [pytest.mark.usefixtures("logged_in")]
 
 
-def _make_namespace():
+def _make_namespace(domain):
     name = fauxfactory.gen_alphanumeric(8)
     description = fauxfactory.gen_alphanumeric(32)
-    ns = Namespace(name=name, description=description)
+    ns = Namespace(name=name, description=description, parent=domain)
     ns.create()
     return ns
 
 
-def _make_class():
+def _make_class(domain):
     name = fauxfactory.gen_alphanumeric(8)
     description = fauxfactory.gen_alphanumeric(32)
-    cls = Class(name=name, description=description, namespace=_make_namespace())
+    cls = Class(name=name, description=description, namespace=_make_namespace(domain))
     cls.create()
     return cls
 
 
+@pytest.fixture(scope="module")
+def domain(request):
+    domain = Domain(name=fauxfactory.gen_alphanumeric(), enabled=True)
+    domain.create()
+    request.addfinalizer(lambda: domain.delete() if domain.exists() else None)
+    return domain
+
+
 @pytest.fixture(scope='module')
-def a_class():
-    return _make_class()
+def a_class(domain):
+    return _make_class(domain)
 
 
 @pytest.fixture

--- a/cfme/tests/automate/test_namespace.py
+++ b/cfme/tests/automate/test_namespace.py
@@ -4,7 +4,7 @@
 import fauxfactory
 import pytest
 
-from cfme.automate.explorer import Namespace
+from cfme.automate.explorer import Namespace, Domain
 from utils.providers import setup_a_provider
 from utils.update import update
 from utils import version
@@ -15,14 +15,22 @@ import cfme.tests.automate as ta
 pytestmark = [pytest.mark.usefixtures("logged_in")]
 
 
+@pytest.fixture(scope="module")
+def domain(request):
+    domain = Domain(name=fauxfactory.gen_alphanumeric(), enabled=True)
+    domain.create()
+    request.addfinalizer(lambda: domain.delete() if domain.exists() else None)
+    return domain
+
+
 @pytest.fixture(
     scope="function",
     params=[ta.a_namespace, ta.a_namespace_with_path])
-def namespace(request):
+def namespace(request, domain):
     # don't test with existing paths on upstream (there aren't any)
     if request.param is ta.a_namespace_with_path and version.current_version() == version.LATEST:
         pytest.skip("don't test with existing paths on upstream (there aren't any)")
-    return request.param()
+    return request.param(domain=domain)
 
 
 @pytest.fixture
@@ -58,8 +66,8 @@ def test_duplicate_namespace_disallowed(namespace):
 
 # provider needed as workaround for bz1035399
 @pytest.mark.meta(blockers=[1140331])
-def test_permissions_namespace_crud(setup_single_provider):
+def test_permissions_namespace_crud(setup_single_provider, domain):
     """ Tests that a namespace can be manipulated only with the right permissions"""
     tac.single_task_permission_test([['Automate', 'Explorer']],
                                     {'Namespace CRUD':
-                                     lambda: test_namespace_crud(ta.a_namespace())})
+                                     lambda: test_namespace_crud(ta.a_namespace(domain=domain))})

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -160,8 +160,6 @@ class Appliance(object):
         self.ipapp.enable_internal_db(log_callback=log_callback)
         self.ipapp.wait_for_web_ui(timeout=1800, log_callback=log_callback)
         self.ipapp.loosen_pgssl(log_callback=log_callback)
-        self.ipapp.clone_domain("ManageIQ", "Default", log_callback=log_callback)
-        self.ipapp.clone_domain("RedHat", "RedHat_Over", log_callback=log_callback)
         self.ipapp.update_rhel(log_callback=log_callback)
         self.ipapp.wait_for_web_ui(timeout=1800, log_callback=log_callback)
 
@@ -174,7 +172,6 @@ class Appliance(object):
         self.ipapp.setup_upstream_db(log_callback=log_callback)
         self.ipapp.wait_for_web_ui(timeout=1800, log_callback=log_callback)
         self.ipapp.loosen_pgssl(log_callback=log_callback)
-        self.ipapp.clone_domain(log_callback=log_callback)
 
     def configure(self, setup_fleece=False, log_callback=None, **kwargs):
         """Configures appliance - database setup, rename, ntp sync, ajax wait patch

--- a/utils/events.py
+++ b/utils/events.py
@@ -119,8 +119,8 @@ ALL_VDI_EVENTS = [event for event in ALL_EVENTS if event[1].startswith("vdi_")]
 
 
 def setup_for_event_testing(ssh_client, db, listener_info, providers):
-
-    domain = Domain(name="new_domain", enabled=True)
+    domain_name = "EventTesting"
+    domain = Domain(name=domain_name, enabled=True)
     if not domain.exists():
         domain.create()
 
@@ -184,8 +184,8 @@ def setup_for_event_testing(ssh_client, db, listener_info, providers):
             version.LOWEST: None,
 
             "5.3.0.0":
-            "evm:automate:convert DOMAIN=Default FILE=/root/{} ZIP_FILE=/root/{}.zip".format(
-                qe_automate_namespace_xml, qe_automate_namespace_xml),
+            "evm:automate:convert DOMAIN={} FILE=/root/{} ZIP_FILE=/root/{}.zip".format(
+                domain_name, qe_automate_namespace_xml, qe_automate_namespace_xml),
         })
         if convert_cmd is not None:
             logger.info("Converting namespace for use on newer appliance...")
@@ -203,8 +203,8 @@ def setup_for_event_testing(ssh_client, db, listener_info, providers):
             version.LOWEST: "evm:automate:import FILE=/root/{}".format(qe_automate_namespace_xml),
 
             "5.3.0.0":
-            "evm:automate:import ZIP_FILE=/root/{}.zip DOMAIN=Default OVERWRITE=true "
-            "PREVIEW=false".format(qe_automate_namespace_xml),
+            "evm:automate:import ZIP_FILE=/root/{}.zip DOMAIN={} OVERWRITE=true "
+            "PREVIEW=false".format(qe_automate_namespace_xml, domain_name),
         })
         logger.info("Importing the QE Automation namespace ...")
         return_code, stdout = ssh_client.run_rake_command(rake_cmd)


### PR DESCRIPTION
Removed default domain dependance for test
{{pytest: cfme/tests/automate/test_method.py cfme/tests/automate/test_namespace.py cfme/tests/automate/test_vmware_methods.py cfme/tests/infrastructure/test_vm_analysis.py --long-running}}