### PR TITLE
Move all ssh_client calls to use the cache

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -970,7 +970,7 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
             logger.exception(e)
         # Restart some workers
         logger.warning("Restarting UI and VimBroker workers!")
-        with store.current_appliance.ssh_client() as ssh:
+        with store.current_appliance.ssh_client as ssh:
             # Blow off the Vim brokers and UI workers
             ssh.run_rails_command("\"(MiqVimBrokerWorker.all + MiqUiWorker.all).each &:kill\"")
         logger.info("Waiting for web UI to come back alive.")
@@ -987,10 +987,10 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
         logger.warning("Page was blocked by rails error, renavigating.")
         logger.error(rails_e)
         logger.debug('Top CPU consumers:')
-        logger.debug(store.current_appliance.ssh_client().run_command(
+        logger.debug(store.current_appliance.ssh_client.run_command(
             'top -c -b -n1 -M | head -30').output)
         logger.debug('Top Memory consumers:')
-        logger.debug(store.current_appliance.ssh_client().run_command(
+        logger.debug(store.current_appliance.ssh_client.run_command(
             'top -c -b -n1 -M -a | head -30').output)
         logger.debug('Managed Providers:')
         logger.debug(store.current_appliance.managed_providers)
@@ -1091,7 +1091,7 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
         else:
             logger.error("Could not determine the reason for failing the navigation. " +
                 " Reraising.  Exception: %s" % str(e))
-            logger.debug(store.current_appliance.ssh_client().run_command(
+            logger.debug(store.current_appliance.ssh_client.run_command(
                 'service evmserverd status').output)
             raise
 

--- a/cfme/tests/configure/test_update_appliances.py
+++ b/cfme/tests/configure/test_update_appliances.py
@@ -106,7 +106,7 @@ def appliance_set(cfme_data):
 
     # Unregister and destroy all
     for appliance in appliance_set.all_appliances:
-        with appliance.ssh_client() as ssh:
+        with appliance.ssh_client as ssh:
             ssh.run_command('subscription-manager remove --all')
             ssh.run_command('subscription-manager unregister')
         appliance.destroy()
@@ -189,7 +189,7 @@ def download_repo_files(appliance_set, rh_updates_data, reg_method, target_appli
 
     for appliance_name in target_appliances:
         appliance = appliance_set.find_by_name(appliance_name)
-        with appliance.ssh_client() as ssh:
+        with appliance.ssh_client as ssh:
             status, output = ssh.run_command(download_repos_str)
             assert status == 0, 'Failed to download specified repository files on machine {}'\
                                 .format(appliance.address)
@@ -212,7 +212,7 @@ def enable_repos(appliance_set, rh_updates_data, reg_method, target_appliances):
 
     for appliance_name in target_appliances:
         appliance = appliance_set.find_by_name(appliance_name)
-        with appliance.ssh_client() as ssh:
+        with appliance.ssh_client as ssh:
             for repo_name in enable_repos:
                 # Get first column from 'yum' using 'cut' and grep for repo with matching name
                 is_repo_disabled_str = "yum repolist disabled | cut -f1 -d' ' | grep '{}'"\
@@ -241,7 +241,7 @@ def add_channels(appliance_set, rh_updates_data, appliances_to_update):
 
     for appliance_name in appliances_to_update:
         appliance = appliance_set.find_by_name(appliance_name)
-        with appliance.ssh_client() as ssh:
+        with appliance.ssh_client as ssh:
             status, output = ssh.run_command(add_channels_str)
             assert status == 0, 'Failed to add specified channels on machine {}'\
                                 .format(appliance.address)
@@ -256,7 +256,7 @@ def rhn_mirror_setup(appliance_set):
 
     appliance_set.primary.restart_evm_service()
 
-    with appliance_set.primary.ssh_client() as ssh:
+    with appliance_set.primary.ssh_client as ssh:
         def is_repotrack_running():
             status, output = ssh.run_command('pgrep repotrack')
             if status == 0:
@@ -282,7 +282,7 @@ def rhn_mirror_setup(appliance_set):
 
     # Check /etc/yum.repos.d/cfme-mirror.repo file exists on secondary appliances
     for appliance in appliance_set.secondary:
-        with appliance.ssh_client() as ssh:
+        with appliance.ssh_client as ssh:
             def repo_file_exists():
                 status, output = ssh.run_command('ls /etc/yum.repos.d/cfme-mirror.repo')
                 if status == 0:
@@ -345,7 +345,7 @@ def run_platform_updates(appliance_set, appliances_to_update):
         primary_will_be_updated = False
         for appliance_name in appliances_to_update:
             appliance = appliance_set.find_by_name(appliance_name)
-            with appliance.ssh_client() as ssh:
+            with appliance.ssh_client as ssh:
                 status, output = ssh.run_command('yum check-update')
                 # 100 == there are packages available for update on this appliance
                 if status != 100:

--- a/cfme/tests/infrastructure/test_vm_analysis.py
+++ b/cfme/tests/infrastructure/test_vm_analysis.py
@@ -196,7 +196,7 @@ def finish_appliance_setup(get_appliance, appliance_browser, provider_crud, vm):
 
     # Configure for events
     # setup_for_event_testing(
-    #    appliance.ssh_client(), None, listener_info, providers.list_infra_providers())
+    #    appliance.ssh_client, None, listener_info, providers.list_infra_providers())
     return appliance_browser
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,6 @@ from utils import ports
 from utils.log import logger
 from utils.path import data_path
 from utils.net import net_check
-from utils.ssh import SSHClient
 from utils.version import current_version
 from utils.wait import TimedOutError
 
@@ -48,7 +47,7 @@ def set_session_timeout():
 def set_default_domain():
     if current_version() < "5.3":
         return  # Domains are not in 5.2.x and lower
-    ssh_client = SSHClient()
+    ssh_client = store.current_appliance.ssh_client
     # The command ignores the case when the Default domain is not present (: true)
     result = ssh_client.run_rails_command(
         "\"d = MiqAeDomain.where :name => 'Default'; puts (d) ? d.first.enabled : true\"")
@@ -61,7 +60,7 @@ def set_default_domain():
 @pytest.fixture(scope="session", autouse=True)
 def fix_merkyl_workaround():
     """Workaround around merkyl not opening an iptables port for communication"""
-    ssh_client = SSHClient()
+    ssh_client = store.current_appliance.ssh_client
     if ssh_client.run_command('test -s /etc/init.d/merkyl').rc != 0:
         logger.info('Rudely overwriting merkyl init.d on appliance;')
         local_file = data_path.join("bundles").join("merkyl").join("merkyl")

--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -143,7 +143,7 @@ class Store(object):
         except KeyError:
             # Fall back to having an appliance tell us what it thinks our IP
             # address is
-            return self.current_appliance.ssh_client().client_address()
+            return self.current_appliance.ssh_client.client_address()
 
     def write_line(self, line, **kwargs):
         return write_line(line, **kwargs)

--- a/fixtures/ssh_client.py
+++ b/fixtures/ssh_client.py
@@ -43,13 +43,13 @@ def ssh_client(uses_ssh):
             ssh_client_4 = ssh_client(hostname='different.host', **credentials['ssh'])
 
     """
-    return store.current_appliance.ssh_client()
+    return store.current_appliance.ssh_client
 
 
 @pytest.fixture(scope="module")
 def ssh_client_modscope(uses_ssh):
     """See :py:func:`ssh_client`."""
-    return store.current_appliance.ssh_client()
+    return store.current_appliance.ssh_client
 
 
 @pytest.mark.hookwrapper

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -498,7 +498,7 @@ class IPAppliance(object):
 
         Usage:
 
-            with appliance.ssh_client() as ssh:
+            with appliance.ssh_client as ssh:
                 status, output = ssh.run_command('...')
 
         Note:
@@ -545,7 +545,7 @@ class IPAppliance(object):
         logger.info('Checking appliance database')
         if not self.db_online:
             # postgres isn't running, try to start it
-            result = self.db_ssh_client().run_command('service postgresql92-postgresql restart')
+            result = self.db_ssh_client.run_command('service postgresql92-postgresql restart')
             if result.rc != 0:
                 return 'postgres failed to start:\n{}'.format(result.output)
             else:
@@ -1335,21 +1335,21 @@ class IPAppliance(object):
     @property
     def db_online(self):
         db_check_command = ('psql -U postgres -t  -c "select now()" postgres')
-        result = self.db_ssh_client().run_command(db_check_command)
+        result = self.db_ssh_client.run_command(db_check_command)
         return result.rc == 0
 
     @property
     def db_has_database(self):
         db_check_command = ('psql -U postgres -t  -c "SELECT datname FROM pg_database '
             'WHERE datname LIKE \'vmdb_%\';" postgres | grep -q vmdb_production')
-        result = self.db_ssh_client().run_command(db_check_command)
+        result = self.db_ssh_client.run_command(db_check_command)
         return result.rc == 0
 
     @property
     def db_has_tables(self):
         db_check_command = ('psql -U postgres -t  -c "SELECT * FROM information_schema.tables '
             'WHERE table_schema = \'public\';" vmdb_production | grep -q vmdb_production')
-        result = self.db_ssh_client().run_command(db_check_command)
+        result = self.db_ssh_client.run_command(db_check_command)
         return result.rc == 0
 
     @property

--- a/utils/db.py
+++ b/utils/db.py
@@ -363,7 +363,7 @@ def set_yaml_config(config_name, data_dict, hostname=None):
         _ssh_client = SSHClient(hostname=hostname)
     # Else, connect to the default one set up for this session
     else:
-        _ssh_client = store.current_appliance.ssh_client()
+        _ssh_client = store.current_appliance.ssh_client
     # Build & send new config
     temp_yaml = NamedTemporaryFile()
     dest_yaml = '/tmp/conf.yaml'


### PR DESCRIPTION
* All references to cur_app.ssh_client() will force a new transport, by
  removing the (), we can force it to use the cache. This should be safe
  for all situations where new details are not supplied.