### PR TITLE
[WIP][NOTEST] - Fix testgen to be better

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -1,0 +1,54 @@
+from utils import conf
+from cfme.exceptions import (
+    ProviderHasNoKey
+)
+from utils.providers import provider_factory
+from utils.log import logger
+
+
+class BaseProvider():
+
+    @property
+    def data(self):
+        return self.get_yaml_data()
+
+    @property
+    def mgmt(self):
+        return self.get_mgmt_system()
+
+    @property
+    def type(self):
+        return self.data['type']
+
+    @property
+    def version(self):
+        return self.data['version']
+
+    def get_yaml_data(self):
+        """ Returns yaml data for this provider.
+        """
+        if hasattr(self, 'provider_data') and self.provider_data is not None:
+            return self.provider_data
+        elif self.key is not None:
+            return conf.cfme_data['management_systems'][self.key]
+        else:
+            raise ProviderHasNoKey('Provider %s has no key, so cannot get yaml data', self.name)
+
+    def get_mgmt_system(self):
+        """ Returns the mgmt_system using the :py:func:`utils.providers.provider_factory` method.
+        """
+        if hasattr(self, 'provider_data') and self.provider_data is not None:
+            return provider_factory(self.provider_data)
+        elif self.key is not None:
+            return provider_factory(self.key)
+        else:
+            raise ProviderHasNoKey('Provider %s has no key, so cannot get mgmt system')
+
+
+def cleanup_vm(vm_name, provider):
+    try:
+        logger.info('Cleaning up VM %s on provider %s' % (vm_name, provider.key))
+        provider.mgmt.delete_vm(vm_name)
+    except:
+        # The mgmt_sys classes raise Exception :\
+        logger.warning('Failed to clean up VM %s on provider %s' % (vm_name, provider.key))

--- a/cfme/fixtures/vm_name.py
+++ b/cfme/fixtures/vm_name.py
@@ -5,13 +5,13 @@ from utils.log import logger
 
 
 @pytest.yield_fixture(scope='function')
-def vm_name(provider_key, provider_mgmt):
+def vm_name(provider):
     # also tries to delete the VM that gets made with this name
     vm_name = 'test_servicecatalog-%s' % fauxfactory.gen_alphanumeric()
     yield vm_name
     try:
-        logger.info('Cleaning up VM %s on provider %s' % (vm_name, provider_key))
-        provider_mgmt.delete_vm(vm_name)
+        logger.info('Cleaning up VM %s on provider %s' % (vm_name, provider.key))
+        provider.mgmt.delete_vm(vm_name)
     except:
         # The mgmt_sys classes raise Exception :\
-        logger.warning('Failed to clean up VM %s on provider %s' % (vm_name, provider_key))
+        logger.warning('Failed to clean up VM %s on provider %s' % (vm_name, provider.key))

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -208,25 +208,16 @@ nav.add_branch('clouds_instances_by_provider', {
 })
 
 
