### PR TITLE
DRY provider

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -11,27 +11,19 @@
 
 from functools import partial
 
-import ui_navigate as nav
-
-import cfme
 import cfme.fixtures.pytest_selenium as sel
-from cfme.web_ui import flash
 from cfme.web_ui import form_buttons
 from cfme.web_ui import toolbar as tb
 from cfme.common.provider import BaseProvider
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
-from cfme.exceptions import HostStatsNotContains, ProviderHasNoProperty, UnknownProviderType
-from cfme.web_ui import Region, Quadicon, Form, Select, CheckboxTree, fill, paginator
+from cfme.web_ui.menu import nav
+from cfme.web_ui import Region, Quadicon, Form, Select, fill, paginator
 from cfme.web_ui import Input
-from utils import conf
-from utils.db import cfmedb
 from utils.log import logger
 from utils.update import Updateable
-from utils.wait import wait_for, RefreshTimer
+from utils.wait import wait_for
 from utils import version
 from utils.pretty import Pretty
-from utils.signals import fire
-from utils.stats import tol_check
+
 
 # Specific Add button
 add_provider_button = form_buttons.FormButton("Add this Cloud Provider")
@@ -59,26 +51,6 @@ properties_form = Form(
         )),
         ('api_port', Input("port")),
     ])
-
-credential_form = Form(
-    fields=[
-        ('default_button', "//div[@id='auth_tabs']/ul/li/a[@href='#default']"),
-        ('default_principal', "#default_userid"),
-        ('default_secret', "#default_password"),
-        ('default_verify_secret', "#default_verify"),
-        ('amqp_button', "//div[@id='auth_tabs']/ul/li/a[@href='#amqp']"),
-        ('amqp_principal', "#amqp_userid"),
-        ('amqp_secret', "#amqp_password"),
-        ('amqp_verify_secret', "#amqp_verify"),
-        ('validate_btn', form_buttons.validate)
-    ])
-
-manage_policies_tree = CheckboxTree(
-    {
-        version.LOWEST: "//div[@id='treebox']/div/table",
-        "5.3": "//div[@id='protect_treebox']/ul"
-    }
-)
 
 details_page = Region(infoblock_type='detail')
 
@@ -119,8 +91,17 @@ class Provider(Updateable, Pretty, BaseProvider):
     """
     pretty_attrs = ['name', 'credentials', 'zone', 'key']
     STATS_TO_MATCH = ['num_template', 'num_vm']
+    string_name = "Cloud"
+    page_name = "clouds"
+    quad_name = "cloud_prov"
+    vm_name = "Instances"
+    template_name = "Images"
+    properties_form = properties_form
+    add_provider_button = add_provider_button
 
     def __init__(self, name=None, credentials=None, zone=None, key=None):
+        if not credentials:
+            credentials = {}
         self.name = name
         self.credentials = credentials
         self.zone = zone
@@ -128,337 +109,6 @@ class Provider(Updateable, Pretty, BaseProvider):
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name')}
-
-    class Credential(cfme.Credential, Updateable):
-        """Provider credentials
-
-           Args:
-             **kwargs: If using amqp type credential, amqp = True"""
-
-        def __init__(self, **kwargs):
-            super(Provider.Credential, self).__init__(**kwargs)
-            self.amqp = kwargs.get('amqp')
-
-    def _submit(self, cancel, submit_button):
-        if cancel:
-            sel.click(form_buttons.cancel)
-            # sel.wait_for_element(page.configuration_btn)
-        else:
-            sel.click(submit_button)
-            flash.assert_no_errors()
-
-    def create(self, cancel=False, validate_credentials=False):
-        """
-        Creates a provider in the UI
-
-        Args:
-           cancel (boolean): Whether to cancel out of the creation.  The cancel is done
-               after all the information present in the Provider has been filled in the UI.
-           validate_credentials (boolean): Whether to validate credentials - if True and the
-               credentials are invalid, an error will be raised.
-        """
-        sel.force_navigate('clouds_provider_new')
-        fill(properties_form, self._form_mapping(True, **self.__dict__))
-        fill(credential_form, self.credentials, validate=validate_credentials)
-        self._submit(cancel, add_provider_button)
-        fire("providers_changed")
-        if not cancel:
-            flash.assert_message_match('Cloud Providers "%s" was saved' % self.name)
-
-    def update(self, updates, cancel=False, validate_credentials=False):
-        """
-        Updates a provider in the UI.  Better to use utils.update.update context
-        manager than call this directly.
-
-        Args:
-           updates (dict): fields that are changing.
-           cancel (boolean): whether to cancel out of the update.
-        """
-
-        sel.force_navigate('clouds_provider_edit', context={'provider': self})
-        fill(properties_form, self._form_mapping(**updates))
-        fill(credential_form, updates.get('credentials', None), validate=validate_credentials)
-        self._submit(cancel, form_buttons.save)
-        name = updates['name'] or self.name
-        if not cancel:
-            flash.assert_message_match('Cloud Provider "%s" was saved' % name)
-
-    def delete(self, cancel=True):
-        """
-        Deletes a provider from CFME
-
-        Args:
-            cancel: Whether to cancel the deletion, defaults to True
-        """
-
-        sel.force_navigate('clouds_provider', context={'provider': self})
-        cfg_btn('Remove this Cloud Provider from the VMDB', invokes_alert=True)
-        sel.handle_alert(cancel=cancel)
-        fire("providers_changed")
-        if not cancel:
-            flash.assert_message_match(
-                'Delete initiated for 1 Cloud Provider from the CFME Database')
-
-    def delete_if_exists(self, *args, **kwargs):
-        """Combines ``.exists`` and ``.delete()`` as a shortcut for ``request.addfinalizer``"""
-        if self.exists:
-            self.delete(*args, **kwargs)
-
-    def validate(self, db=True):
-        """ Validates that the detail page matches the Providers information.
-
-        This method logs into the provider using the mgmt_system interface and collects
-        a set of statistics to be matched against the UI. The details page is then refreshed
-        continuously until the matching of all items is complete. A error will be raised
-        if the match is not complete within a certain defined time period.
-        """
-
-        client = self.get_mgmt_system()
-
-        # If we're not using db, make sure we are on the provider detail page
-        if not db:
-            sel.force_navigate('clouds_provider', context={'provider': self})
-
-        # Initial bullet check
-        if self._do_stats_match(client, self.STATS_TO_MATCH, db=db):
-            client.disconnect()
-            return
-        else:
-            # Set off a Refresh Relationships
-            sel.force_navigate('clouds_provider', context={'provider': self})
-            tb.select("Configuration", "Refresh Relationships and Power States", invokes_alert=True)
-            sel.handle_alert()
-
-            refresh_timer = RefreshTimer(time_for_refresh=300)
-            wait_for(self._do_stats_match,
-                     [client, self.STATS_TO_MATCH, refresh_timer],
-                     {'db': db},
-                     message="do_stats_match_db",
-                     num_sec=1000,
-                     delay=60)
-
-        client.disconnect()
-
-    def load_all_provider_instances(self):
-        """ Loads the list of instances that are running under the provider.
-
-        If it could click through the link in infoblock, returns ``True``. If it sees that the
-        number of instances is 0, it returns ``False``.
-        """
-        sel.force_navigate('clouds_provider', context={'provider': self})
-        if details_page.infoblock.text("Relationships", "Instances") == "0":
-            return False
-        else:
-            sel.click(details_page.infoblock.element("Relationships", "Instances"))
-            return True
-
-    def load_all_provider_images(self):
-        """ Loads the list of images that are available under the provider.
-
-        If it could click through the link in infoblock, returns ``True``. If it sees that the
-        number of images is 0, it returns ``False``.
-        """
-        sel.force_navigate('clouds_provider', context={'provider': self})
-        if details_page.infoblock.text("Relationships", "Images") == "0":
-            return False
-        else:
-            sel.click(details_page.infoblock.element("Relationships", "Images"))
-            return True
-
-    def refresh_provider_relationships(self):
-        """Clicks on Refresh relationships button in provider"""
-        sel.force_navigate('clouds_provider', context={"provider": self})
-        tb.select("Configuration", "Refresh Relationships and Power States", invokes_alert=True)
-        sel.handle_alert(cancel=False)
-
-    def _load_details(self):
-        if not self._on_detail_page():
-            sel.force_navigate('cloud_provider', context={'provider': self})
-
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-
-        The function first ensures that we are on the detail page for the specific provider.
-
-        Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
-        """
-        if not self._on_detail_page():
-            sel.force_navigate('clouds_provider', context={'provider': self})
-        return details_page.infoblock.text(*ident)
-
-    def _do_stats_match(self, client, stats_to_match=None, refresh_timer=None, db=True):
-        """ A private function to match a set of statistics, with a Provider.
-
-        This function checks if the list of stats match, if not, the page is refreshed.
-
-        Note: Provider mgmt_system uses the same key names as this Provider class to avoid
-            having to map keyname/attributes e.g. ``num_template``, ``num_vm``.
-
-        Args:
-            client: A provider mgmt_system instance.
-            stats_to_match: A list of key/attribute names to match.
-
-        Raises:
-            KeyError: If the host stats does not contain the specified key.
-            ProviderHasNoProperty: If the provider does not have the property defined.
-        """
-        host_stats = client.stats(*stats_to_match)
-        if not db:
-            sel.refresh()
-
-        if refresh_timer:
-            if refresh_timer.is_it_time():
-                logger.info(' Time for a refresh!')
-                sel.force_navigate('clouds_provider', context={'provider': self})
-                tb.select("Configuration", "Refresh Relationships and Power States",
-                          invokes_alert=True)
-                sel.handle_alert(cancel=False)
-                refresh_timer.reset()
-
-        for stat in stats_to_match:
-            try:
-                cfme_stat = getattr(self, stat)(db=db)
-                success, value = tol_check(host_stats[stat],
-                                           cfme_stat,
-                                           min_error=0.05,
-                                           low_val_correction=2)
-                logger.info(' Matching stat [{}], Host({}), CFME({}), '
-                    'with tolerance {} is {}'.format(stat, host_stats[stat], cfme_stat,
-                                                     value, success))
-                if not success:
-                    return False
-            except KeyError:
-                raise HostStatsNotContains("Host stats information does not contain '%s'" % stat)
-            except AttributeError:
-                raise ProviderHasNoProperty("Provider does not know how to get '%s'" % stat)
-        else:
-            return True
-
-    def _on_detail_page(self):
-        """ Returns ``True`` if on the providers detail page, ``False`` if not."""
-        return sel.is_displayed('//div[@class="dhtmlxInfoBarLabel-2"][contains(., "%s")]'
-                                % self.name)
-
-    def num_template(self, db=True):
-        """ Returns the providers number of templates, as shown on the Details page."""
-        if db:
-            ext_management_systems = cfmedb()["ext_management_systems"]
-            vms = cfmedb()["vms"]
-            truthy = True  # This is to prevent a lint error with ==True
-            temlist = list(cfmedb().session.query(vms.name)
-                           .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
-                           .filter(ext_management_systems.name == self.name)
-                           .filter(vms.template == truthy))
-            return len(temlist)
-        else:
-            return int(self.get_detail("Relationships", "Images"))
-
-    def num_vm(self, db=True):
-        """ Returns the providers number of instances, as shown on the Details page."""
-        if db:
-            ext_management_systems = cfmedb()["ext_management_systems"]
-            vms = cfmedb()["vms"]
-            falsey = False  # This is to prevent a lint error with ==False
-            vmlist = list(cfmedb().session.query(vms.name)
-                          .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
-                          .filter(ext_management_systems.name == self.name)
-                          .filter(vms.template == falsey))
-            return len(vmlist)
-        return int(self.get_detail("Relationships", "Instances"))
-
-    @property
-    def exists(self):
-        ems = cfmedb()['ext_management_systems']
-        provs = (prov[0] for prov in cfmedb().session.query(ems.name))
-        if self.name in provs:
-            return True
-        else:
-            return False
-
-    @property
-    def _all_available_policy_profiles(self):
-        pp_rows_locator = "//table/tbody/tr/td[@class='standartTreeImage']"\
-            "/img[contains(@src, 'policy_profile')]/../../td[@class='standartTreeRow']"
-        return sel.elements(pp_rows_locator)
-
-    def _is_policy_profile_row_checked(self, row):
-        return "Check" in row.find_element_by_xpath("../td[@width='16px']/img").get_attribute("src")
-
-    @property
-    def _assigned_policy_profiles(self):
-        result = set([])
-        for row in self._all_available_policy_profiles:
-            if self._is_policy_profile_row_checked(row):
-                result.add(row.text.encode("utf-8"))
-        return result
-
-    def get_assigned_policy_profiles(self):
-        """ Return a set of Policy Profiles which are available and assigned.
-
-        Returns: :py:class:`set` of :py:class:`str` of Policy Profile names
-        """
-        sel.force_navigate('clouds_provider_policy_assignment', context={'provider': self})
-        return self._assigned_policy_profiles
-
-    @property
-    def _unassigned_policy_profiles(self):
-        result = set([])
-        for row in self._all_available_policy_profiles:
-            if not self._is_policy_profile_row_checked(row):
-                result.add(row.text.encode("utf-8"))
-        return result
-
-    def get_unassigned_policy_profiles(self):
-        """ Return a set of Policy Profiles which are available but not assigned.
-
-        Returns: :py:class:`set` of :py:class:`str` of Policy Profile names
-        """
-        sel.force_navigate('clouds_provider_policy_assignment', context={'provider': self})
-        return self._unassigned_policy_profiles
-
-    def _assign_unassign_policy_profiles(self, assign, *policy_profile_names):
-        """ Assign or unassign Policy Profiles to this Provider. DRY method
-
-        Args:
-            assign: Whether this method assigns or unassigns policy profiles.
-            policy_profile_names: :py:class:`str` with Policy Profile's name. After Control/Explorer
-                coverage goes in, PolicyProfile object will be also passable.
-        """
-        sel.force_navigate('clouds_provider_policy_assignment', context={'provider': self})
-        for policy_profile in policy_profile_names:
-            if assign:
-                manage_policies_tree.check_node(policy_profile)
-            else:
-                manage_policies_tree.uncheck_node(policy_profile)
-        sel.move_to_element('#tP')
-        form_buttons.save()
-
-    def assign_policy_profiles(self, *policy_profile_names):
-        """ Assign Policy Profiles to this Provider.
-
-        Args:
-            policy_profile_names: :py:class:`str` with Policy Profile names. After Control/Explorer
-                coverage goes in, PolicyProfile objects will be also passable.
-        """
-        self._assign_unassign_policy_profiles(True, *policy_profile_names)
-
-    def unassign_policy_profiles(self, *policy_profile_names):
-        """ Unssign Policy Profiles to this Provider.
-
-        Args:
-            policy_profile_names: :py:class:`str` with Policy Profile names. After Control/Explorer
-                coverage goes in, PolicyProfile objects will be also passable.
-        """
-        self._assign_unassign_policy_profiles(False, *policy_profile_names)
-
-    def wait_for_delete(self):
-        sel.force_navigate('clouds_providers')
-        quad = Quadicon(self.name, 'cloud_prov')
-        logger.info('Waiting for a provider to delete...')
-        wait_for(lambda prov: not sel.is_displayed(prov), func_args=[quad], fail_condition=False,
-                 message="Wait provider to disappear", num_sec=1000, fail_func=sel.refresh)
 
 
 class EC2Provider(Provider):
