### PR TITLE
Improved RHOS floating IP behaviour

### DIFF
--- a/utils/mgmt_system/exceptions.py
+++ b/utils/mgmt_system/exceptions.py
@@ -15,6 +15,10 @@ class MultipleImagesError(Exception):
     pass
 
 
+class NoMoreFloatingIPs(Exception):
+    """Raised when provider runs out of FIPs."""
+
+
 class MultipleInstancesError(Exception):
     def __init__(self, value):
         self.value = value


### PR DESCRIPTION
* When the instance is deleted, it also tries to delete the associated floating IP.
* When an instance is created, it looks for free floating IPs in the pool, reusing them. There is a 'gap threshold' of 1 FIP because I did not discover any race condition prevention mechanism that would eg. raise an exception when you try to reassign an already assigned FIP. If there is 1 or 0 FIPs, it creates a new one, if there are 2 or more, it reuses one from them.

Test sample (`tail -f log/cfme.log` for the messages):
```python
from utils.providers import provider_factory
p = provider_factory(some_rhos)
# We suppose there are no free FIPs at this moment
vm = p.deploy_template("cirros", floating_ip_pool="public", network_name="private")
# Terminate it in the RHOS UI directly so the floating IP stays
# It should write that it allocated a new one (0 -> 1 FIPs)
vm = p.deploy_template("cirros", floating_ip_pool="public", network_name="private")
# Terminate it in the RHOS UI directly so the floating IP stays
# It should write that it allocated a new one (1 -> 2 FIPs, that is the (crude) race condition safety threshold)
vm = p.deploy_template("cirros", floating_ip_pool="public", network_name="private")
# It should write that it took one from the pool public
p.delete_vm(vm)
# It should state that it deleted the attached FIP (2 -> 1 FIPs)
```