### PR TITLE
Stick the idlist and argvalues adding together

### DIFF
--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -11,21 +11,20 @@ pytestmark = [pytest.mark.usefixtures('test_power_control')]
 
 
 def pytest_generate_tests(metafunc):
-    final_argv, final_argn, final_ids = [], [], []
+    final_argv, final_ids = [], []
 
     # Get all providers and pick those, that have power control test enabled
-    argnames, argvalues, idlist = testgen.provider_by_type(
+    argnames, argvalues, providers = testgen.provider_by_type(
         metafunc, ['ec2', 'openstack'], 'test_power_control')
 
-    for argn, argv, single_id in zip(argnames, argvalues, idlist):
-        test_pwr_ctl_i = argnames.index('test_power_control')
-        provider_key_i = argnames.index('provider_key')
-        final_argn = argnames
-        if argv[test_pwr_ctl_i] is True:
-            final_argv.append(argv)
-            final_ids.append(argv[provider_key_i])
+    for i, provider in enumerate(providers):
+        values = argvalues[i]
+        params = dict(zip(argnames, values))
+        if params["test_power_control"]:
+            final_ids.append(provider)
+            final_argv.append(values)
 
-    testgen.parametrize(metafunc, final_argn, final_argv, ids=final_ids, scope="function")
+    testgen.parametrize(metafunc, argnames, final_argv, ids=final_ids, scope="module")
 
 
 # This fixture must be named 'vm_name' because its tied to fixtures/virtual_machine

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -298,9 +298,6 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
         if provider not in filtered:
             continue
 
-        # Use the provider name for idlist, helps with readable parametrized test output
-        idlist.append(provider)
-
         # Get values for the requested fields, filling in with None for undefined fields
         data_values = {field: data.get(field, None) for field in fields}
 
@@ -312,10 +309,6 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
                     options['require_fields'] = True
                 if options['require_fields']:
                     skip = True
-                    try:
-                        idlist.remove(provider)
-                    except ValueError:
-                        pass
                     logger.warning('Field "%s" not defined for provider "%s", skipping' %
                         (key, provider)
                     )
@@ -364,6 +357,8 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
 
         # skip when required field is not present and option['require_field'] == True
         if not skip:
+            # ID for nice display in the test list
+            idlist.append(provider)
             argvalues.append(values)
 
     # pick a single provider if option['choose_random'] == True


### PR DESCRIPTION
Trying to mitigate the wrong parametrization values passing.

{{pytest: -v -m uses_testgen --long-running --use-provider complete}}