@@ -490,26 +140,6 @@ class OpenStackProvider(Provider):
                 'ipaddress_text': kwargs.get('ip_address')}
 
 
-@fill.method((Form, Provider.Credential))
-def _fill_credential(form, cred, validate=None):
-    """How to fill in a credential (either amqp or default).  Validates the
-    credential if that option is passed in.
-    """
-    if cred.amqp:
-        fill(credential_form, {'amqp_button': True,
-                               'amqp_principal': cred.principal,
-                               'amqp_secret': cred.secret,
-                               'amqp_verify_secret': cred.verify_secret,
-                               'validate_btn': validate})
-    else:
-        fill(credential_form, {'default_principal': cred.principal,
-                               'default_secret': cred.secret,
-                               'default_verify_secret': cred.verify_secret,
-                               'validate_btn': validate})
-    if validate:
-        flash.assert_no_errors()
-
-
 def get_all_providers(do_not_navigate=False):
     """Returns list of all providers"""
     if not do_not_navigate:
@@ -524,43 +154,6 @@ def get_all_providers(do_not_navigate=False):
                 "'{}/show')]".format(link_marker)):
             providers.add(sel.get_attribute(title, "title"))
     return providers
-
-
-def get_credentials_from_config(credential_config_name):
-    creds = conf.credentials[credential_config_name]
-    return Provider.Credential(principal=creds['username'],
-                               secret=creds['password'])
-
-
-def get_from_config(provider_config_name):
-    """
-    Creates a Provider object given a yaml entry in cfme_data.
-
-    Usage:
-        get_from_config('ec2east')
-
-    Returns: A Provider object that has methods that operate on CFME
-    """
-
-    prov_config = conf.cfme_data.get('management_systems', {})[provider_config_name]
-    credentials = get_credentials_from_config(prov_config['credentials'])
-    prov_type = prov_config.get('type')
-    if prov_type == 'ec2':
-        return EC2Provider(name=prov_config['name'],
-                           region=prov_config['region'],
-                           credentials=credentials,
-                           zone=prov_config['server_zone'],
-                           key=provider_config_name)
-    elif prov_type == 'openstack':
-        return OpenStackProvider(name=prov_config['name'],
-                                 hostname=prov_config['hostname'],
-                                 ip_address=prov_config['ipaddress'],
-                                 api_port=prov_config['port'],
-                                 credentials=credentials,
-                                 zone=prov_config['server_zone'],
-                                 key=provider_config_name)
-    else:
-        raise UnknownProviderType('{} is not a known cloud provider type'.format(prov_type))
 
 
 def discover(credential, cancel=False):

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -1,12 +1,65 @@
+from functools import partial
+
 from utils import conf
 from cfme.exceptions import (
-    ProviderHasNoKey
+    ProviderHasNoKey, HostStatsNotContains, ProviderHasNoProperty
 )
-from utils.providers import provider_factory
+import cfme
+from cfme.web_ui import flash, Quadicon, CheckboxTree, Region, fill, Form, Input
+from cfme.web_ui import toolbar as tb
+from cfme.web_ui import form_buttons
+import cfme.fixtures.pytest_selenium as sel
+from utils.browser import ensure_browser_open
+from utils.db import cfmedb
 from utils.log import logger
+from utils.signals import fire
+from utils.wait import wait_for, RefreshTimer
+from utils.stats import tol_check
+from utils.update import Updateable
+from utils import version
+
+
+cfg_btn = partial(tb.select, 'Configuration')
+
+manage_policies_tree = CheckboxTree(
+    {
+        version.LOWEST: "//div[@id='treebox']/div/table",
+        "5.3": "//div[@id='protect_treebox']/ul"
+    }
+)
+
+details_page = Region(infoblock_type='detail')
+
+credential_form = Form(
+    fields=[
+        ('default_button', "//div[@id='auth_tabs']/ul/li/a[@href='#default']"),
+        ('default_principal', "#default_userid"),
+        ('default_secret', "#default_password"),
+        ('default_verify_secret', "#default_verify"),
+        ('amqp_button', "//div[@id='auth_tabs']/ul/li/a[@href='#amqp']"),
+        ('amqp_principal', "#amqp_userid"),
+        ('amqp_secret', "#amqp_password"),
+        ('amqp_verify_secret', "#amqp_verify"),
+        ('candu_button', "//div[@id='auth_tabs']/ul/li/a[@href='#metrics']"),
+        ('candu_principal', Input("metrics_userid")),
+        ('candu_secret', Input("metrics_password")),
+        ('candu_verify_secret', Input("metrics_verify")),
+        ('validate_btn', form_buttons.validate)
+    ])
 
 
 class BaseProvider(object):
+    class Credential(cfme.Credential, Updateable):
+        """Provider credentials
+
+           Args:
+             **kwargs: If using amqp type credential, amqp = True"""
+
+        def __init__(self, **kwargs):
+            super(BaseProvider.Credential, self).__init__(**kwargs)
+            self.amqp = kwargs.get('amqp')
+            self.candu = kwargs.get('candu')
+            self.domain = kwargs.get('domain')
 
     @property
     def data(self):
@@ -35,14 +88,401 @@ class BaseProvider(object):
             raise ProviderHasNoKey('Provider %s has no key, so cannot get yaml data', self.name)
 
     def get_mgmt_system(self):
