### PR TITLE
Updated Docker file

### DIFF
--- a/scripts/dockerbot/pytestbase/Dockerfile
+++ b/scripts/dockerbot/pytestbase/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:20
-RUN yum install -y gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-devel git nano python-pip python-devel gnupg gnupg2
-RUN git clone https://github.com/RedHatQE/cfme_tests.git 
+FROM fedora:21
+RUN yum install -y gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-devel git nano python-devel gnupg gnupg2
+RUN git clone https://github.com/RedHatQE/cfme_tests.git
+RUN yum -y install python-setuptools; easy_install pip
 RUN pip install -U -r /cfme_tests/requirements.txt
-RUN yum -y install https://kojipkgs.fedoraproject.org//packages/git/2.1.0/1.fc21/x86_64/git-2.1.0-1.fc21.x86_64.rpm git.rpm https://kojipkgs.fedoraproject.org//packages/git/2.1.0/1.fc21/noarch/perl-Git-2.1.0-1.fc21.noarch.rpm
 ADD setup.sh /setup.sh
 ADD post_result.py /post_result.py
 ADD get_keys.py /get_keys.py


### PR DESCRIPTION
py_test_base needed a few updates because of a pip incompatibility the
following changes were made:

* Move to using fedora21 as the new base
* Remove the custom git package install, as git2.1 is in Fedora21
* Install newer version of pip not packaged version