### PR TITLE
ec2 tries VM refresh to trigger the events.

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -1286,6 +1286,7 @@ def _select_iter(loc, items):
 
 
 def _sel_desel(el, getter_fn, setter_attr, item):
+    wait_for_ajax()
     if item is not None:
         old_item = getter_fn(el)
         if old_item != item:


### PR DESCRIPTION
{{pytest: cfme/tests/control/test_actions.py cfme/tests/cloud_infra_common/test_tag_objects.py --long-running --use-provider complete -v}}