### PR TITLE
Adding pyenv's .python-version file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ pytest.ini
 .pydevproject
 .settings
 .floo*
+.python-version
 
 # rendered documentation
 docs/_build


### PR DESCRIPTION
This just adds the .python-version file that pyenv generates to .gitignore.