-        """ Returns the mgmt_system using the :py:func:`utils.providers.provider_factory` method.
+        """ Returns the mgmt_system using the :py:func:`utils.providers.get_mgmt` method.
         """
-        if hasattr(self, 'provider_data') and self.provider_data is not None:
-            return provider_factory(self.provider_data)
-        elif self.key is not None:
-            return provider_factory(self.key)
+        # gotta stash this in here to prevent circular imports
+        from utils.providers import get_mgmt
+
+        if self.key:
+            return get_mgmt(self.key)
+        elif getattr(self, 'provider_data', None):
+            return get_mgmt(self.provider_data)
         else:
             raise ProviderHasNoKey('Provider %s has no key, so cannot get mgmt system')
+
+    def _submit(self, cancel, submit_button):
+        if cancel:
+            form_buttons.cancel()
+            # sel.wait_for_element(page.configuration_btn)
+        else:
+            submit_button()
+            flash.assert_no_errors()
+
+    def create(self, cancel=False, validate_credentials=False):
+        """
+        Creates a provider in the UI
+
+        Args:
+           cancel (boolean): Whether to cancel out of the creation.  The cancel is done
+               after all the information present in the Provider has been filled in the UI.
+           validate_credentials (boolean): Whether to validate credentials - if True and the
+               credentials are invalid, an error will be raised.
+        """
+        sel.force_navigate('{}_provider_new'.format(self.page_name))
+        fill(self.properties_form, self._form_mapping(True, **self.__dict__))
+        for cred in self.credentials:
+            fill(credential_form, self.credentials[cred], validate=validate_credentials)
+        self._submit(cancel, self.add_provider_button)
+        fire("providers_changed")
+        if not cancel:
+            flash.assert_message_match('{} Providers "{}" was saved'.format(self.string_name,
+                                                                            self.name))
+
+    def update(self, updates, cancel=False, validate_credentials=False):
+        """
+        Updates a provider in the UI.  Better to use utils.update.update context
+        manager than call this directly.
+
+        Args:
+           updates (dict): fields that are changing.
+           cancel (boolean): whether to cancel out of the update.
+        """
+
+        sel.force_navigate('{}_provider_edit'.format(self.page_name), context={'provider': self})
+        fill(self.properties_form, self._form_mapping(**updates))
+        for cred in self.credentials:
+            fill(credential_form, updates.get('credentials', {}).get(cred, None),
+                 validate=validate_credentials)
+        self._submit(cancel, form_buttons.save)
+        name = updates['name'] or self.name
+        if not cancel:
+            flash.assert_message_match('{} Provider "{}" was saved'.format(self.string_name, name))
+
+    def delete(self, cancel=True):
+        """
+        Deletes a provider from CFME
+
+        Args:
+            cancel: Whether to cancel the deletion, defaults to True
+        """
+
+        sel.force_navigate('{}_provider'.format(self.page_name), context={'provider': self})
+        cfg_btn('Remove this {} Provider from the VMDB'.format(self.string_name),
+            invokes_alert=True)
+        sel.handle_alert(cancel=cancel)
+        fire("providers_changed")
+        if not cancel:
+            flash.assert_message_match(
+                'Delete initiated for 1 {} Provider from the CFME Database'.format(
+                    self.string_name))
+
+    def delete_if_exists(self, *args, **kwargs):
+        """Combines ``.exists`` and ``.delete()`` as a shortcut for ``request.addfinalizer``"""
+        if self.exists:
+            self.delete(*args, **kwargs)
+
+    def wait_for_creds_ok(self):
+        """Waits for provider's credentials to become O.K. (circumvents the summary rails exc.)"""
+        self.refresh_provider_relationships(from_list_view=True)
+
+        def _wait_f():
+            sel.force_navigate("{}_providers".format(self.page_name))
+            q = Quadicon(self.name, self.quad_name)
+            creds = q.creds
+            return creds == "checkmark"
+
+        wait_for(_wait_f, num_sec=300, delay=5, message="credentials of {} ok!".format(self.name))
+
+    def validate(self, db=True):
+        """ Validates that the detail page matches the Providers information.
+
+        This method logs into the provider using the mgmt_system interface and collects
+        a set of statistics to be matched against the UI. The details page is then refreshed
+        continuously until the matching of all items is complete. A error will be raised
+        if the match is not complete within a certain defined time period.
+        """
+
+        client = self.get_mgmt_system()
+
+        # If we're not using db, make sure we are on the provider detail page
+        if not db:
+            sel.force_navigate('{}_provider'.format(self.page_name), context={'provider': self})
+
+        # Initial bullet check
+        if self._do_stats_match(client, self.STATS_TO_MATCH, db=db):
+            client.disconnect()
+            return
+        else:
+            # Set off a Refresh Relationships
+            sel.force_navigate('{}_provider'.format(self.page_name), context={'provider': self})
+            tb.select("Configuration", "Refresh Relationships and Power States", invokes_alert=True)
+            sel.handle_alert()
+
+            refresh_timer = RefreshTimer(time_for_refresh=300)
+            wait_for(self._do_stats_match,
+                     [client, self.STATS_TO_MATCH, refresh_timer],
+                     {'db': db},
+                     message="do_stats_match_db",
+                     num_sec=1000,
+                     delay=60)
+
+        client.disconnect()
+
+    def _do_stats_match(self, client, stats_to_match=None, refresh_timer=None, db=True):
+        """ A private function to match a set of statistics, with a Provider.
+
+        This function checks if the list of stats match, if not, the page is refreshed.
+
+        Note: Provider mgmt_system uses the same key names as this Provider class to avoid
+            having to map keyname/attributes e.g. ``num_template``, ``num_vm``.
+
+        Args:
+            client: A provider mgmt_system instance.
+            stats_to_match: A list of key/attribute names to match.
+
+        Raises:
+            KeyError: If the host stats does not contain the specified key.
+            ProviderHasNoProperty: If the provider does not have the property defined.
+        """
+        host_stats = client.stats(*stats_to_match)
+        if not db:
+            sel.refresh()
+
+        if refresh_timer:
+            if refresh_timer.is_it_time():
+                logger.info(' Time for a refresh!')
+                sel.force_navigate('{}_provider'.format(self.page_name), context={'provider': self})
+                tb.select("Configuration", "Refresh Relationships and Power States",
+                          invokes_alert=True)
+                sel.handle_alert(cancel=False)
+                refresh_timer.reset()
+
+        for stat in stats_to_match:
+            try:
+                cfme_stat = getattr(self, stat)(db=db)
+                success, value = tol_check(host_stats[stat],
+                                           cfme_stat,
+                                           min_error=0.05,
+                                           low_val_correction=2)
+                logger.info(' Matching stat [{}], Host({}), CFME({}), '
+                    'with tolerance {} is {}'.format(stat, host_stats[stat], cfme_stat,
+                                                     value, success))
+                if not success:
+                    return False
+            except KeyError:
+                raise HostStatsNotContains("Host stats information does not contain '%s'" % stat)
+            except AttributeError:
+                raise ProviderHasNoProperty("Provider does not know how to get '%s'" % stat)
+        else:
+            return True
+
+    def num_template(self, db=True):
+        """ Returns the providers number of templates, as shown on the Details page."""
+        if db:
+            ext_management_systems = cfmedb()["ext_management_systems"]
+            vms = cfmedb()["vms"]
+            truthy = True  # This is to prevent a lint error with ==True
+            temlist = list(cfmedb().session.query(vms.name)
+                           .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                           .filter(ext_management_systems.name == self.name)
+                           .filter(vms.template == truthy))
+            return len(temlist)
+        else:
+            return int(self.get_detail("Relationships", self.template_name))
+
+    def num_vm(self, db=True):
+        """ Returns the providers number of instances, as shown on the Details page."""
+        if db:
+            ext_management_systems = cfmedb()["ext_management_systems"]
+            vms = cfmedb()["vms"]
+            falsey = False  # This is to prevent a lint error with ==False
+            vmlist = list(cfmedb().session.query(vms.name)
+                          .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                          .filter(ext_management_systems.name == self.name)
+                          .filter(vms.template == falsey))
+            return len(vmlist)
+        return int(self.get_detail("Relationships", self.vm_name))
+
+    @property
+    def exists(self):
+        ems = cfmedb()['ext_management_systems']
+        provs = (prov[0] for prov in cfmedb().session.query(ems.name))
+        if self.name in provs:
+            return True
+        else:
+            return False
+
+    def wait_for_delete(self):
+        sel.force_navigate('{}_providers'.format(self.page_name))
+        quad = Quadicon(self.name, self.quad_name)
+        logger.info('Waiting for a provider to delete...')
+        wait_for(lambda prov: not sel.is_displayed(prov), func_args=[quad], fail_condition=False,
+                 message="Wait provider to disappear", num_sec=1000, fail_func=sel.refresh)
+
+    def assign_policy_profiles(self, *policy_profile_names):
+        """ Assign Policy Profiles to this Provider.
+
+        Args:
+            policy_profile_names: :py:class:`str` with Policy Profile names. After Control/Explorer
+                coverage goes in, PolicyProfile objects will be also passable.
+        """
+        self._assign_unassign_policy_profiles(True, *policy_profile_names)
+
+    def unassign_policy_profiles(self, *policy_profile_names):
+        """ Unssign Policy Profiles to this Provider.
+
+        Args:
+            policy_profile_names: :py:class:`str` with Policy Profile names. After Control/Explorer
+                coverage goes in, PolicyProfile objects will be also passable.
+        """
+        self._assign_unassign_policy_profiles(False, *policy_profile_names)
+
+    def _assign_unassign_policy_profiles(self, assign, *policy_profile_names):
+        """ Assign or unassign Policy Profiles to this Provider. DRY method
+
+        See :py:func:`assign_policy_profiles` and :py:func:`assign_policy_profiles`
+
+        Args:
+            assign: Whether this method assigns or unassigns policy profiles.
+            policy_profile_names: :py:class:`str` with Policy Profile's name. After Control/Explorer
+                coverage goes in, PolicyProfile object will be also passable.
+        """
+        sel.force_navigate('{}_provider_policy_assignment'.format(self.page_name),
+            context={'provider': self})
+        for policy_profile in policy_profile_names:
+            if assign:
+                manage_policies_tree.check_node(policy_profile)
+            else:
+                manage_policies_tree.uncheck_node(policy_profile)
+        sel.move_to_element('#tP')
+        form_buttons.save()
+
+    @property
+    def _assigned_policy_profiles(self):
+        result = set([])
+        for row in self._all_available_policy_profiles:
+            if self._is_policy_profile_row_checked(row):
+                result.add(row.text.encode("utf-8"))
+        return result
+
+    def get_assigned_policy_profiles(self):
+        """ Return a set of Policy Profiles which are available and assigned.
+
+        Returns: :py:class:`set` of :py:class:`str` of Policy Profile names
+        """
+        sel.force_navigate('{}_provider_policy_assignment'.format(self.page_name),
+            context={'provider': self})
+        return self._assigned_policy_profiles
+
+    @property
+    def _unassigned_policy_profiles(self):
+        result = set([])
+        for row in self._all_available_policy_profiles:
+            if not self._is_policy_profile_row_checked(row):
+                result.add(row.text.encode("utf-8"))
+        return result
+
+    def get_unassigned_policy_profiles(self):
+        """ Return a set of Policy Profiles which are available but not assigned.
+
+        Returns: :py:class:`set` of :py:class:`str` of Policy Profile names
+        """
+        sel.force_navigate('{}_provider_policy_assignment'.format(self.page_name),
+            context={'provider': self})
+        return self._unassigned_policy_profiles
+
+    @property
+    def _all_available_policy_profiles(self):
+        pp_rows_locator = "//table/tbody/tr/td[@class='standartTreeImage']"\
+            "/img[contains(@src, 'policy_profile')]/../../td[@class='standartTreeRow']"
+        return sel.elements(pp_rows_locator)
+
+    def _is_policy_profile_row_checked(self, row):
+        return "Check" in row.find_element_by_xpath("../td[@width='16px']/img").get_attribute("src")
+
+    def refresh_provider_relationships(self, from_list_view=False):
+        """Clicks on Refresh relationships button in provider"""
+        if from_list_view:
+            sel.force_navigate("{}_providers".format(self.page_name))
+            sel.check(Quadicon(self.name, self.quad_name).checkbox())
+        else:
+            sel.force_navigate('{}_provider'.format(self.page_name), context={"provider": self})
+        tb.select("Configuration", "Refresh Relationships and Power States", invokes_alert=True)
+        sel.handle_alert(cancel=False)
+
+    def _load_details(self):
+        if not self._on_detail_page():
+            sel.force_navigate('{}_provider'.format(self.page_name), context={'provider': self})
+
+    def get_detail(self, *ident):
+        """ Gets details from the details infoblock
+
+        The function first ensures that we are on the detail page for the specific provider.
+
+        Args:
+            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
+        Returns: A string representing the contents of the InfoBlock's value.
+        """
+        self._load_details()
+        return details_page.infoblock.text(*ident)
+
+    def load_all_provider_instances(self):
+        self.load_all_provider_vms()
+
+    def load_all_provider_vms(self):
+        """ Loads the list of instances that are running under the provider.
+
+        If it could click through the link in infoblock, returns ``True``. If it sees that the
+        number of instances is 0, it returns ``False``.
+        """
+        sel.force_navigate('{}_provider'.format(self.page_name), context={'provider': self})
+        if details_page.infoblock.text("Relationships", self.vm_name) == "0":
+            return False
+        else:
+            sel.click(details_page.infoblock.element("Relationships", self.vm_name))
+            return True
+
+    def load_all_provider_images(self):
+        self.load_all_provider_templates()
+
+    def load_all_provider_templates(self):
+        """ Loads the list of images that are available under the provider.
+
+        If it could click through the link in infoblock, returns ``True``. If it sees that the
+        number of images is 0, it returns ``False``.
+        """
+        sel.force_navigate('{}_provider'.format(self.page_name), context={'provider': self})
+        if details_page.infoblock.text("Relationships", self.template_name) == "0":
+            return False
+        else:
+            sel.click(details_page.infoblock.element("Relationships", self.template_name))
+            return True
+
+    def _on_detail_page(self):
+        """ Returns ``True`` if on the providers detail page, ``False`` if not."""
+        ensure_browser_open()
+        return sel.is_displayed(
+            '//div[@class="dhtmlxInfoBarLabel-2"][contains(., "%s (Summary)")]' % self.name)
+
+
+@fill.method((Form, BaseProvider.Credential))
+def _fill_credential(form, cred, validate=None):
+    """How to fill in a credential (either amqp or default).  Validates the
+    credential if that option is passed in.
+    """
+    if cred.amqp:
+        fill(credential_form, {'amqp_button': True,
+                               'amqp_principal': cred.principal,
+                               'amqp_secret': cred.secret,
+                               'amqp_verify_secret': cred.verify_secret,
+                               'validate_btn': validate})
+    elif cred.candu:
+        fill(credential_form, {'candu_button': True,
+                               'candu_principal': cred.principal,
+                               'candu_secret': cred.secret,
+                               'candu_verify_secret': cred.verify_secret,
+                               'validate_btn': validate})
+    else:
+        if cred.domain:
+            principal = r'{}\{}'.format(cred.domain, cred.principal)
+        else:
+            principal = cred.principal
+        fill(credential_form, {'default_principal': principal,
+                               'default_secret': cred.secret,
+                               'default_verify_secret': cred.verify_secret,
+                               'validate_btn': validate})
+    if validate:
+        flash.assert_no_errors()
 
 
 def cleanup_vm(vm_name, provider):

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -7,10 +7,10 @@
 
 import ui_navigate as nav
 from cfme.fixtures import pytest_selenium as sel
