### PR TITLE
Check for modal window before navigating

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -956,6 +956,11 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
         kwargs.pop("start", None)
         force_navigate("dashboard")  # Start fresh
 
+    # Check if modal window is displayed
+    if (is_displayed("//div[contains(@class, 'modal-dialog') and contains(@class, 'modal-lg')]")):
+        logger.warning("Modal window was open; closing the window")
+        click("//button[contains(@class, 'close') and contains(@data-dismiss, 'modal')]")
+
     # Check if jQuery present
     try:
         execute_script("jQuery")


### PR DESCRIPTION
This is what broke jenkins. It's caused by `test_vm_clone` tests not being able to find "Default" automate datastore.

**How to test:**
Rename the "Default" automation datastore to anything else... e.g. "Default_2"

Run: `py.test cfme/tests/services/test_catalog_item.py`

Expected: lots of FAILs, no ERRORs

I'll set this up to be tested on PRT as well but I've got no idea what's gonna happen without the Default --> Default_2 datastore rename.

{{pytest: cfme/tests/services/test_catalog_item.py -v }}