### PR TITLE
Alerts tests resurrected

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
-
+import fauxfactory
 import pytest
 
 from cfme.control import explorer
@@ -9,6 +8,7 @@ from utils import testgen
 from utils.log import logger
 from utils.providers import setup_provider
 from utils.update import update
+from utils.virtual_machines import deploy_template
 from utils.wait import wait_for
 
 
@@ -16,7 +16,8 @@ pytestmark = [pytest.mark.long_running]
 
 
 def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.infra_providers(metafunc, "test_vm_power_control")
+    argnames, argvalues, idlist = testgen.infra_providers(metafunc,
+        'small_template', scope="module", template_location=["small_template"])
     testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
@@ -84,39 +85,51 @@ def setup_for_alerts(request, alerts, event, vm_name, provider_data, provider_ke
     prov.assign_policy_profiles(policy_profile.description)
 
 
-@pytest.mark.meta(server_roles="+automate")
+@pytest.yield_fixture(scope="module")
+def vm_name(provider_key, provider_mgmt, small_template):
+    name = "test_alerts_{}".format(fauxfactory.gen_alpha())
+    try:
+        name = deploy_template(
+            provider_key, name, template_name=small_template, allow_skip="default")
+        yield name
+    finally:
+        try:
+            if provider_mgmt.does_vm_exist(name):
+                provider_mgmt.delete_vm(name)
+        except Exception as e:
+            logger.exception(e)
+
+
+@pytest.mark.meta(server_roles=["+automate", "+notifier"])
 def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(
-        test_vm_power_control, provider_crud, provider_data, provider_mgmt, provider_type, request,
-        smtp_test, provider_key, register_event):
+        vm_name, provider_crud, provider_data, provider_mgmt, provider_type, request, smtp_test,
+        provider_key, register_event):
     """ Tests alerts for vm turned on more than twice in 15 minutes
 
     Metadata:
         test_flag: alerts, provision
     """
-    if test_vm_power_control is None or len(test_vm_power_control) == 0:
-        pytest.skip("No power control vm specified!")
-    test_vm_power_control = test_vm_power_control[0]
     alert = explorer.Alert("VM Power On > 2 in last 15 min")
     with update(alert):
         alert.emails = "test@test.test"
 
     setup_for_alerts(
-        request, [alert], "VM Power On", test_vm_power_control, provider_data, provider_key)
+        request, [alert], "VM Power On", vm_name, provider_data, provider_key)
 
     # Ok, hairy stuff done, now - hammertime!
     register_event(
         provider_crud.get_yaml_data()['type'],
-        "vm", test_vm_power_control, ["vm_power_off"])
+        "vm", vm_name, ["vm_power_off"])
     register_event(
         provider_crud.get_yaml_data()['type'],
-        "vm", test_vm_power_control, ["vm_power_on"])
+        "vm", vm_name, ["vm_power_on"])
     # We don't check for *_req events because these happen only if the operation is issued via CFME.
-    provider_mgmt.stop_vm(test_vm_power_control)
-    wait_for(lambda: provider_mgmt.is_vm_stopped(test_vm_power_control), num_sec=240)
+    provider_mgmt.stop_vm(vm_name)
+    wait_for(lambda: provider_mgmt.is_vm_stopped(vm_name), num_sec=240)
     for i in range(5):
-        provider_mgmt.start_vm(test_vm_power_control)
-        wait_for(lambda: provider_mgmt.is_vm_running(test_vm_power_control), num_sec=240)
-        provider_mgmt.stop_vm(test_vm_power_control)
-        wait_for(lambda: provider_mgmt.is_vm_stopped(test_vm_power_control), num_sec=240)
+        provider_mgmt.start_vm(vm_name)
+        wait_for(lambda: provider_mgmt.is_vm_running(vm_name), num_sec=240)
+        provider_mgmt.stop_vm(vm_name)
+        wait_for(lambda: provider_mgmt.is_vm_stopped(vm_name), num_sec=240)
 
-    wait_for_alert(smtp_test, alert, delay=800)
+    wait_for_alert(smtp_test, alert, delay=16 * 60)


### PR DESCRIPTION
{{pytest: cfme/tests/control/test_alerts.py -v --long-running }}