-from cfme.infrastructure import provider
 from cfme.web_ui import Quadicon, Region, listaccordion as list_acc, paginator, toolbar as tb
 from functools import partial
 from utils.pretty import Pretty
+from utils.providers import get_crud
 from utils.wait import wait_for
 
 details_page = Region(infoblock_type='detail')
@@ -50,7 +50,7 @@ class Cluster(Pretty):
     def __init__(self, name=None, provider_key=None):
         self.name = name
         if provider_key:
-            self.provider = provider.get_from_config(provider_key)
+            self.provider = get_crud(provider_key)
         else:
             self.provider = None
 

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -11,10 +11,10 @@ import cfme.web_ui.menu  # noqa
 
 from cfme.exceptions import CandidateNotFound
 from cfme.fixtures import pytest_selenium as sel
-from cfme.infrastructure import provider
 from cfme.web_ui import Quadicon, Region, listaccordion as list_acc, toolbar as tb, paginator as pg
 from functools import partial
 from utils.pretty import Pretty
+from utils.providers import get_crud
 from utils.wait import wait_for
 from utils import version
 
@@ -56,7 +56,7 @@ class Datastore(Pretty):
     def __init__(self, name=None, provider_key=None):
         self.name = name
         if provider_key:
-            self.provider = provider.get_from_config(provider_key)
+            self.provider = get_crud(provider_key)
         else:
             self.provider = None
 

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -11,20 +11,13 @@
 
 from functools import partial
 
-import ui_navigate as nav
-
-import cfme
 from utils.db import cfmedb
 import cfme.fixtures.pytest_selenium as sel
 from cfme.infrastructure.host import Host
-import cfme.web_ui.flash as flash
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
+from cfme.web_ui.menu import nav
 import cfme.web_ui.toolbar as tb
 from cfme.common.provider import BaseProvider
 import utils.conf as conf
-from cfme.exceptions import (
-    HostStatsNotContains, ProviderHasNoProperty, UnknownProviderType
-)
 from cfme.web_ui import (
     Region, Quadicon, Form, Select, CheckboxTree, fill, form_buttons, paginator, Input
 )
@@ -32,11 +25,10 @@ from cfme.web_ui.form_buttons import FormButton
 from utils.browser import ensure_browser_open
 from utils.log import logger
 from utils.update import Updateable
-from utils.wait import wait_for, RefreshTimer
+from utils.wait import wait_for
 from utils import version
 from utils.pretty import Pretty
-from utils.signals import fire
-from utils.stats import tol_check
+
 
 add_infra_provider = FormButton("Add this Infrastructure Provider")
 
