### PR TITLE
[WIP][NO TEST] Sprout - Correctly delete pool after salvaging appliances

### DIFF
--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -895,6 +895,14 @@ class AppliancePool(MetadataMixin):
                         "The appliance was taken out of dying pool {}".format(self.id))
                 else:
                     Appliance.kill(appliance)
+
+            if self.current_count == 0:
+                # Pool is empty, no point of keeping it alive.
+                # This is needed when deleting a pool that has appliances that can be salvaged.
+                # They are not deleted. the .delete() method on appliances takes care that when the
+                # last appliance in pool is deleted, it deletes the pool. But since we don't delete
+                # in the case of salvaging them, we do have to do it manually here.
+                self.delete()
         else:
             # No appliances, so just delete it
             self.delete()


### PR DESCRIPTION
The code that deletes the pool when pool is killed is placed in Appliance's .delete() method. That ensures that when the last appliance in the pool gets deleted, the pool gets deleted with it. However when we kill an unfinished pool and the appliances are salvaged, this obviously does not happen when the appliances are put in shepherd. So an additional check is required.