### PR TITLE
IP Appliance updates for urls

### DIFF
--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
-
 import diaper
 import fauxfactory
 import pytest
@@ -17,6 +15,7 @@ from utils.appliance import Appliance, ApplianceException, provision_appliance
 from utils.log import logger
 from utils.update import update
 from utils.wait import wait_for
+from urlparse import urlparse
 
 PREFIX = "test_compliance_"
 
@@ -43,8 +42,8 @@ def wait_for_ssa_enabled():
 @pytest.yield_fixture(scope="module")
 def compliance_vm(request, provider):
     try:
-        ip_addr = re.findall(r'[0-9]+(?:\.[0-9]+){3}', store.base_url)[0]
-        appl_name = provider.get_mgmt_system().get_vm_name_from_ip(ip_addr)
+        ip_addr = urlparse(store.base_url).hostname
+        appl_name = provider.mgmt.get_vm_name_from_ip(ip_addr)
         appliance = Appliance(provider.key, appl_name)
         logger.info(
             "The tested appliance ({}) is already on this provider ({}) so reusing it.".format(

--- a/cfme/tests/infrastructure/test_vm_analysis.py
+++ b/cfme/tests/infrastructure/test_vm_analysis.py
@@ -2,13 +2,15 @@
 import fauxfactory
 import pytest
 import random
-import re
 import time
+import urlparse
+
 from cfme.configure import tasks
 from cfme.exceptions import CFMEException
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.web_ui import flash, toolbar
-from utils import conf, testgen, version
+from fixtures.pytest_store import store
+from utils import testgen, version
 from utils.appliance import Appliance, provision_appliance
 from utils.log import logger
 from utils.wait import wait_for
@@ -95,7 +97,7 @@ def get_appliance(provider):
     if provider.key not in appliance_list:
         try:
             # see if the current appliance is on the needed provider
-            ip_addr = re.findall(r'[0-9]+(?:\.[0-9]+){3}', conf.env['base_url'])[0]
+            ip_addr = urlparse(store.base_url).hostname
             appl_name = provider.mgmt.get_vm_name_from_ip(ip_addr)
             logger.info("re-using already provisioned appliance on {}...".format(provider.key))
             main_provider = provider.key

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -491,12 +491,12 @@ class IPAppliance(object):
 
     @lazycache
     def hostname(self):
-        parsed_url = urlparse(self.url or store.base_url)
+        parsed_url = urlparse(self.url)
         return parsed_url.hostname
 
     @property
     def ui_port(self):
-        parsed_url = urlparse(self.url or store.base_url)
+        parsed_url = urlparse(self.url)
         if parsed_url.port is not None:
             return parsed_url.port
         elif parsed_url.scheme == "https":

--- a/utils/browser.py
+++ b/utils/browser.py
@@ -242,7 +242,7 @@ class DuckwebQaTestSetup(object):
     """
     def __init__(self):
         self.selenium_client = DuckwebQaClient()
-        self.base_url = conf.env['base_url']
+        self.base_url = store.base_url
         self.credentials = conf.credentials
 
     @property

--- a/utils/db.py
+++ b/utils/db.py
@@ -45,7 +45,7 @@ class Db(Mapping):
     """Helper class for interacting with a CFME database using SQLAlchemy
 
     Args:
-        hostname: base url to be used (default ``conf.env['base_url']``)
+        hostname: base url to be used (default is from current_appliance)
         credentials: name of credentials to use from :py:attr:`utils.conf.credentials`
             (default ``database``)
 


### PR DESCRIPTION
* Since the address is the canonical source, either passed in at init or
  grabbed from the store.base_url, there is no need for methods that
  rely on the address, to also try to search for the base_url from the
  store. This could cause confusions.