@@ -65,19 +57,6 @@ properties_form = Form(
         ('api_port', Input("port")),
         ('sec_protocol', Select("select#security_protocol")),
         ('sec_realm', Input("realm"))
-    ])
-
-credential_form = Form(
-    fields=[
-        ('default_button', "//div[@id='auth_tabs']/ul/li/a[@href='#default']"),
-        ('default_principal', Input("default_userid")),
-        ('default_secret', Input("default_password")),
-        ('default_verify_secret', Input("default_verify")),
-        ('candu_button', "//div[@id='auth_tabs']/ul/li/a[@href='#metrics']"),
-        ('candu_principal', Input("metrics_userid")),
-        ('candu_secret', Input("metrics_password")),
-        ('candu_verify_secret', Input("metrics_verify")),
-        ('validate_btn', form_buttons.validate)
     ])
 
 manage_policies_tree = CheckboxTree(
@@ -127,246 +106,32 @@ class Provider(Updateable, Pretty, BaseProvider):
     """
     pretty_attrs = ['name', 'key', 'zone']
     STATS_TO_MATCH = ['num_template', 'num_vm', 'num_datastore', 'num_host', 'num_cluster']
+    string_name = "Infrastructure"
+    page_name = "infrastructure"
+    quad_name = "infra_prov"
+    vm_name = "VMs"
+    template_name = "Templates"
+    properties_form = properties_form
+    add_provider_button = add_infra_provider
 
     def __init__(
-            self, name=None, credentials=None, key=None, zone=None, candu=None, provider_data=None):
+            self, name=None, credentials=None, key=None, zone=None, provider_data=None):
+        if not credentials:
+            credentials = {}
         self.name = name
         self.credentials = credentials
         self.key = key
         self.provider_data = provider_data
         self.zone = zone
-        self.candu = candu
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name')}
-
-    class Credential(cfme.Credential, Updateable):
-        """Provider credentials
-
-           Args:
-             **kwargs: If using C & U database type credential, candu = True"""
-
-        def __init__(self, **kwargs):
-            super(Provider.Credential, self).__init__(**kwargs)
-            self.candu = kwargs.get('candu')
-
-    def _submit(self, cancel, submit_button):
-        if cancel:
-            form_buttons.cancel()
-            # sel.wait_for_element(page.configuration_btn)
-        else:
-            submit_button()
-            flash.assert_no_errors()
-
-    def create(self, cancel=False, validate_credentials=False):
-        """
-        Creates a provider in the UI
-
-        Args:
-           cancel (boolean): Whether to cancel out of the creation.  The cancel is done
-               after all the information present in the Provider has been filled in the UI.
-           validate_credentials (boolean): Whether to validate credentials - if True and the
-               credentials are invalid, an error will be raised.
-        """
-        sel.force_navigate('infrastructure_provider_new')
-        fill(properties_form, self._form_mapping(True, **self.__dict__))
-        fill(credential_form, self.credentials, validate=validate_credentials)
-        fill(credential_form, self.candu, validate=validate_credentials)
-        self._submit(cancel, add_infra_provider)
-        fire("providers_changed")
-        if not cancel:
-            flash.assert_message_match('Infrastructure Providers "%s" was saved' % self.name)
-
-    def update(self, updates, cancel=False, validate_credentials=False):
-        """
-        Updates a provider in the UI.  Better to use utils.update.update context
-        manager than call this directly.
-
-        Args:
-           updates (dict): fields that are changing.
-           cancel (boolean): whether to cancel out of the update.
-        """
-
-        sel.force_navigate('infrastructure_provider_edit', context={'provider': self})
-        fill(properties_form, self._form_mapping(**updates))
-        fill(credential_form, updates.get('credentials', None), validate=validate_credentials)
-        fill(credential_form, updates.get('candu', None), validate=validate_credentials)
-        self._submit(cancel, form_buttons.save)
-        name = updates['name'] or self.name
-        if not cancel:
-            flash.assert_message_match('Infrastructure Provider "%s" was saved' % name)
-
-    def delete(self, cancel=True):
-        """
-        Deletes a provider from CFME
-
-        Args:
-            cancel: Whether to cancel the deletion, defaults to True
-        """
-
-        sel.force_navigate('infrastructure_provider', context={'provider': self})
-        cfg_btn('Remove this Infrastructure Provider from the VMDB', invokes_alert=True)
-        sel.handle_alert(cancel=cancel)
-        fire("providers_changed")
-        if not cancel:
-            flash.assert_message_match(
-                'Delete initiated for 1 Infrastructure Provider from the CFME Database')
-
-    def wait_for_creds_ok(self):
-        """Waits for provider's credentials to become O.K. (circumvents the summary rails exc.)"""
-        self.refresh_provider_relationships(from_list_view=True)
-
-        def _wait_f():
-            sel.force_navigate("infrastructure_providers")
-            q = Quadicon(self.name, "infra_prov")
-            creds = q.creds
-            return creds == "checkmark"
-
-        wait_for(_wait_f, num_sec=300, delay=5, message="credentials of {} ok!".format(self.name))
-
-    def validate(self, db=True):
-        """ Validates that the detail page matches the Providers information.
-
-        This method logs into the provider using the mgmt_system interface and collects
-        a set of statistics to be matched against the UI. The details page is then refreshed
-        continuously until the matching of all items is complete. A error will be raised
-        if the match is not complete within a certain defined time period.
-        """
-        # Wait for credentials to become OK to prevent the error in some 5.4 builds
-        self.wait_for_creds_ok()
-
-        client = self.get_mgmt_system()
-
-        # If we're not using db, make sure we are on the provider detail page
-        if not db:
-            sel.force_navigate('infrastructure_provider', context={'provider': self})
-
-        # Initial bullet check
-        if self._do_stats_match(client, self.STATS_TO_MATCH, db=db):
-            client.disconnect()
-            return
-        else:
-            # Set off a Refresh Relationships
-            sel.force_navigate('infrastructure_provider', context={'provider': self})
-            tb.select("Configuration", "Refresh Relationships and Power States", invokes_alert=True)
-            sel.handle_alert()
-
-            refresh_timer = RefreshTimer(time_for_refresh=300)
-            wait_for(self._do_stats_match,
-                     [client, self.STATS_TO_MATCH, refresh_timer],
-                     {'db': db},
-                     message="do_stats_match_db",
-                     num_sec=1000,
-                     delay=60)
-
-        client.disconnect()
-
-    def refresh_provider_relationships(self, from_list_view=False):
-        """Clicks on Refresh relationships button in provider"""
-        if from_list_view:
-            sel.force_navigate("infrastructure_providers")
-            sel.check(Quadicon(self.name, "infra_prov").checkbox())
-        else:
-            sel.force_navigate('infrastructure_provider', context={"provider": self})
-        tb.select("Configuration", "Refresh Relationships and Power States", invokes_alert=True)
-        sel.handle_alert(cancel=False)
-
-    def _load_details(self):
-        if not self._on_detail_page():
-            sel.force_navigate('infrastructure_provider', context={'provider': self})
-
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-
-        The function first ensures that we are on the detail page for the specific provider.
-
-        Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
-        """
-        self._load_details()
-        return details_page.infoblock.text(*ident)
-
-    def _do_stats_match(self, client, stats_to_match=None, refresh_timer=None, db=True):
-        """ A private function to match a set of statistics, with a Provider.
-
-        This function checks if the list of stats match, if not, the page is refreshed.
-
-        Note: Provider mgmt_system uses the same key names as this Provider class to avoid
-            having to map keyname/attributes e.g. ``num_template``, ``num_vm``.
-
-        Args:
-            client: A provider mgmt_system instance.
-            stats_to_match: A list of key/attribute names to match.
-
-        Raises:
-            KeyError: If the host stats does not contain the specified key.
-            ProviderHasNoProperty: If the provider does not have the property defined.
-        """
-        host_stats = client.stats(*stats_to_match)
-        if not db:
-            sel.refresh()
-
-        if refresh_timer:
-            if refresh_timer.is_it_time():
-                logger.info(' Time for a refresh!')
-                sel.force_navigate('infrastructure_provider', context={'provider': self})
-                tb.select("Configuration", "Refresh Relationships and Power States",
-                          invokes_alert=True)
-                sel.handle_alert(cancel=False)
-                refresh_timer.reset()
-
-        for stat in stats_to_match:
-            try:
-                cfme_stat = getattr(self, stat)(db=db)
-                success, value = tol_check(host_stats[stat],
-                                           cfme_stat,
-                                           min_error=0.05,
-                                           low_val_correction=2)
-                logger.info(' Matching stat [{}], Host({}), CFME({}), '
-                    'with tolerance {} is {}'.format(stat, host_stats[stat], cfme_stat,
-                                                     value, success))
-                if not success:
-                    return False
-            except KeyError:
-                raise HostStatsNotContains("Host stats information does not contain '%s'" % stat)
-            except AttributeError:
-                raise ProviderHasNoProperty("Provider does not know how to get '%s'" % stat)
-        else:
-            return True
 
     def _on_detail_page(self):
         """ Returns ``True`` if on the providers detail page, ``False`` if not."""
         ensure_browser_open()
         return sel.is_displayed(
             '//div[@class="dhtmlxInfoBarLabel-2"][contains(., "%s (Summary)")]' % self.name)
-
-    def num_template(self, db=True):
-        """ Returns the providers number of templates, as shown on the Details page."""
-        if db:
-            ext_management_systems = cfmedb()["ext_management_systems"]
-            vms = cfmedb()["vms"]
-            truthy = True  # This is to prevent a lint error with ==True
-            temlist = list(cfmedb().session.query(vms.name)
-                           .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
-                           .filter(ext_management_systems.name == self.name)
-                           .filter(vms.template == truthy))
-            return len(temlist)
-        else:
-            return int(self.get_detail("Relationships", "Templates"))
-
-    def num_vm(self, db=True):
-        """ Returns the providers number of instances, as shown on the Details page."""
-        if db:
-            ext_management_systems = cfmedb()["ext_management_systems"]
-            vms = cfmedb()["vms"]
-            falsey = False  # This is to prevent a lint error with ==False
-            vmlist = list(cfmedb().session.query(vms.name)
-                          .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
-                          .filter(ext_management_systems.name == self.name)
-                          .filter(vms.template == falsey))
-            return len(vmlist)
-        return int(self.get_detail("Relationships", "VMs"))
 
     def num_datastore(self, db=True):
         """ Returns the providers number of templates, as shown on the Details page."""
@@ -412,22 +177,13 @@ class Provider(Updateable, Pretty, BaseProvider):
         Begins provider discovery from a provider instance
 
         Usage:
-            discover_from_config(provider.get_from_config('rhevm'))
+            discover_from_config(utils.providers.get_crud('rhevm'))
         """
         vmware = isinstance(self, VMwareProvider)
         rhevm = isinstance(self, RHEVMProvider)
         scvmm = isinstance(self, SCVMMProvider)
         discover(rhevm, vmware, scvmm, cancel=False, start_ip=self.start_ip,
                  end_ip=self.end_ip)
-
-    @property
-    def exists(self):
-        ems = cfmedb()['ext_management_systems']
-        provs = (prov[0] for prov in cfmedb().session.query(ems.name))
-        if self.name in provs:
-            return True
-        else:
-            return False
 
     @property
     def hosts(self):
@@ -444,59 +200,6 @@ class Provider(Updateable, Pretty, BaseProvider):
             )
             result.append(Host(name=host["name"], credentials=cred))
         return result
-
-    def load_all_provider_vms(self):
-        """ Loads the list of VMs that are running under the provider. """
-        sel.force_navigate('infrastructure_provider', context={'provider': self})
-        sel.click(details_page.infoblock.element("Relationships", "VMs"))
-
-    def load_all_provider_templates(self):
-        """ Loads the list of templates that are running under the provider. """
-        sel.force_navigate('infrastructure_provider', context={'provider': self})
-        sel.click(details_page.infoblock.element("Relationships", "Templates"))
-
-    def assign_policy_profiles(self, *policy_profile_names):
-        """ Assign Policy Profiles to this Provider.
-
-        Args:
-            policy_profile_names: :py:class:`str` with Policy Profile names. After Control/Explorer
-                coverage goes in, PolicyProfile objects will be also passable.
-        """
-        self._assign_unassign_policy_profiles(True, *policy_profile_names)
-
-    def unassign_policy_profiles(self, *policy_profile_names):
-        """ Unssign Policy Profiles to this Provider.
-
-        Args:
-            policy_profile_names: :py:class:`str` with Policy Profile names. After Control/Explorer
-                coverage goes in, PolicyProfile objects will be also passable.
-        """
-        self._assign_unassign_policy_profiles(False, *policy_profile_names)
-
-    def _assign_unassign_policy_profiles(self, assign, *policy_profile_names):
-        """DRY function for managing policy profiles.
-
-        See :py:func:`assign_policy_profiles` and :py:func:`assign_policy_profiles`
-
-        Args:
-            assign: Wheter to assign or unassign.
-            policy_profile_names: :py:class:`str` with Policy Profile names.
-        """
-        sel.force_navigate('infrastructure_provider_policy_assignment', context={'provider': self})
-        for policy_profile in policy_profile_names:
-            if assign:
-                manage_policies_tree.check_node(policy_profile)
-            else:
-                manage_policies_tree.uncheck_node(policy_profile)
-        sel.move_to_element('#tP')
-        form_buttons.save()
-
-    def wait_for_delete(self):
-        sel.force_navigate('infrastructure_providers')
-        quad = Quadicon(self.name, 'infra_prov')
-        logger.info('Waiting for a provider to delete...')
-        wait_for(lambda prov: not sel.is_displayed(prov), func_args=[quad], fail_condition=False,
-                 message="Wait provider to disappear", num_sec=1000, fail_func=sel.refresh)
 
 
 class VMwareProvider(Provider):
