### PR TITLE
Debug and fix the RHOS REST provisioning test.

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -105,6 +105,8 @@ def test_provision_from_template_using_rest(
         pytest.fail(
             "Cannot find flavour {} for provider {}".format(instance_type, provider_crud.name))
 
+    print flavor_id
+
     provision_data = {
         "version": "1.1",
         "template_fields": {


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_provisioning.py -k test_provision_from_template_using_rest -s -v --long-running --use-provider openstack}}