-def cleanup_vm(vm_name, provider_key, provider_mgmt):
-    try:
-        logger.info('Cleaning up VM {} on provider {}'.format(vm_name, provider_key))
-        provider_mgmt.delete_vm(vm_name)
-    except Exception as e:
-        logger.warning('Failed to clean up VM {} on provider {}: {}'.format(vm_name,
-                                                                            provider_key, str(e)))
-
-
-def do_vm_provisioning(template_name, provider_crud, vm_name, provisioning_data, request,
-                       provider_mgmt, provider_key, smtp_test, num_sec=1500, wait=True):
+def do_vm_provisioning(template_name, provider, vm_name, provisioning_data, request,
+                       smtp_test, num_sec=1500, wait=True):
     # generate_tests makes sure these have values
     sel.force_navigate('infrastructure_provision_vms', context={
-        'provider': provider_crud,
+        'provider': provider,
         'template_name': template_name,
     })
 
     note = ('template %s to vm %s on provider %s' %
-        (template_name, vm_name, provider_crud.key))
+        (template_name, vm_name, provider.key))
     provisioning_data.update({
         'email': 'template_provisioner@example.com',
         'first_name': 'Template',
@@ -241,8 +232,8 @@ def do_vm_provisioning(template_name, provider_crud, vm_name, provisioning_data,
         return
 
     # Wait for the VM to appear on the provider backend before proceeding to ensure proper cleanup
-    logger.info('Waiting for vm %s to appear on provider %s', vm_name, provider_crud.key)
-    wait_for(provider_mgmt.does_vm_exist, [vm_name], handle_exception=True, num_sec=600)
+    logger.info('Waiting for vm %s to appear on provider %s', vm_name, provider.key)
+    wait_for(provider.mgmt.does_vm_exist, [vm_name], handle_exception=True, num_sec=600)
 
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for vm %s' % vm_name)

--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -9,7 +9,6 @@ from cfme.automate.buttons import ButtonGroup, Button
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.web_ui import toolbar
 from utils import testgen
-from utils.providers import setup_provider
 from utils.timeutil import parsetime
 from utils.wait import wait_for
 
@@ -43,14 +42,6 @@ def pytest_generate_tests(metafunc):
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 
 
-@pytest.fixture()
-def provider_init(provider_key):
-    try:
-        setup_provider(provider_key)
-    except Exception:
-        pytest.skip("It's not possible to set up this provider, therefore skipping")
-
-
 @pytest.fixture(scope="function")
 def vm_name():
     vm_name = 'test_ae_methods_{}'.format(fauxfactory.gen_alphanumeric())
@@ -58,8 +49,8 @@ def vm_name():
 
 
 @pytest.fixture(scope="function")
-def testing_vm(request, vm_name, provider_init, provider_crud, provider_mgmt, provisioning):
-    vm_obj = Vm(vm_name, provider_crud, provisioning["template"])
+def testing_vm(request, vm_name, setup_provider, provider, provisioning):
+    vm_obj = Vm(vm_name, provider, provisioning["template"])
 
     def _finalize():
         vm_obj.delete_from_provider()

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -66,11 +66,11 @@ def testing_group(request):
 
 
 @pytest.fixture(scope="function")
-def testing_vm(request, provisioning, provider_crud, provider_key):
-    setup_provider(provider_key)
+def testing_vm(request, provisioning, provider):
+    setup_provider(provider.key)
     vm = Vm(
         name="test_ae_hd_{}".format(fauxfactory.gen_alphanumeric()),
-        provider_crud=provider_crud,
+        provider_crud=provider,
         template_name=provisioning["template"]
     )
 
@@ -85,7 +85,7 @@ def testing_vm(request, provisioning, provider_crud, provider_key):
 
 @pytest.mark.meta(blockers=[1211627])
 def test_vmware_vimapi_hotadd_disk(
-        request, testing_group, provider_crud, provider_mgmt, testing_vm, domain, namespace, cls):
+        request, testing_group, provider, testing_vm, domain, namespace, cls):
     """ Tests hot adding a disk to vmware vm.
 
     This test exercises the ``VMware_HotAdd_Disk`` method, located either in

--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -52,12 +52,12 @@ def setup_ci_template(cloud_init_template):
 
 
 @pytest.fixture(scope="function")
-def vm_name(request, provider_mgmt):
+def vm_name(request):
     vm_name = 'test_image_prov_%s' % fauxfactory.gen_alphanumeric()
     return vm_name
 
 
-def test_provision_cloud_init(request, setup_provider, provider_crud, provisioning,
+def test_provision_cloud_init(request, setup_provider, provider, provisioning,
                               setup_ci_template, vm_name):
     """ Tests provisioning from a template with cloud_init
 
@@ -66,11 +66,11 @@ def test_provision_cloud_init(request, setup_provider, provider_crud, provisioni
     """
     image = provisioning.get('ci-image', None) or provisioning['image']['name']
     note = ('Testing provisioning from image %s to vm %s on provider %s' %
-            (image, vm_name, provider_crud.key))
+            (image, vm_name, provider.key))
 
-    mgmt_system = provider_crud.get_mgmt_system()
+    mgmt_system = provider.mgmt
 
-    instance = instance_factory(vm_name, provider_crud, image)
+    instance = instance_factory(vm_name, provider, image)
 
     request.addfinalizer(instance.delete_from_provider)
 
@@ -86,7 +86,7 @@ def test_provision_cloud_init(request, setup_provider, provider_crud, provisioni
         'custom_template': {'name': [provisioning['ci-template']]},
     }
 
-    if isinstance(provider_crud, OpenStackProvider):
+    if isinstance(provider, OpenStackProvider):
         floating_ip = mgmt_system.get_first_floating_ip()
         inst_args['cloud_network'] = provisioning['cloud_network']
         inst_args['public_ip_address'] = floating_ip

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -39,30 +39,30 @@ def reset():
     toolbar.set_vms_list_view()
 
 
-def test_delete_instance(setup_provider, provider_crud, remove_test):
+def test_delete_instance(setup_provider, provider, remove_test):
     """ Tests delete instance
 
     Metadata:
         test_flag: delete_object
     """
     instance_name = remove_test['instance']
-    test_instance = instance.instance_factory(instance_name, provider_crud)
+    test_instance = instance.instance_factory(instance_name, provider)
     test_instance.remove_from_cfme(cancel=False)
     test_instance.wait_for_delete()
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     test_instance.wait_for_vm_to_appear()
 
 
-def test_delete_image(setup_provider, provider_crud, remove_test, set_grid, request):
+def test_delete_image(setup_provider, provider, remove_test, set_grid, request):
     """ Tests delete image
 
     Metadata:
         test_flag: delete_object
     """
     image_name = remove_test['image']
-    test_image = instance.Image(image_name, provider_crud)
+    test_image = instance.Image(image_name, provider)
     test_image.delete()
     test_image.wait_for_delete()
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     test_image.wait_for_appear()
     request.addfinalizer(reset)

--- a/cfme/tests/cloud/test_stack.py
+++ b/cfme/tests/cloud/test_stack.py
@@ -2,7 +2,6 @@ import pytest
 from cfme.fixtures import pytest_selenium as sel
 from cfme.cloud.stack import Stack
 from utils import testgen
-from utils.providers import setup_provider
 from cfme.configure import settings  # NOQA
 from cfme.web_ui import ButtonGroup, form_buttons
 
@@ -18,12 +17,6 @@ def pytest_generate_tests(metafunc):
     metafunc.parametrize(argnames, argvalues, ids=idlist, scope='module')
 
 
-@pytest.fixture
-def provider_init(provider_key):
-    """cfme/cloud/provider.py provider object."""
-    setup_provider(provider_key)
-
-
 def set_grid_view(name):
     bg = ButtonGroup(name)
     sel.force_navigate("my_settings_default_views")
@@ -34,7 +27,7 @@ def set_grid_view(name):
 
 
 @pytest.fixture(scope="function")
-def stack(provider_init, provisioning):
+def stack(setup_provider, provisioning):
     set_grid_view("Stacks")
     stackname = provisioning['stack']
     stack = Stack(stackname)

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -10,16 +10,16 @@ pytest_generate_tests = testgen.generate(testgen.provider_by_type, ['openstack']
 
 
 @pytest.fixture
-def tenant(provider_key):
+def tenant(provider):
     return Tenant(name=fauxfactory.gen_alphanumeric(8),
                   description=fauxfactory.gen_alphanumeric(8),
-                  provider_key=provider_key)
+                  provider_key=provider.key)
 
 
-def test_tenant(provider_mgmt, tenant, provider_key):
+def test_tenant(tenant, provider):
     """ Tests tenant (currently disabled)
 
     Metadata:
         test_flag: tenant
     """
-    print tenant.name, tenant.description, provider_key
+    print tenant.name, tenant.description, provider.key

--- a/cfme/tests/cloud_infra_common/test_discovery.py
+++ b/cfme/tests/cloud_infra_common/test_discovery.py
@@ -23,13 +23,13 @@ def vm_name():
 
 
 @pytest.fixture(scope="module")
-def vm_crud(vm_name, provider_crud, provider_type):
+def vm_crud(vm_name, provider):
     cls = Vm
-    if provider_type == "ec2":
+    if provider.type == "ec2":
         cls = EC2Instance
-    elif provider_type == "openstack":
+    elif provider.type == "openstack":
         cls = OpenStackInstance
-    return cls(vm_name, provider_crud)
+    return cls(vm_name, provider)
 
 
 def if_scvmm_refresh_provider(provider):
@@ -58,7 +58,7 @@ def wait_for_vm_state_changes(vm, timeout=600):
         raise CFMEException("VM should be Archived but it is Orphaned now.")
 
 
-def test_vm_discovery(request, setup_provider, provider_crud, provider_mgmt, vm_crud):
+def test_vm_discovery(request, setup_provider, provider, vm_crud):
     """ Tests whether cfme will discover a vm change (add/delete) without being manually refreshed.
 
     Prerequisities:
@@ -77,15 +77,15 @@ def test_vm_discovery(request, setup_provider, provider_crud, provider_mgmt, vm_
     @request.addfinalizer
     def _cleanup():
         vm_crud.delete_from_provider()
-        if_scvmm_refresh_provider(provider_crud)
+        if_scvmm_refresh_provider(provider)
 
     vm_crud.create_on_provider(allow_skip="default")
-    if_scvmm_refresh_provider(provider_crud)
+    if_scvmm_refresh_provider(provider)
 
     try:
         vm_crud.wait_to_appear(timeout=600, load_details=False)
     except TimedOutError:
         pytest.fail("VM was not found in CFME")
     vm_crud.delete_from_provider()
-    if_scvmm_refresh_provider(provider_crud)
+    if_scvmm_refresh_provider(provider)
     wait_for_vm_state_changes(vm_crud)

--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -19,18 +19,18 @@ def pytest_generate_tests(metafunc):
 
     for i, argvalue_tuple in enumerate(argvalues):
         args = dict(zip(argnames, argvalue_tuple))
-        if 'remove_test' not in args['provider_crud'].get_yaml_data():
+        if 'remove_test' not in args['provider'].data:
             # No provisioning data available
             continue
 
         new_idlist.append(idlist[i])
-        argvalues[i].append(args['provider_crud'].get_yaml_data()['remove_test'])
+        argvalues[i].append(args['provider'].data['remove_test'])
         new_argvalues.append(argvalues[i])
 
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 
 
-def test_delete_cluster(setup_provider, provider_crud, remove_test):
+def test_delete_cluster(setup_provider, provider, remove_test):
     """ Tests delete cluster
 
     Metadata:
@@ -40,11 +40,11 @@ def test_delete_cluster(setup_provider, provider_crud, remove_test):
     test_cluster = cluster.Cluster(name=cluster_name)
     test_cluster.delete(cancel=False)
     test_cluster.wait_for_delete()
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     test_cluster.wait_for_appear()
 
 
-def test_delete_host(setup_provider, provider_crud, remove_test):
+def test_delete_host(setup_provider, provider, remove_test):
     """ Tests delete host
 
     Metadata:
@@ -54,39 +54,39 @@ def test_delete_host(setup_provider, provider_crud, remove_test):
     test_host = host.Host(name=host_name)
     test_host.delete(cancel=False)
     host.wait_for_host_delete(test_host)
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     host.wait_for_host_to_appear(test_host)
 
 
-def test_delete_vm(setup_provider, provider_crud, remove_test):
+def test_delete_vm(setup_provider, provider, remove_test):
     """ Tests delete vm
 
     Metadata:
         test_flag: delete_object
     """
     vm = remove_test['vm']
-    test_vm = virtual_machines.Vm(vm, provider_crud)
+    test_vm = virtual_machines.Vm(vm, provider)
     test_vm.remove_from_cfme(cancel=False)
     test_vm.wait_for_delete()
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     test_vm.wait_to_appear()
 
 
-def test_delete_template(setup_provider, provider_crud, remove_test):
+def test_delete_template(setup_provider, provider, remove_test):
     """ Tests delete template
 
     Metadata:
         test_flag: delete_object
     """
     template = remove_test['template']
-    test_template = virtual_machines.Template(template, provider_crud)
+    test_template = virtual_machines.Template(template, provider)
     test_template.remove_from_cfme(cancel=False)
     test_template.wait_for_delete()
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     test_template.wait_to_appear()
 
 
-def test_delete_resource_pool(setup_provider, provider_crud, remove_test):
+def test_delete_resource_pool(setup_provider, provider, remove_test):
     """ Tests delete pool
 
     Metadata:
@@ -96,13 +96,13 @@ def test_delete_resource_pool(setup_provider, provider_crud, remove_test):
     test_resourcepool = resource_pool.ResourcePool(name=resourcepool_name)
     test_resourcepool.delete(cancel=False)
     test_resourcepool.wait_for_delete()
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     test_resourcepool.wait_for_appear()
 
 
 @pytest.mark.meta(blockers=[1236977])
 @pytest.mark.ignore_stream("upstream")
-def test_delete_datastore(setup_provider, provider_crud, remove_test):
+def test_delete_datastore(setup_provider, provider, remove_test):
     """ Tests delete datastore
 
     Metadata:
@@ -120,5 +120,5 @@ def test_delete_datastore(setup_provider, provider_crud, remove_test):
         test_datastore.wait_for_delete_all()
     test_datastore.delete(cancel=False)
     test_datastore.wait_for_delete()
-    provider_crud.refresh_provider_relationships()
+    provider.refresh_provider_relationships()
     test_datastore.wait_for_appear()

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -6,7 +6,7 @@ not be difficult to extend the parametrizer.
 import pytest
 import random
 
-from cfme.infrastructure.provider import VMwareProvider, get_from_config, wait_for_provider_delete
+from cfme.infrastructure.provider import VMwareProvider, get_from_config
 from utils.conf import cfme_data, credentials
 from utils.net import resolve_hostname
 from utils.version import Version
@@ -74,7 +74,7 @@ def setup_provider(provider, original_provider_key):
                 host.delete(cancel=False)
         # Get rid of the original provider, it would make a mess.
         original_provider.delete(cancel=False)
-        wait_for_provider_delete(provider)
+        provider.wait_for_delete()
     provider.create()
     provider.refresh_provider_relationships()
     try:
@@ -93,7 +93,7 @@ def setup_provider(provider, original_provider_key):
         if host.exists:
             host.delete(cancel=False)
     provider.delete(cancel=False)
-    wait_for_provider_delete(provider)
+    provider.wait_for_delete()
 
 
 def test_validate(provider, setup_provider, provider_data):

--- a/cfme/tests/infrastructure/test_iso_datastore.py
+++ b/cfme/tests/infrastructure/test_iso_datastore.py
@@ -2,7 +2,6 @@ import pytest
 
 from cfme.infrastructure import pxe
 from utils import testgen
-from utils.providers import setup_provider
 
 pytestmark = [
     pytest.mark.usefixtures("logged_in"),
@@ -29,22 +28,14 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture()
-def provider_init(provider_key):
-    try:
-        setup_provider(provider_key)
-    except Exception:
-        pytest.skip("It's not possible to set up this provider, therefore skipping")
-
-
-@pytest.fixture()
-def no_iso_dss(provider_crud):
-    template_crud = pxe.ISODatastore(provider_crud.name)
+def no_iso_dss(provider):
+    template_crud = pxe.ISODatastore(provider.name)
     if template_crud.exists():
         template_crud.delete(cancel=False)
 
 
 @pytest.mark.meta(blockers=[1200783])
-def test_iso_datastore_crud(provider_init, no_iso_dss, provider_crud, iso_datastore):
+def test_iso_datastore_crud(setup_provider, no_iso_dss, provider, iso_datastore):
     """
     Basic CRUD test for ISO datastores.
 
@@ -54,6 +45,6 @@ def test_iso_datastore_crud(provider_init, no_iso_dss, provider_crud, iso_datast
     Metadata:
         test_flag: iso
     """
-    template_crud = pxe.ISODatastore(provider_crud.name)
+    template_crud = pxe.ISODatastore(provider.name)
     template_crud.create()
     template_crud.delete(cancel=False)

--- a/cfme/tests/infrastructure/test_retirement.py
+++ b/cfme/tests/infrastructure/test_retirement.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
-from utils.log import logger
 from utils import testgen
-from utils.providers import setup_provider
 from cfme.infrastructure import virtual_machines as vms
 from utils.wait import wait_for
 import datetime
@@ -34,20 +32,10 @@ def pytest_generate_tests(metafunc):
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 
 
-@pytest.fixture
-def provider_init(provider_key):
-    """cfme/infrastructure/provider.py provider object."""
-    try:
-        setup_provider(provider_key)
-    except Exception as e:
-        logger.info("Exception detected on provider setup: " + str(e))
-        pytest.skip("It's not possible to set up this provider, therefore skipping")
-
-
 @pytest.fixture(scope="function")
-def vm(request, provider_init, provider_crud, provisioning):
+def vm(request, setup_provider, provider, provisioning):
     vm_name = 'test_retire_prov_%s' % fauxfactory.gen_alphanumeric()
-    myvm = vms.Vm(name=vm_name, provider_crud=provider_crud, template_name=provisioning['template'])
+    myvm = vms.Vm(name=vm_name, provider_crud=provider, template_name=provisioning['template'])
     request.addfinalizer(myvm.delete_from_provider)
     myvm.create_on_provider(find_in_cfme=True, allow_skip="default")
     return myvm

--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -14,14 +14,14 @@ def pytest_generate_tests(metafunc):
 
 @pytest.mark.meta(blockers=[1178961])
 @pytest.mark.uncollectif(
-    lambda provider_data: "host_group" in provider_data.get("provisioning", {}),
+    lambda provider: "host_group" in provider.data.get("provisioning", {}),
     reason="No host group")
-def test_no_dvd_ruins_refresh(provider_mgmt, provider_crud, provider_data, small_template):
-    host_group = provider_data["provisioning"]["host_group"]
-    with provider_mgmt.with_vm(
+def test_no_dvd_ruins_refresh(provider, small_template):
+    host_group = provider.data["provisioning"]["host_group"]
+    with provider.mgmt.with_vm(
             small_template, vm_name="test_no_dvd_{}".format(fauxfactory.gen_alpha()),
             host_group=host_group) as vm_name:
-        provider_mgmt.disconnect_dvd_drives(vm_name)
-        vm = Vm(vm_name, provider_crud)
-        provider_crud.refresh_provider_relationships()
+        provider.mgmt.disconnect_dvd_drives(vm_name)
+        vm = Vm(vm_name, provider)
+        provider.refresh_provider_relationships()
         vm.wait_to_appear()

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -7,22 +7,21 @@ from cfme.web_ui import toolbar, jstimelines
 from cfme.exceptions import ToolbarOptionGreyed
 from utils import testgen
 from utils.log import logger
-from utils.providers import setup_provider
 from utils.wait import wait_for
 
 pytestmark = [pytest.mark.ignore_stream("upstream")]
 
 
 @pytest.fixture(scope="module")
-def delete_fx_provider_event(db, provider_crud):
-    logger.debug("Deleting timeline events for provider name {}".format(provider_crud.name))
+def delete_fx_provider_event(db, provider):
+    logger.debug("Deleting timeline events for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
     ems_events = db['ems_events']
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)
             .join(ems, ems_events.ems_id == ems.id)
-            .filter(ems.name == provider_crud.name)
+            .filter(ems.name == provider.name)
         )
         db.session.query(ems_events).filter(ems_events.id.in_(providers.subquery())).delete(False)
 
@@ -33,36 +32,27 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope="module")
-def provider_init(provider_key):
-    """cfme/infrastructure/provider.py provider object."""
-    try:
-        setup_provider(provider_key)
-    except Exception:
-        pytest.skip("It's not possible to set up this provider, therefore skipping")
-
-
-@pytest.fixture(scope="module")
 def vm_name():
     return "test_tt_" + fauxfactory.gen_alphanumeric(length=4)
 
 
 @pytest.fixture(scope="module")
-def test_vm(request, provider_crud, provider_mgmt, vm_name, provider_init):
+def test_vm(request, provider, vm_name, setup_provider_modscope):
     """Fixture to provision appliance to the provider being tested if necessary"""
     pytest.sel.force_navigate('infrastructure_providers')
-    vm = Vm(vm_name, provider_crud)
+    vm = Vm(vm_name, provider)
 
     request.addfinalizer(vm.delete_from_provider)
 
-    if not provider_mgmt.does_vm_exist(vm_name):
+    if not provider.mgmt.does_vm_exist(vm_name):
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
     return vm
 
 
 @pytest.fixture(scope="module")
-def gen_events(delete_fx_provider_event, provider_crud, test_vm):
+def gen_events(delete_fx_provider_event, provider, test_vm):
     logger.debug('Starting, stopping VM')
-    mgmt = provider_crud.get_mgmt_system()
+    mgmt = provider.mgmt
     mgmt.stop_vm(test_vm.name)
     mgmt.start_vm(test_vm.name)
 
@@ -82,7 +72,7 @@ def count_events(vm_name, nav_step):
     return 0
 
 
-def test_provider_event(provider_crud, gen_events, test_vm):
+def test_provider_event(provider, gen_events, test_vm):
     """Tests provider event on timelines
 
     Metadata:
@@ -90,13 +80,13 @@ def test_provider_event(provider_crud, gen_events, test_vm):
     """
     def nav_step():
         pytest.sel.force_navigate('infrastructure_provider',
-                                  context={'provider': provider_crud})
+                                  context={'provider': provider})
         toolbar.select('Monitoring', 'Timelines')
     wait_for(count_events, [test_vm.name, nav_step], timeout=60, fail_condition=0,
              message="events to appear")
 
 
-def test_host_event(provider_crud, gen_events, test_vm):
+def test_host_event(provider, gen_events, test_vm):
     """Tests host event on timelines
 
     Metadata:
@@ -110,7 +100,7 @@ def test_host_event(provider_crud, gen_events, test_vm):
              message="events to appear")
 
 
-def test_vm_event(provider_crud, gen_events, test_vm):
+def test_vm_event(provider, gen_events, test_vm):
     """Tests vm event on timelines
 
     Metadata:
@@ -123,7 +113,7 @@ def test_vm_event(provider_crud, gen_events, test_vm):
              message="events to appear")
 
 
-def test_cluster_event(provider_crud, gen_events, test_vm):
+def test_cluster_event(provider, gen_events, test_vm):
     """Tests cluster event on timelines
 
     Metadata:

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from utils.providers import setup_provider
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.services import requests
 from cfme.web_ui import flash
@@ -18,22 +17,14 @@ def pytest_generate_tests(metafunc):
     testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
-@pytest.fixture()
-def provider_init(provider_key):
-    try:
-        setup_provider(provider_key)
-    except Exception:
-        pytest.skip("It's not possible to set up this provider, therefore skipping")
-
-
 @pytest.mark.meta(blockers=[1174881])
-def test_vm_migrate(provider_init, provider_crud, provider_mgmt, request):
+def test_vm_migrate(setup_provider, provider, request):
     """Tests migration of a vm
 
     Metadata:
         test_flag: migrate, provision
     """
-    vm = Vm("vmtest", provider_crud)
+    vm = Vm("vmtest", provider)
     vm.migrate_vm("email@xyz.com", "first", "last", "host", "datstore")
     flash.assert_no_errors()
     row_description = 'VM Migrate'

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -56,22 +56,22 @@ def vm_name():
 
 
 @pytest.fixture(scope="class")
-def test_vm(request, provider_crud, provider_mgmt, vm_name):
+def test_vm(request, provider, vm_name):
     """Fixture to provision appliance to the provider being tested if necessary"""
-    vm = Vm(vm_name, provider_crud)
-    logger.info("provider_key: {}".format(provider_crud.key))
+    vm = Vm(vm_name, provider)
+    logger.info("provider_key: {}".format(provider.key))
 
     def _cleanup():
         vm.delete_from_provider()
-        if_scvmm_refresh_provider(provider_crud)
+        if_scvmm_refresh_provider(provider)
 
     request.addfinalizer(_cleanup)
 
-    if not provider_mgmt.does_vm_exist(vm_name):
-        logger.info("deploying {} on provider {}".format(vm_name, provider_crud.key))
+    if not provider.mgmt.does_vm_exist(vm_name):
+        logger.info("deploying {} on provider {}".format(vm_name, provider.key))
         vm.create_on_provider(allow_skip="default")
     else:
-        logger.info("recycling deployed vm {} on provider {}".format(vm_name, provider_crud.key))
+        logger.info("recycling deployed vm {} on provider {}".format(vm_name, provider.key))
     vm.provider_crud.refresh_provider_relationships()
     vm.wait_to_appear()
     return vm
@@ -358,9 +358,9 @@ class TestVmDetailsPowerControlPerProvider(object):
                         "ui: {} should !=  orig: {}".format(new_last_boot_time, last_boot_time))
 
 
-def test_no_template_power_control(provider_crud, setup_provider_funcscope):
+def test_no_template_power_control(provider, setup_provider_funcscope):
     """ Ensures that no power button is displayed for templates."""
-    provider_crud.load_all_provider_templates()
+    provider.load_all_provider_templates()
     toolbar.set_vms_grid_view()
     try:
         with error.expected(NoSuchElementException):
@@ -373,7 +373,7 @@ def test_no_template_power_control(provider_crud, setup_provider_funcscope):
     # Ensure selecting a template doesn't cause power menu to appear
     templates = list(get_all_vms(True))
     template_name = random.choice(templates)
-    selected_template = Vm(template_name, provider_crud)
+    selected_template = Vm(template_name, provider)
     quadicon = selected_template.find_quadicon(do_not_navigate=True, mark=False, refresh=False)
     with error.expected(NoSuchElementException):
         toolbar.select("Power")

--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -2,7 +2,6 @@
 import fauxfactory
 from cfme.services.catalogs.orchestration_template import OrchestrationTemplate
 import pytest
-from utils.providers import setup_provider
 from utils import testgen
 from utils.update import update
 
@@ -61,15 +60,6 @@ def pytest_generate_tests(metafunc):
         new_argvalues.append([args[argname] for argname in argnames])
 
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
-
-
-@pytest.fixture
-def provider_init(provider_key):
-    """cfme/infrastructure/provider.py provider object."""
-    try:
-        setup_provider(provider_key)
-    except Exception:
-        pytest.skip("It's not possible to set up this provider, therefore skipping")
 
 
 def test_orchestration_template_crud(provisioning):

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -9,7 +9,6 @@ from cfme.services.catalogs.myservice import MyService
 from cfme.services import requests
 from cfme.web_ui import flash
 from utils import testgen
-from utils.providers import setup_provider
 from utils.log import logger
 from utils.wait import wait_for
 
@@ -113,15 +112,6 @@ def pytest_generate_tests(metafunc):
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 
 
-@pytest.fixture
-def provider_init(provider_key):
-    """cfme/infrastructure/provider.py provider object."""
-    try:
-        setup_provider(provider_key)
-    except Exception:
-        pytest.skip("It's not possible to set up this provider, therefore skipping")
-
-
 @pytest.fixture(scope="function")
 def dialog(provisioning):
     dialog_name = "dialog_" + fauxfactory.gen_alphanumeric()
@@ -140,8 +130,7 @@ def catalog():
     catalog.delete()
 
 
-def test_provision_stack(provider_init, provider_key, provider_crud,
-                        provider_type, provisioning, dialog, catalog, request):
+def test_provision_stack(setup_provider, provider, provisioning, dialog, catalog, request):
     """Tests stack provisioning
 
     Metadata:
@@ -152,9 +141,9 @@ def test_provision_stack(provider_init, provider_key, provider_crud,
     catalog_item = CatalogItem(item_type="Orchestration", name=item_name,
                   description="my catalog", display_in=True, catalog=catalog.name,
                   dialog=dialog_name, orch_template=template_name,
-                  provider_type=provider_crud.name)
+                  provider_type=provider.name)
     catalog_item.create()
-    if provider_type == 'ec2':
+    if provider.type == 'ec2':
         stack_data = {
             'stack_name': "stack" + fauxfactory.gen_alphanumeric(),
             'key_name': provisioning['stack_provisioning']['key_name'],
@@ -163,7 +152,7 @@ def test_provision_stack(provider_init, provider_key, provider_crud,
             'db_root_password': provisioning['stack_provisioning']['db_root_password'],
             'select_instance_type': provisioning['stack_provisioning']['instance_type'],
         }
-    elif provider_type == 'openstack':
+    elif provider.type == 'openstack':
         stack_data = {
             'stack_name': "stack" + fauxfactory.gen_alphanumeric()
         }
@@ -179,8 +168,7 @@ def test_provision_stack(provider_init, provider_key, provider_crud,
 
 
 @pytest.mark.meta(blockers=[1221333])
-def test_reconfigure_service(provider_init, provider_key, provider_crud,
-                        provider_type, provisioning, dialog, catalog, request):
+def test_reconfigure_service(setup_provider, provider, provisioning, dialog, catalog, request):
     """Tests stack provisioning
 
     Metadata:
@@ -191,9 +179,9 @@ def test_reconfigure_service(provider_init, provider_key, provider_crud,
     catalog_item = CatalogItem(item_type="Orchestration", name=item_name,
                   description="my catalog", display_in=True, catalog=catalog.name,
                   dialog=dialog_name, orch_template=template_name,
-                  provider_type=provider_crud.name)
+                  provider_type=provider.name)
     catalog_item.create()
-    if provider_type == 'ec2':
+    if provider.type == 'ec2':
         stack_data = {
             'stack_name': fauxfactory.gen_alphanumeric(),
             'key_name': provisioning['stack_provisioning']['key_name'],
@@ -202,7 +190,7 @@ def test_reconfigure_service(provider_init, provider_key, provider_crud,
             'db_root_password': provisioning['stack_provisioning']['db_root_password'],
             'select_instance_type': provisioning['stack_provisioning']['instance_type'],
         }
-    elif provider_type == 'openstack':
+    elif provider.type == 'openstack':
         stack_data = {
             'stack_name': fauxfactory.gen_alphanumeric()
         }
@@ -220,8 +208,7 @@ def test_reconfigure_service(provider_init, provider_key, provider_crud,
 
 
 @pytest.mark.meta(blockers=[1236932])
-def test_remove_template_provisioning(provider_init, provider_key, provider_crud,
-                        provider_type, provisioning, catalog, request):
+def test_remove_template_provisioning(setup_provider, provider, provisioning, catalog, request):
     """Tests stack provisioning
 
     Metadata:
@@ -238,13 +225,13 @@ def test_remove_template_provisioning(provider_init, provider_key, provider_crud
     catalog_item = CatalogItem(item_type="Orchestration", name=item_name,
                   description="my catalog", display_in=True, catalog=catalog.name,
                   dialog=dialog_name_new, orch_template=template.template_name,
-                  provider_type=provider_crud.name)
+                  provider_type=provider.name)
     catalog_item.create()
-    if provider_type == 'ec2':
+    if provider.type == 'ec2':
         stack_data = {
             'stack_name': "stack" + fauxfactory.gen_alphanumeric()
         }
-    elif provider_type == 'openstack':
+    elif provider.type == 'openstack':
         stack_data = {
             'stack_name': "stack" + fauxfactory.gen_alphanumeric()
         }

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -28,11 +28,10 @@ def setup_a_provider():
 
 @pytest.fixture(scope="module")
 def provision_data(
-        rest_api_modscope, provider_crud, provider_key, provider_data, small_template,
-        provider_mgmt):
+        rest_api_modscope, provider, small_template):
     templates = rest_api_modscope.collections.templates.find_by(name=small_template)
     for template in templates:
-        if template.ems.name == provider_data["name"]:
+        if template.ems.name == provider.data["name"]:
             guid = template.guid
             break
     else:
@@ -46,7 +45,7 @@ def provision_data(
             "number_of_cpus": 1,
             "vm_name": "test_rest_prov_{}".format(fauxfactory.gen_alphanumeric()),
             "vm_memory": "2048",
-            "vlan": provider_data["provisioning"]["vlan"],
+            "vlan": provider.data["provisioning"]["vlan"],
         },
         "requester": {
             "user_name": "admin",
@@ -65,14 +64,14 @@ def provision_data(
         "ems_custom_attributes": {},
         "miq_custom_attributes": {}
     }
-    if isinstance(provider_mgmt, mgmt_system.RHEVMSystem):
+    if isinstance(provider.mgmt, mgmt_system.RHEVMSystem):
         result["vm_fields"]["provision_type"] = "native_clone"
     return result
 
 
 @pytest.mark.meta(server_roles="+automate")
 @pytest.mark.usefixtures("setup_provider")
-def test_provision(request, provision_data, provider_mgmt, rest_api):
+def test_provision(request, provision_data, provider, rest_api):
     """Tests provision via REST API.
 
     Prerequisities:
@@ -89,7 +88,7 @@ def test_provision(request, provision_data, provider_mgmt, rest_api):
 
     vm_name = provision_data["vm_fields"]["vm_name"]
     request.addfinalizer(
-        lambda: provider_mgmt.delete_vm(vm_name) if provider_mgmt.does_vm_exist(vm_name) else None)
+        lambda: provider.mgmt.delete_vm(vm_name) if provider.mgmt.does_vm_exist(vm_name) else None)
     request = rest_api.collections.provision_requests.action.create(**provision_data)[0]
 
     def _finished():
@@ -99,7 +98,7 @@ def test_provision(request, provision_data, provider_mgmt, rest_api):
         return request.request_state.lower() in {"finished", "provisioned"}
 
     wait_for(_finished, num_sec=600, delay=5, message="REST provisioning finishes")
-    assert provider_mgmt.does_vm_exist(vm_name), "The VM {} does not exist!".format(vm_name)
+    assert provider.mgmt.does_vm_exist(vm_name), "The VM {} does not exist!".format(vm_name)
 
 
 def test_add_delete_service_catalog(rest_api):

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -40,19 +40,25 @@ def _setup_provider(provider_key):
 
 
 @pytest.fixture(scope='function')
-def setup_provider(provider_key):
-    """Module-scoped fixture to set up a provider"""
-    _setup_provider(provider_key)
+def setup_provider(provider):
+    """Function-scoped fixture to set up a provider"""
+    _setup_provider(provider.key)
+
+
+@pytest.fixture(scope='module')
+def setup_provider_modscope(provider):
+    """Function-scoped fixture to set up a provider"""
+    _setup_provider(provider.key)
 
 
 @pytest.fixture(scope='class')
-def setup_provider_clsscope(provider_key):
+def setup_provider_clsscope(provider):
     """Module-scoped fixture to set up a provider"""
-    _setup_provider(provider_key)
+    _setup_provider(provider.key)
 
 
 @pytest.fixture
-def setup_provider_funcscope(provider_key):
+def setup_provider_funcscope(provider):
     """Function-scoped fixture to set up a provider
 
     Note:
@@ -61,7 +67,7 @@ def setup_provider_funcscope(provider_key):
         be module-scoped the majority of the time.
 
     """
-    _setup_provider(provider_key)
+    _setup_provider(provider.key)
 
 
 @pytest.fixture(scope="session")

--- a/fixtures/virtual_machine.py
+++ b/fixtures/virtual_machine.py
@@ -8,26 +8,26 @@ from utils.wait import wait_for
 
 
 @pytest.fixture
-def verify_vm_running(provider_mgmt, vm_name):
+def verify_vm_running(provider, vm_name):
     """ Ensures that the VM/instance is in running state for the test
 
     Uses calls to the actual provider api; it will start the vm if necessary.
 
     Args:
-        provider_mgmt: :py:class:`utils.mgmt_system.MgmtSystemAPIBase` object
+        provider: Provider class object
         vm_name: Name of the VM/instance
     """
 
     def _wait_for_vm_running():
-        if provider_mgmt.is_vm_running(vm_name):
+        if provider.mgmt.is_vm_running(vm_name):
             return True
-        elif provider_mgmt.is_vm_stopped(vm_name) or \
-                provider_mgmt.can_suspend and provider_mgmt.is_vm_suspended(vm_name) or \
-                provider_mgmt.can_pause and provider_mgmt.is_vm_paused(vm_name):
-            provider_mgmt.start_vm(vm_name)
+        elif provider.mgmt.is_vm_stopped(vm_name) or \
+                provider.mgmt.can_suspend and provider.mgmt.is_vm_suspended(vm_name) or \
+                provider.mgmt.can_pause and provider.mgmt.is_vm_paused(vm_name):
+            provider.mgmt.start_vm(vm_name)
 
         logger.debug("Sleeping 15secs...(current state: {}, needed state: running)".format(
-            provider_mgmt.vm_status(vm_name)
+            provider.mgmt.vm_status(vm_name)
         ))
         return False
 
@@ -35,27 +35,27 @@ def verify_vm_running(provider_mgmt, vm_name):
 
 
 @pytest.fixture
-def verify_vm_stopped(provider_mgmt, vm_name):
+def verify_vm_stopped(provider, vm_name):
     """ Ensures that the VM/instance is stopped for the test
 
     Uses calls to the actual provider api; it will stop the vm if necessary.
 
     Args:
-        provider_mgmt: :py:class:`utils.mgmt_system.MgmtSystemAPIBase` object
+        provider: Provider class object
         vm_name: Name of the VM/instance
     """
 
     def _wait_for_vm_stopped():
-        if provider_mgmt.is_vm_stopped(vm_name):
+        if provider.mgmt.is_vm_stopped(vm_name):
             return True
-        elif provider_mgmt.is_vm_running(vm_name):
-            provider_mgmt.stop_vm(vm_name)
-        elif provider_mgmt.can_suspend and provider_mgmt.is_vm_suspended(vm_name) or \
-                provider_mgmt.can_pause and provider_mgmt.is_vm_paused(vm_name):
-            provider_mgmt.start_vm(vm_name)
+        elif provider.mgmt.is_vm_running(vm_name):
+            provider.mgmt.stop_vm(vm_name)
+        elif provider.mgmt.can_suspend and provider.mgmt.is_vm_suspended(vm_name) or \
+                provider.mgmt.can_pause and provider.mgmt.is_vm_paused(vm_name):
+            provider.mgmt.start_vm(vm_name)
 
         logger.debug("Sleeping 15secs...(current state: {}, needed state: stopped)".format(
-            provider_mgmt.vm_status(vm_name)
+            provider.mgmt.vm_status(vm_name)
         ))
         return False
 
@@ -63,27 +63,27 @@ def verify_vm_stopped(provider_mgmt, vm_name):
 
 
 @pytest.fixture
-def verify_vm_suspended(provider_mgmt, vm_name):
+def verify_vm_suspended(provider, vm_name):
     """ Ensures that the VM/instance is suspended for the test
 
     Uses calls to the actual provider api; it will suspend the vm if necessary.
 
     Args:
-        provider_mgmt: :py:class:`utils.mgmt_system.MgmtSystemAPIBase` object
+        provider.mgmt: Provider class object
         vm_name: Name of the VM/instance
     """
 
     def _wait_for_vm_suspended():
-        if provider_mgmt.is_vm_suspended(vm_name):
+        if provider.mgmt.is_vm_suspended(vm_name):
             return True
-        elif provider_mgmt.is_vm_running(vm_name):
-            provider_mgmt.suspend_vm(vm_name)
-        elif provider_mgmt.is_vm_stopped(vm_name) or \
-                provider_mgmt.can_pause and provider_mgmt.is_vm_paused(vm_name):
-            provider_mgmt.start_vm(vm_name)
+        elif provider.mgmt.is_vm_running(vm_name):
+            provider.mgmt.suspend_vm(vm_name)
+        elif provider.mgmt.is_vm_stopped(vm_name) or \
+                provider.mgmt.can_pause and provider.mgmt.is_vm_paused(vm_name):
+            provider.mgmt.start_vm(vm_name)
 
         logger.debug("Sleeping 15secs...(current state: {}, needed state: suspended)".format(
-            provider_mgmt.vm_status(vm_name)
+            provider.mgmt.vm_status(vm_name)
         ))
         return False
 
@@ -91,27 +91,27 @@ def verify_vm_suspended(provider_mgmt, vm_name):
 
 
 @pytest.fixture
-def verify_vm_paused(provider_mgmt, vm_name):
+def verify_vm_paused(provider, vm_name):
     """ Ensures that the VM/instance is paused for the test
 
     Uses calls to the actual provider api; it will pause the vm if necessary.
 
     Args:
-        provider_mgmt: :py:class:`utils.mgmt_system.MgmtSystemAPIBase` object
+        provider.mgmt: Provider class object
         vm_name: Name of the VM/instance
     """
 
     def _wait_for_vm_paused():
-        if provider_mgmt.is_vm_paused(vm_name):
+        if provider.mgmt.is_vm_paused(vm_name):
             return True
-        elif provider_mgmt.is_vm_running(vm_name):
-            provider_mgmt.pause_vm(vm_name)
-        elif provider_mgmt.is_vm_stopped(vm_name) or \
-                provider_mgmt.can_suspend and provider_mgmt.is_vm_suspended(vm_name):
-            provider_mgmt.start_vm(vm_name)
+        elif provider.mgmt.is_vm_running(vm_name):
+            provider.mgmt.pause_vm(vm_name)
+        elif provider.mgmt.is_vm_stopped(vm_name) or \
+                provider.mgmt.can_suspend and provider.mgmt.is_vm_suspended(vm_name):
+            provider.mgmt.start_vm(vm_name)
 
         logger.debug("Sleeping 15secs...(current state: {}, needed state: paused)".format(
-            provider_mgmt.vm_status(vm_name)
+            provider.mgmt.vm_status(vm_name)
         ))
         return False
 

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -145,7 +145,7 @@ def setup_a_provider(prov_class=None, prov_type=None, validate=True, check_exist
     """
     global problematic_providers
     if prov_class == "infra":
-        from cfme.infrastructure.provider import get_from_config, wait_for_provider_delete
+        from cfme.infrastructure.provider import get_from_config
         potential_providers = list_infra_providers()
         if prov_type:
             providers = []
@@ -155,7 +155,7 @@ def setup_a_provider(prov_class=None, prov_type=None, validate=True, check_exist
         else:
             providers = potential_providers
     elif prov_class == "cloud":
-        from cfme.cloud.provider import get_from_config, wait_for_provider_delete
+        from cfme.cloud.provider import get_from_config
         potential_providers = list_cloud_providers()
         if prov_type:
             providers = []


### PR DESCRIPTION
* Removed all instances of provider_init custom functions and replaced
  with the setup_provider fixture where required.
* Removed all instances of the cleanup_vm custom functions and replaced
  with a common one from provider. This was previously in the
  do_vm_provisioning function, but is now more common than just for
  provisioning.
* Rejigged do_vm_provisioning function to accept less parameters. This
  function used to require provider_crud, provider_key and provider_mgmt, it
  now only requires provider and obtains all others from the provider
  object.
* Updated provider objects from both Infrastructure and Cloud to
  inherit a BaseProvider object which has been added to the common
  provider module introduced in this commit.
* BaseProvider object gives access to mgmt, data, key, version, type in
  convenience properties.
* Updated testgen to no longer supply provider_* fixture names. This has
  been reduced to just the provider_crud object, called 'provider'. This
  object, as stated above, now has access to the mgmt, data, type and
  key data from within itself.
* Updated the setup_provider fixture to use new provider fixture.
* Rewrote analysis testgen functions to close align them with the
  functionality of all other custom testgen functions.

{{sprouts: 5}}