@@ -523,8 +226,8 @@ class SCVMMProvider(Provider):
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, sec_protocol=None, sec_realm=None,
                  provider_data=None):
-        super(SCVMMProvider, self).__init__(name=name, credentials=credentials, zone=zone, key=key,
-            provider_data=provider_data)
+        super(SCVMMProvider, self).__init__(name=name, credentials=credentials,
+            zone=zone, key=key, provider_data=provider_data)
 
         self.hostname = hostname
         self.ip_address = ip_address
@@ -554,16 +257,10 @@ class SCVMMProvider(Provider):
 
         return values
 
-    class Credential(Provider.Credential):
-        # SCVMM needs to deal with domain
-        def __init__(self, **kwargs):
-            self.domain = kwargs.pop('domain', None)
-            super(SCVMMProvider.Credential, self).__init__(**kwargs)
-
 
 class RHEVMProvider(Provider):
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
-                 ip_address=None, api_port=None, start_ip=None, end_ip=None, candu=None,
+                 ip_address=None, api_port=None, start_ip=None, end_ip=None,
                  provider_data=None):
         super(RHEVMProvider, self).__init__(name=name, credentials=credentials,
                                             zone=zone, key=key, provider_data=provider_data)
@@ -573,7 +270,6 @@ class RHEVMProvider(Provider):
         self.api_port = api_port
         self.start_ip = start_ip
         self.end_ip = end_ip
-        self.candu = candu
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name'),
@@ -581,41 +277,6 @@ class RHEVMProvider(Provider):
                 'hostname_text': kwargs.get('hostname'),
                 'api_port': kwargs.get('api_port'),
                 'ipaddress_text': kwargs.get('ip_address')}
-
-
-@fill.method((Form, Provider.Credential))
-def _fill_credential(form, cred, validate=None):
-    """How to fill in a credential (either candu or default).  Validates the
-    credential if that option is passed in.
-    """
-    if cred.candu:
-        fill(credential_form, {'candu_button': True,
-                               'candu_principal': cred.principal,
-                               'candu_secret': cred.secret,
-                               'candu_verify_secret': cred.verify_secret,
-                               'validate_btn': validate})
-    else:
-        fill(credential_form, {'default_principal': cred.principal,
-                               'default_secret': cred.secret,
-                               'default_verify_secret': cred.verify_secret,
-                               'validate_btn': validate})
-    if validate:
-        flash.assert_no_errors()
-
-
-@fill.method((Form, SCVMMProvider.Credential))
-def _fill_scvmm_credential(form, cred, validate=None):
-    fill(
-        credential_form,
-        {
-            'default_principal': r'{}\{}'.format(cred.domain, cred.principal),
-            'default_secret': cred.secret,
-            'default_verify_secret': cred.verify_secret,
-            'validate_btn': validate
-        }
-    )
-    if validate:
-        flash.assert_no_errors()
 
 
 def get_all_providers(do_not_navigate=False):
@@ -632,78 +293,6 @@ def get_all_providers(do_not_navigate=False):
                 "'{}/show')]".format(link_marker)):
             providers.add(sel.get_attribute(title, "title"))
     return providers
-
-
-def get_credentials_from_config(credential_config_name):
-    creds = conf.credentials[credential_config_name]
-    return Provider.Credential(principal=creds['username'],
-                               secret=creds['password'])
-
-
-def get_from_config(provider_config_name):
-    """
-    Creates a Provider object given a yaml entry in cfme_data.
-
-    Usage:
-        get_from_config('rhevm32')
-
-    Returns: A Provider object that has methods that operate on CFME
-    """
-
-    prov_config = conf.cfme_data.get('management_systems', {})[provider_config_name]
-    credentials = get_credentials_from_config(prov_config['credentials'])
-    prov_type = prov_config.get('type')
-
-    if prov_config.get('discovery_range', None):
-        start_ip = prov_config['discovery_range']['start']
-        end_ip = prov_config['discovery_range']['end']
-    else:
-        start_ip = prov_config['ipaddress']
-        end_ip = prov_config['ipaddress']
-
-    if prov_type == 'virtualcenter':
-        return VMwareProvider(name=prov_config['name'],
-                              hostname=prov_config['hostname'],
-                              ip_address=prov_config['ipaddress'],
-                              credentials=credentials,
-                              zone=prov_config['server_zone'],
-                              key=provider_config_name,
-                              start_ip=start_ip,
-                              end_ip=end_ip)
-    elif prov_type == 'scvmm':
-        creds = conf.credentials[prov_config['credentials']]
-        credentials = SCVMMProvider.Credential(
-            principal=creds['username'],
-            secret=creds['password'],
-            domain=creds['domain'],)
-        return SCVMMProvider(
-            name=prov_config['name'],
-            hostname=prov_config['hostname'],
-            ip_address=prov_config['ipaddress'],
-            credentials=credentials,
-            key=provider_config_name,
-            start_ip=start_ip,
-            end_ip=end_ip,
-            sec_protocol=prov_config['sec_protocol'],
-            sec_realm=prov_config['sec_realm'])
-    elif prov_type == 'rhevm':
-        if prov_config.get('candu_credentials', None):
-            candu_credentials = get_credentials_from_config(prov_config['candu_credentials'])
-            candu_credentials.candu = True
-        else:
-            candu_credentials = None
-        return RHEVMProvider(name=prov_config['name'],
-                             hostname=prov_config['hostname'],
-                             ip_address=prov_config['ipaddress'],
-                             api_port='',
-                             credentials=credentials,
-                             candu=candu_credentials,
-                             zone=prov_config['server_zone'],
-                             key=provider_config_name,
-                             start_ip=start_ip,
-                             end_ip=end_ip)
-    else:
-        raise UnknownProviderType('{} is not a known infra provider type'.format(prov_type))
 
 
 def discover(rhevm=False, vmware=False, scvmm=False, cancel=False, start_ip=None, end_ip=None):

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -7,10 +7,10 @@
 
 import ui_navigate as nav
 from cfme.fixtures import pytest_selenium as sel
-from cfme.infrastructure import provider
 from cfme.web_ui import Quadicon, Region, toolbar as tb
 from functools import partial
 from utils.pretty import Pretty
+from utils.providers import get_crud
 from utils.wait import wait_for
 
 details_page = Region(infoblock_type='detail')
@@ -43,7 +43,7 @@ class ResourcePool(Pretty):
     def __init__(self, name=None, provider_key=None):
         self.name = name
         if provider_key:
-            self.provider = provider.get_from_config(provider_key)
+            self.provider = get_crud(provider_key)
         else:
             self.provider = None
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -9,9 +9,10 @@ import pytest
 import cfme.web_ui.flash as flash
 import utils.error as error
 from cfme import Credential
-from cfme.cloud.provider import (discover, EC2Provider, get_credentials_from_config,
-    wait_for_a_provider, Provider, OpenStackProvider)
+from cfme.cloud.provider import (discover, EC2Provider, wait_for_a_provider,
+    Provider, OpenStackProvider)
 from utils import testgen, version
+from utils.providers import get_credentials_from_config
 from utils.update import update
 
 pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="function")
@@ -65,7 +66,7 @@ def test_provider_add_with_bad_credentials(provider):
     Metadata:
         test_flag: crud
     """
-    provider.credentials = get_credentials_from_config('bad_credentials')
+    provider.credentials['default'] = get_credentials_from_config('bad_credentials')
     with error.expected('Login failed due to a bad username or password.'):
         provider.create(validate_credentials=True)
 

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -6,9 +6,10 @@ not be difficult to extend the parametrizer.
 import pytest
 import random
 
-from cfme.infrastructure.provider import VMwareProvider, get_from_config
+from cfme.infrastructure.provider import VMwareProvider
 from utils.conf import cfme_data, credentials
 from utils.net import resolve_hostname
+from utils.providers import get_crud
 from utils.version import Version
 from utils.wait import wait_for
 
@@ -56,7 +57,7 @@ def pytest_generate_tests(metafunc):
             name=host["name"],
             hostname=host["name"],
             ip_address=ip_address,
-            credentials=cred,
+            credentials={'default': cred},
             provider_data=provider_data,
         )
         arg_values.append([host_provider, provider_data, provider_key])
@@ -66,7 +67,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.yield_fixture(scope="module")
 def setup_provider(provider, original_provider_key):
-    original_provider = get_from_config(original_provider_key)
+    original_provider = get_crud(original_provider_key)
     if original_provider.exists:
         # Delete original provider's hosts first
         for host in original_provider.hosts:

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -6,9 +6,10 @@ import pytest
 
 import cfme.web_ui.flash as flash
 import utils.error as error
-from cfme.infrastructure.provider import (discover, Provider, VMwareProvider,
-    get_credentials_from_config, RHEVMProvider, wait_for_a_provider)
+from cfme.infrastructure.provider import (discover, Provider, VMwareProvider, RHEVMProvider,
+    wait_for_a_provider)
 from utils import testgen, providers, version
+from utils.providers import get_credentials_from_config
 from utils.update import update
 
 
@@ -143,7 +144,7 @@ def test_provider_add_with_bad_credentials(provider):
     Metadata:
         test_flag: crud
     """
-    provider.credentials = get_credentials_from_config('bad_credentials')
+    provider.credentials['default'] = get_credentials_from_config('bad_credentials')
     if isinstance(provider, VMwareProvider):
         with error.expected('Cannot complete login due to an incorrect user name or password.'):
             provider.create(validate_credentials=True)

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -6,7 +6,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.provider import Provider, details_page
 from cfme.intelligence.reports.reports import CannedSavedReport
 from utils.net import ip_address, resolve_hostname
-from utils.providers import provider_factory_by_name, setup_a_provider as _setup_a_provider
+from utils.providers import get_mgmt_by_name, setup_a_provider as _setup_a_provider
 
 provider_props = partial(details_page.infoblock.text, "Properties")
 
@@ -52,7 +52,7 @@ def test_cluster_relationships(soft_assert, setup_a_provider):
         if not provider_name.strip():
             # If no provider name specified, ignore it
             continue
-        provider = provider_factory_by_name(provider_name)
+        provider = get_mgmt_by_name(provider_name)
         host_name = relation["Host Name"].strip()
         soft_assert(name in provider.list_cluster(), "Cluster {} not found in {}".format(
             name, provider_name

--- a/cfme/tests/intelligence/reports/test_report_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_report_corresponds.py
@@ -6,7 +6,7 @@ from random import sample
 import utils
 from cfme.intelligence.reports.reports import CustomReport
 from utils import version
-from utils.providers import provider_factory_by_name, setup_a_provider
+from utils.providers import get_mgmt_by_name, setup_a_provider
 from utils.version import since_date_or_version
 
 
@@ -69,7 +69,7 @@ def test_custom_vm_report(soft_assert, report_vms):
             version.LOWEST: "Provider : Name",
             "5.3": "Cloud/Infrastructure Provider Name",
         })]
