### PR TITLE
Add the service catalog item ordering via REST.

### DIFF
--- a/fixtures/wait.py
+++ b/fixtures/wait.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""This module contains integration between pytest and :py:mod:`utils.wait`."""
+
+
+def pytest_namespace():
+    # Expose the waiting function in pytest
+    from utils.wait import wait_for_decorator
+    return {'wait_for': wait_for_decorator}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ multimethods.py
 numpy
 ovirt-engine-sdk-python
 paramiko
+parsedatetime
 pdfminer
 psphere
 py

--- a/utils/tests/test_wait.py
+++ b/utils/tests/test_wait.py
@@ -59,3 +59,31 @@ def test_callable_fail_condition():
         wait_for(
             incman.i_sleep_a_lot,
             fail_condition=lambda value: value <= 10, num_sec=2, delay=1)
+
+
+def test_wait_decorator():
+    incman = Incrementor()
+
+    @pytest.wait_for(fail_condition=0, delay=.05)
+    def a_test():
+        incman.i_sleep_a_lot()
+    print "Function output %s in time %s " % (a_test.out, a_test.duration)
+    assert a_test.duration < 1, "Should take less than 1 seconds"
+
+
+def test_wait_decorator_noparams():
+    incman = Incrementor()
+
+    @pytest.wait_for
+    def a_test():
+        return incman.i_sleep_a_lot() != 0
+    print "Function output %s in time %s " % (a_test.out, a_test.duration)
+    assert a_test.duration < 1, "Should take less than 1 seconds"
+
+
+def test_nonnumeric_numsec_timedelta_via_string():
+    incman = Incrementor()
+    func = partial(lambda: incman.i_sleep_a_lot() > 10)
+    with pytest.raises(TimedOutError):
+        wait_for(func,
+                 timeout="2s", delay=1)


### PR DESCRIPTION
Also adds a new feature, `pytest.wait_for` wrapper. Usage in the newly written test. @psav has already seen it, @seandst ?

{{pytest: cfme/tests/services/test_service_catalogs.py -v --long-running -k rest}}