### PR TITLE
use SIGQUIT instead of USR2 to stop master/slaves

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -131,7 +131,7 @@ def handle_end_session(signal, frame):
     # when signaled, end the current test session immediately
     if store.parallel_session:
         store.parallel_session.session_finished = True
-signal.signal(signal.SIGUSR2, handle_end_session)
+signal.signal(signal.SIGQUIT, handle_end_session)
 
 
 class SlaveDict(dict):


### PR DESCRIPTION
It wasn't really necessary to use USR2 to tell the parallelizer workers to quit, considering SIGQUIT is a thing that already exists, so I switched the signal handler. While I was in there, I added the ability to break a slave out of its runtest loop and shut down.