### PR TITLE
Change PyPDF2 for pdfminer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,12 +16,12 @@ multimethods.py
 numpy
 ovirt-engine-sdk-python
 paramiko
+pdfminer
 psphere
 py
 pycrypto
 pygal
 PyGithub
-PyPDF2
 # Temporary stick to 2.7.0 due to fixture scoping mismatches in 2.7.1 and possibly up
 pytest==2.7.0
 python-bugzilla>=1.2.0


### PR DESCRIPTION
also **Check Cloudforms version instead of CFME version in docs**

PyPDF2's `extract_text()` is very fragile and can't handle CFME PDFs. pdfminer is a bit harder to use but can extract all the text from the title page allowing us to check the version as well. And since some docs (like REST and SOAP) don't contain CFME version anywhere, we have to check for Cloudforms version instead.

{{pytest: cfme/tests/configure/test_docs.py -k test_contents -v }}