-        provider = provider_factory_by_name(provider_name)
+        provider = get_mgmt_by_name(provider_name)
         provider_hosts_and_ips = utils.net.resolve_ips(provider.list_host())
         provider_datastores = provider.list_datastore()
         provider_clusters = provider.list_cluster()

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -6,7 +6,7 @@ import pytest
 from cfme.configure.configuration import server_roles_disabled
 
 from utils import error, mgmt_system, testgen
-from utils.providers import setup_a_provider as _setup_a_provider, provider_factory
+from utils.providers import setup_a_provider as _setup_a_provider, get_mgmt
 from utils.version import current_version
 from utils.virtual_machines import deploy_template
 from utils.wait import wait_for
@@ -181,7 +181,7 @@ def test_provider_refresh(request, setup_a_provider, rest_api):
     """
     if "refresh" not in rest_api.collections.providers.action.all:
         pytest.skip("Refresh action is not implemented in this version")
-    provider_mgmt = provider_factory(setup_a_provider.key)
+    provider_mgmt = get_mgmt(setup_a_provider.key)
     provider = rest_api.collections.providers.find_by(name=setup_a_provider.name)[0]
     with server_roles_disabled("ems_inventory", "ems_operations"):
         vm_name = deploy_template(
@@ -274,7 +274,7 @@ def test_provider_crud(request, rest_api, from_detail):
 def vm(request, setup_a_provider, rest_api):
     if "refresh" not in rest_api.collections.providers.action.all:
         pytest.skip("Refresh action is not implemented in this version")
-    provider_mgmt = provider_factory(setup_a_provider.key)
+    provider_mgmt = get_mgmt(setup_a_provider.key)
     provider = rest_api.collections.providers.find_by(name=setup_a_provider.name)[0]
     vm_name = deploy_template(
         setup_a_provider.key,

--- a/fixtures/mgmt_system.py
+++ b/fixtures/mgmt_system.py
@@ -35,7 +35,7 @@ def mgmt_sys_api_clients(cfme_data, uses_providers):
     """Returns a list of management system api clients"""
     clients = {}
     for provider_key in cfme_data['management_systems']:
-        clients[provider_key] = providers.provider_factory(provider_key)
+        clients[provider_key] = providers.get_mgmt(provider_key)
     return clients
 
 

--- a/scripts/appliance_spring.py
+++ b/scripts/appliance_spring.py
@@ -21,7 +21,7 @@ class Queue(pretty.Pretty):
         self.template_name = template_name
         self.max_size = max_size
         self.shutdown_flag = False
-        self.provider = providers.provider_factory(self.provider_name)
+        self.provider = providers.get_mgmt(self.provider_name)
 
     def vm_generator(self):
         '''Generates unique Vm definitions for this queue'''
@@ -141,7 +141,7 @@ def manage_all_queues(target_providers):
 
     '''
     init()
-    provs = {(p, providers.provider_factory(p)) for p in target_providers}
+    provs = {(p, providers.get_mgmt(p)) for p in target_providers}
     global queues
     queues = set()
     template_re = re.compile("autoqueue-(\d+)")

--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from threading import Lock, Thread
 
 from utils.log import logger
-from utils.providers import list_all_providers, provider_factory
+from utils.providers import list_all_providers, get_mgmt
 
 lock = Lock()
 
@@ -42,7 +42,7 @@ def process_provider_vms(provider_key, matchers, delta, vms_to_delete):
         print '%s processing' % provider_key
     try:
         now = datetime.datetime.now()
-        provider = provider_factory(provider_key)
+        provider = get_mgmt(provider_key)
         for vm_name in provider.list_vm():
             if not match(matchers, vm_name):
                 continue
@@ -103,7 +103,7 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
         print 'No VMs to delete.'
 
     for provider_key, vm_set in vms_to_delete.items():
-        provider = provider_factory(provider_key)
+        provider = get_mgmt(provider_key)
         for vm_name, __ in vm_set:
             print 'Deleting %s on %s' % (vm_name, provider_key)
             try:

--- a/scripts/cleanup_openstack_fips.py
+++ b/scripts/cleanup_openstack_fips.py
@@ -10,13 +10,13 @@ If no providers specified, it will cleanup all of them.
 import sys
 from traceback import format_exc
 
-from utils.providers import list_providers, provider_factory
+from utils.providers import list_providers, get_mgmt
 
 
 def main(*providers):
     for provider_key in list_providers('openstack'):
         print 'Checking {}'.format(provider_key)
-        api = provider_factory(provider_key).api
+        api = get_mgmt(provider_key).api
         try:
             fips = api.floating_ips.findall(fixed_ip=None)
         except Exception:

--- a/scripts/cleanup_openstack_volumes.py
+++ b/scripts/cleanup_openstack_volumes.py
@@ -12,7 +12,7 @@ import iso8601
 import tzlocal
 from datetime import datetime, timedelta
 
-from utils.providers import list_providers, provider_factory
+from utils.providers import list_providers, get_mgmt
 
 local_tz = tzlocal.get_localzone()
 GRACE_TIME = timedelta(hours=2)
@@ -21,7 +21,7 @@ GRACE_TIME = timedelta(hours=2)
 def main(*providers):
     for provider_key in providers:
         print "Cleaning up", provider_key
-        api = provider_factory(provider_key).capi
+        api = get_mgmt(provider_key).capi
         try:
             volumes = api.volumes.findall(attachments=[])
         except Exception as e:

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -8,7 +8,7 @@ import sys
 from utils.appliance import Appliance
 from utils.conf import cfme_data
 from utils.log import logger
-from utils.providers import destroy_vm, provider_factory
+from utils.providers import destroy_vm, get_mgmt
 from utils.wait import wait_for
 
 
@@ -51,8 +51,8 @@ def main():
 
     args = parser.parse_args()
 
-    # provider_factory validates, since it will explode without an existing key or type
-    provider = provider_factory(args.provider)
+    # get_mgmt validates, since it will explode without an existing key or type
+    provider = get_mgmt(args.provider)
     provider_dict = cfme_data['management_systems'][args.provider]
     provider_type = provider_dict['type']
 

--- a/scripts/connect_directlun.py
+++ b/scripts/connect_directlun.py
@@ -5,7 +5,7 @@
 
 import argparse
 import sys
-from utils.providers import provider_factory
+from utils.providers import get_mgmt
 
 
 def main():
@@ -16,7 +16,7 @@ def main():
     parser.add_argument('--remove', help='remove disk from vm', action="store_true")
     args = parser.parse_args()
 
-    provider = provider_factory(args.provider_name)
+    provider = get_mgmt(args.provider_name)
 
     provider.connect_direct_lun_to_appliance(args.vm_name, args.remove)
 

--- a/scripts/provider_usage.py
+++ b/scripts/provider_usage.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python2
 from collections import defaultdict
-from utils.providers import provider_factory
+from utils.providers import get_mgmt
 from utils.conf import cfme_data, jenkins
 from utils import appliance
 from jinja2 import Environment, FileSystemLoader
@@ -59,7 +59,7 @@ for prov in li:
     ip = li[prov].get('ipaddress', None)
     prov_key_db[ip] = prov
     if li[prov]['type'] not in ['ec2', 'scvmm']:
-        mgmt = provider_factory(prov)
+        mgmt = get_mgmt(prov)
         print "DOING {}".format(prov)
         process_provider(mgmt, prov)
 

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -21,11 +21,11 @@ import argparse
 import os
 import sys
 
-# Make sure the parent dir is on the path before importing provider_factory
+# Make sure the parent dir is on the path before importing get_mgmt
 cfme_tests_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, cfme_tests_path)
 
-from utils.providers import provider_factory
+from utils.providers import get_mgmt
 
 
 def main():
@@ -69,7 +69,7 @@ def main():
 def call_provider(provider_name, action, *args):
     # Given a provider class, find the named method and call it with
     # *args. This could possibly be generalized for other CLI tools.
-    provider = provider_factory(provider_name)
+    provider = get_mgmt(provider_name)
 
     try:
         call = getattr(provider, action)

--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -9,7 +9,7 @@ from slumber.exceptions import SlumberHttpBaseException
 
 from utils import trackerbot
 from utils.conf import cfme_data
-from utils.providers import list_all_providers, provider_factory
+from utils.providers import list_all_providers, get_mgmt
 
 
 def main(trackerbot_url, mark_usable=None):
@@ -106,7 +106,7 @@ def main(trackerbot_url, mark_usable=None):
 
 def get_provider_templates(provider_key, template_providers, unresponsive_providers, thread_lock):
     # functionalized to make it easy to farm this out to threads
-    provider_mgmt = provider_factory(provider_key)
+    provider_mgmt = get_mgmt(provider_key)
     try:
         if cfme_data['management_systems'][provider_key]['type'] == 'ec2':
             # dirty hack to filter out ec2 public images, because there are literally hundreds.

--- a/scripts/toggle_vm.py
+++ b/scripts/toggle_vm.py
@@ -15,7 +15,7 @@ import argparse
 import sys
 import time
 
-from utils.providers import provider_factory
+from utils.providers import get_mgmt
 
 
 def main():
@@ -32,7 +32,7 @@ def main():
     args = parser.parse_args()
 
     # Make sure the VM is off to start
-    provider = provider_factory(args.provider_name)
+    provider = get_mgmt(args.provider_name)
 
     if provider.is_vm_running(args.vm_name):
         provider.stop_vm(args.vm_name)
@@ -56,7 +56,7 @@ def main():
                     start_success = True
                     provider.disconnect()
                     time.sleep(args.uptime)
-                    provider = provider_factory(args.provider_name)
+                    provider = get_mgmt(args.provider_name)
                 except Exception:
                     time.sleep(60)
                     times_failed_counter += 1
@@ -76,7 +76,7 @@ def main():
                     stop_success = True
                     provider.disconnect()
                     time.sleep(args.downtime)
-                    provider = provider_factory(args.provider_name)
+                    provider = get_mgmt(args.provider_name)
                 except Exception:
                     time.sleep(60)
                     times_failed_counter += 1

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -14,7 +14,7 @@ from sprout.log import create_logger
 from utils import mgmt_system
 from utils.appliance import Appliance as CFMEAppliance, IPAppliance
 from utils.conf import cfme_data
-from utils.providers import provider_factory
+from utils.providers import get_mgmt
 from utils.timeutil import nice_seconds
 from utils.version import Version
 
@@ -106,7 +106,7 @@ class Provider(MetadataMixin):
 
     @property
     def api(self):
-        return provider_factory(self.id)
+        return get_mgmt(self.id)
 
     @property
     def num_currently_provisioning(self):

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -24,7 +24,7 @@ from sprout.log import create_logger
 
 from utils.appliance import Appliance as CFMEAppliance
 from utils.path import project_path
-from utils.providers import provider_factory
+from utils.providers import get_mgmt
 from utils.timeutil import parsetime
 from utils.trackerbot import api, parse_template
 
@@ -1134,25 +1134,25 @@ def wait_appliance_ready(self, appliance_id):
 
 @singleton_task()
 def anyvm_power_on(self, provider, vm):
-    provider = provider_factory(provider)
+    provider = get_mgmt(provider)
     provider.start_vm(vm)
 
 
 @singleton_task()
 def anyvm_power_off(self, provider, vm):
-    provider = provider_factory(provider)
+    provider = get_mgmt(provider)
     provider.stop_vm(vm)
 
 
 @singleton_task()
 def anyvm_suspend(self, provider, vm):
-    provider = provider_factory(provider)
+    provider = get_mgmt(provider)
     provider.suspend_vm(vm)
 
 
 @singleton_task()
 def anyvm_delete(self, provider, vm):
-    provider = provider_factory(provider)
+    provider = get_mgmt(provider)
     provider.delete_vm(vm)
 
 

--- a/sprout/appliances/views.py
+++ b/sprout/appliances/views.py
@@ -18,7 +18,7 @@ from appliances.tasks import (appliance_power_on, appliance_power_off, appliance
     appliance_rename)
 
 from sprout.log import create_logger
-from utils.providers import provider_factory
+from utils.providers import get_mgmt
 
 add_to_builtins('appliances.templatetags.appliances_extras')
 
@@ -507,20 +507,20 @@ def vms(request, current_provider=None):
 def vms_table(request, current_provider=None):
     if not request.user.is_authenticated():
         return go_home(request)
-    manager = provider_factory(current_provider)
+    manager = get_mgmt(current_provider)
     vms = sorted(manager.list_vm())
     return render(request, 'appliances/vms/_list.html', locals())
 
 
 def power_state(request, current_provider):
     vm_name = request.POST["vm_name"]
-    manager = provider_factory(current_provider)
+    manager = get_mgmt(current_provider)
     state = Appliance.POWER_STATES_MAPPING.get(manager.vm_status(vm_name), "unknown")
     return HttpResponse(state, content_type="text/plain")
 
 
 def power_state_buttons(request, current_provider):
-    manager = provider_factory(current_provider)
+    manager = get_mgmt(current_provider)
     vm_name = request.POST["vm_name"]
     power_state = request.POST["power_state"]
     can_power_on = power_state in {Appliance.Power.SUSPENDED, Appliance.Power.OFF}
@@ -534,7 +534,7 @@ def vm_action(request, current_provider):
     if not request.user.is_authenticated():
         return HttpResponse("Not authenticated", content_type="text/plain")
     try:
-        provider_factory(current_provider)
+        get_mgmt(current_provider)
     except Exception as e:
         return HttpResponse(
             "Troubles with provider {}: {}".format(current_provider, str(e)),

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -17,7 +17,6 @@ from urlparse import ParseResult, urlparse
 import requests
 
 from cfme.configure.configuration import server_name, server_id
-from cfme.infrastructure.provider import get_from_config
 from cfme.infrastructure.virtual_machines import Vm
 from fixtures import ui_coverage
 from fixtures.pytest_store import _push_appliance, _pop_appliance, store
@@ -26,7 +25,7 @@ from utils.log import logger, create_sublogger
 from utils.mgmt_system import RHEVMSystem, VMWareSystem
 from utils.net import net_check, resolve_hostname
 from utils.path import data_path, scripts_path
-from utils.providers import provider_factory
+from utils.providers import get_mgmt, get_crud
 from utils.version import Version, get_stream, LATEST
 from utils.signals import fire
 from utils.wait import wait_for
@@ -75,7 +74,7 @@ class Appliance(object):
         Note:
             Cannot be cached because provider object is unpickable.
         """
