### PR TITLE
Pull db address from yamls instead of the rails console

### DIFF
--- a/utils/ports.py
+++ b/utils/ports.py
@@ -2,12 +2,14 @@
 """Storage for ports. Set defaults here, then :py:mod:`fixtures.portset` will make overrides."""
 import sys
 
+from fixtures.pytest_store import store
+from utils.log import logger
+
 
 class Ports(object):
-    from fixtures.pytest_store import store  # NOQA
-    from utils.log import logger  # NOQA
-
     def __init__(self):
+        self.store = store
+        self.logger = logger
         # Port that is used to used for SSH connections to an appliance
         self.SSH = 22
         # POrt that is used to connect to the POstgreSQL database of the appliance.

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -92,10 +92,13 @@ class SSHClient(paramiko.SSHClient):
         # It will be reopened automatically on next command
         pass
 
+    def __del__(self):
+        self.close()
+
     def _check_port(self):
         hostname = self._connect_kwargs['hostname']
-        if not net_check(ports.SSH, hostname):
-            raise Exception("SSH connection to %s:%d failed, port unavailable".format(
+        if not net_check(ports.SSH, hostname, force=True):
+            raise Exception("SSH connection to {}:{} failed, port unavailable".format(
                 hostname, ports.SSH))
 
     def _progress_callback(self, filename, size, sent):


### PR DESCRIPTION
- We picked up a new deprecation warning upstream, which broke the
  method being used to get the db address. We already have a desire
  to pull and parse yaml files from the appliance, so I made that work,
  and used it here to get the DB address.
- IPAppliance.ssh_client is lazycached now, to promote reuse throughout
  IPAppliance. The previous behavior is still supported by SSHClient's
  call behavior, which is to return a copy of itself with updated kwargs
- fixed some unnecessary NOQAs in ports (If you think you have to NOQA,
  spend some time and see if you can get around the problem)