### PR TITLE
Ensure the message is a string in art_log

### DIFF
--- a/utils/log.py
+++ b/utils/log.py
@@ -445,6 +445,10 @@ class ArtifactorLoggerAdapter(logging.LoggerAdapter):
         return SLAVEID or ""
 
     def art_log(self, level_name, message, kwargs):
+        if not isinstance(message, basestring):
+            # INTERNALERROR>     'message': message.encode("ascii", "xmlcharrefreplace"),
+            # INTERNALERROR> AttributeError: ReprExceptionInfo instance has no attribute 'encode'
+            message = str(message)
         art_log_record = {
             'level': level_name,
             'message': message.encode("ascii", "xmlcharrefreplace"),


### PR DESCRIPTION
There was some opposition against casting the message as string if it is not a string but it looks I had a good idea.

{{pytest: -v -k "test_display_name_unset_from_ui and instance"  --long-running}}