-        return provider_factory(self._provider_name)
+        return get_mgmt(self._provider_name)
 
     @property
     def vm_name(self):
@@ -246,7 +245,7 @@ class Appliance(object):
 
             # if rhev, set relationship
             if self.is_on_rhev:
-                vm = Vm(self.vm_name, get_from_config(self._provider_name))
+                vm = Vm(self.vm_name, get_crud(self._provider_name))
                 cfme_rel = Vm.CfmeRelationship(vm)
                 cfme_rel.set_relationship(str(server_name()), server_id())
 
@@ -1663,7 +1662,7 @@ def provision_appliance(version=None, vm_name_prefix='cfme', template=None, prov
 
     prov_data = conf.cfme_data.get('management_systems', {})[provider_name]
 
-    provider = provider_factory(provider_name)
+    provider = get_mgmt(provider_name)
     if not vm_name:
         vm_name = _generate_vm_name()
 

--- a/utils/events.py
+++ b/utils/events.py
@@ -10,10 +10,10 @@ from py.path import local
 from cfme.automate.explorer import Namespace, Instance, Class, Domain
 from cfme.control.import_export import import_file, is_imported
 from cfme.exceptions import AutomateImportError
-from cfme.infrastructure.provider import get_from_config
 from cfme.web_ui import flash
 from utils import version
 from utils.log import logger
+from utils.providers import get_crud
 
 ALL_EVENTS = [
     ('Datastore Analysis Complete', 'datastore_analysis_complete'),
@@ -247,7 +247,7 @@ def setup_for_event_testing(ssh_client, db, listener_info, providers):
 
     # ASSIGN POLICY PROFILES
     for provider in providers:
-        prov_obj = get_from_config(provider)
+        prov_obj = get_crud(provider)
         if not prov_obj.exists:
             prov_obj.create()
         prov_obj.assign_policy_profiles("Automate event policies")

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -85,8 +85,7 @@ More information on ``parametrize`` can be found in pytest's documentation:
 import pytest
 import random
 
-from cfme.cloud.provider import get_from_config as get_cloud_provider
-from cfme.infrastructure.provider import get_from_config as get_infra_provider
+from cfme.exceptions import UnknownProviderType
 from cfme.infrastructure.pxe import get_pxe_server_from_config
 from fixtures.prov_filter import filtered
 from fixtures.templateloader import TEMPLATES
@@ -95,7 +94,7 @@ from utils import version
 from utils.conf import cfme_data
 from utils.log import logger
 from utils.providers import (
-    cloud_provider_type_map, infra_provider_type_map, provider_type_map)
+    cloud_provider_type_map, infra_provider_type_map, provider_type_map, get_crud)
 
 
 def generate(gen_func, *args, **kwargs):
@@ -238,11 +237,9 @@ def provider_by_type(metafunc, provider_types, *fields, **options):
         argnames.append('provider')
 
     for provider, data in cfme_data.get('management_systems', {}).iteritems():
-        if data['type'] in cloud_provider_type_map:
-            prov_obj = get_cloud_provider(provider)
-        elif data['type'] in infra_provider_type_map:
-            prov_obj = get_infra_provider(provider)
-        else:
+        try:
+            prov_obj = get_crud(provider)
+        except UnknownProviderType:
             continue
 
         skip = False

--- a/utils/virtual_machines.py
+++ b/utils/virtual_machines.py
@@ -2,17 +2,14 @@
 """
 import pytest
 
-from cfme.cloud.provider import get_from_config as get_cloud_from_config
-from cfme.infrastructure.provider import get_from_config as get_infra_from_config
+from utils.providers import get_crud
 from fixtures.pytest_store import store
 from novaclient.exceptions import OverLimit as OSOverLimit
 from ovirtsdk.infrastructure.errors import RequestError as RHEVRequestError
 from ssl import SSLError
-from utils import conf
 from utils.log import logger
 from utils.mgmt_system import RHEVMSystem, VMWareSystem, EC2System, OpenstackSystem, SCVMMSystem
 from utils.mgmt_system.exceptions import VMInstanceNotCloned
-from utils.providers import infra_provider_type_map
 
 
 def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **deploy_args):
@@ -27,11 +24,7 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
     else:
         skip_exceptions = allow_skip
         callable_mapping = {}
-    provider_type = conf.cfme_data.get('management_systems', {})[provider_key]['type']
-    if provider_type in infra_provider_type_map:
-        provider_crud = get_infra_from_config(provider_key)
-    else:
-        provider_crud = get_cloud_from_config(provider_key)
+    provider_crud = get_crud(provider_key)
 
     mgmt = provider_crud.get_mgmt_system()
     data = provider_crud.get_yaml_data()


### PR DESCRIPTION
The efforts in this PR are to try and consolidate and unify the provider
classes to have a single base class. This has meant multiple changes to
existing files and some new methodology.

* credential_form has been moved to the common/provider.py file and has
  been augmented with all cloud and infra credential types
* Infra and Cloud now have their own base classes which set up certain
  base attributes to assist in making the right decisions when it comes to
  string naming, quadicon matching and forms.
* create, update, delete, delete_if_exists, validate, load_all_*
  refresh_provider_relationships, get_detail, _do_stats_match,
  num_template, num_vm, exists, wait_for_delete and all policy methods
  have been removed from both the Infra/Cloud provider class and have been
  moved into the common class.
* SCVMM custom fill method has been removed and functionality for
  handling the special domain has been incorporated into the other fill
  functions.
* get_from_config and get_credentials_from_config no longer exist in the
  provider modules and are now called get_crud and
  get_credentials_from_config and live in the utils.providers
  module. These are special in that they now are no longer class
  specific. get_from_config will return an Infra or Cloud object,
  depending on the key of the provider loaded.
* Big change in how credentials are passed into the provider
  objects. Previously there was a credentials attribute which stored the
  "default" credentials and then other attributes that stored credentials
  like amqp and candu. This prevented the unification of the provider
  classes. To combat this, the providers credentials attribute is now a
  dict. The credentials key name is actually not important as the
  credential object still has the attributes that denote it's type, ie
  candu and the forms are handled accordingly. As a result, all tests that
  "add" or mess with credentials will need to be aware of this change. The
  "update" methods seem to work fine with the dict credentials
  approach. This _has_ been tested, but if you find any issues, please let
  us know.
* utils.providers.provider_factory function has been renamed get_mgmt to
  provider better specificity and bring it inline with the other methods.