### PR TITLE
Use full template for snapshots

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -505,7 +505,7 @@ class Vm(Common):
 
         def _nav_to_snapshot_mgmt(self):
             locator = ("//div[@class='dhtmlxInfoBarLabel' and " +
-                       "contains(. , '\"Snapshots\" for Virtual Machine \"%s\"' % self.name) ]")
+                       "contains(. , '\"Snapshots\" for Virtual Machine \"%s\"') ]" % self.name)
             if not sel.is_displayed(locator):
                 self.vm.load_details()
                 sel.click(details_page.infoblock.element("Properties", "Snapshots"))


### PR DESCRIPTION
Use full template for snapshots

{{pytest: -k test_verify_revert_snapshot cfme/tests/infrastructure/test_snapshot.py --use-provider complete --long-running}}