### PR TITLE
setup_a_provider() skips on certain errors

### DIFF
--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -12,10 +12,8 @@ from utils.version import current_version
 
 @pytest.fixture(scope="module")
 def setup_first_provider():
-    providers.setup_a_provider(
-        prov_class="infra", validate=True, check_existing=True, delete_failure=True)
-    providers.setup_a_provider(
-        prov_class="cloud", validate=True, check_existing=True, delete_failure=True)
+    providers.setup_a_provider(prov_class="infra", validate=True, check_existing=True)
+    providers.setup_a_provider(prov_class="cloud", validate=True, check_existing=True)
 
 
 pytestmark = [

--- a/utils/mgmt_system/virtualcenter.py
+++ b/utils/mgmt_system/virtualcenter.py
@@ -3,6 +3,13 @@
 
 Used to communicate with providers without using CFME facilities
 """
+try:
+    # In Fedora 22, we see SSL errors when connecting to vSphere, this prevents the error.
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+except AttributeError:
+    pass
+
 import re
 from datetime import datetime
 from functools import partial

--- a/utils/virtual_machines.py
+++ b/utils/virtual_machines.py
@@ -7,6 +7,7 @@ from cfme.infrastructure.provider import get_from_config as get_infra_from_confi
 from fixtures.pytest_store import store
 from novaclient.exceptions import OverLimit as OSOverLimit
 from ovirtsdk.infrastructure.errors import RequestError as RHEVRequestError
+from ssl import SSLError
 from utils import conf
 from utils.log import logger
 from utils.mgmt_system import RHEVMSystem, VMWareSystem, EC2System, OpenstackSystem, SCVMMSystem
@@ -21,7 +22,7 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
         skip_exceptions = allow_skip.keys()
         callable_mapping = allow_skip
     elif isinstance(allow_skip, basestring) and allow_skip.lower() == "default":
-        skip_exceptions = (OSOverLimit, RHEVRequestError, VMInstanceNotCloned)
+        skip_exceptions = (OSOverLimit, RHEVRequestError, VMInstanceNotCloned, SSLError)
         callable_mapping = {}
     else:
         skip_exceptions = allow_skip


### PR DESCRIPTION
I noticed this ruined last build, that one of the vspheres was not responding therefore invoking SSLError.

{{pytest: cfme/tests/control/test_bugs.py -v --long-running}}