### PR TITLE
When creating the AE QE event hook, copy the class to retain the schema

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -65,6 +65,9 @@ def pytest_generate_tests(metafunc):
     for i, argvalue_tuple in enumerate(argvalues):
         args = dict(zip(argnames, argvalue_tuple))
 
+        if args["provider_type"] in {"scvmm"}:
+            continue
+
         if ((metafunc.function is test_action_create_snapshot_and_delete_last)
             or
             (metafunc.function is test_action_create_snapshots_and_delete_them)) \

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -18,7 +18,18 @@ pytestmark = [pytest.mark.long_running]
 def pytest_generate_tests(metafunc):
     argnames, argvalues, idlist = testgen.infra_providers(metafunc,
         'small_template', scope="module", template_location=["small_template"])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+    new_idlist = []
+    new_argvalues = []
+    for i, argvalue_tuple in enumerate(argvalues):
+        args = dict(zip(argnames, argvalue_tuple))
+
+        if args["provider_type"] in {"scvmm"}:
+            continue
+
+        new_idlist.append(idlist[i])
+        new_argvalues.append(argvalues[i])
+
+    testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 
 
 def wait_for_alert(smtp, alert, delay=None):

--- a/utils/events.py
+++ b/utils/events.py
@@ -219,7 +219,13 @@ def setup_for_event_testing(ssh_client, db, listener_info, providers):
     # CREATE AUTOMATE INSTANCE HOOK
     if db is None or db.session.query(db['miq_ae_instances'].name)\
             .filter(db['miq_ae_instances'].name == "RelayEvents").count() == 0:
-        # Check presence
+        original_class = Class(
+            name=version.pick({
+                version.LOWEST: "Automation Requests (Request)",
+                "5.3": "Request"
+            }),
+            namespace=Namespace("System", domain=Domain("ManageIQ (Locked)")))
+        copied_class = original_class.copy_to(domain)
         instance = Instance(
             name="RelayEvents",
             display_name="RelayEvents",
@@ -229,12 +235,7 @@ def setup_for_event_testing(ssh_client, db, listener_info, providers):
                     "value": "/QE/Automation/APIMethods/relay_events?event=$evm.object['event']"
                 }
             },
-            cls=Class(
-                name=version.pick({
-                    version.LOWEST: "Automation Requests (Request)",
-                    "5.3": "Request"
-                }),
-                namespace=Namespace("System", domain=domain))
+            cls=copied_class,
         )
         instance.create()
 


### PR DESCRIPTION
I don't know whether will the event listener listen even in the docker conainer, but this is more to check whether all stuff works.

{{pytest: cfme/tests/infrastructure/test_vm_power_control.py cfme/tests/control/test_alerts.py cfme/tests/control/test_actions.py -v -m uses_event_listener --long-running --use-provider vsphere55 --event-testing}}