### PR TITLE
RBAC truly disabled unless specified

### DIFF
--- a/fixtures/rbac.py
+++ b/fixtures/rbac.py
@@ -135,6 +135,9 @@ def pytest_pyfunc_call(pyfuncitem):
         pyfuncitem: A pytest test item.
     """
     # do whatever you want before the next hook executes
+    if not enable_rbac:
+        yield
+        return
 
     # Login as the "new" user to run the test under
     global last_user


### PR DESCRIPTION
RBAC truly disabled unless specified
{{pytest: -k test_provision_from_template}}