### PR TITLE
load_all_provider_instances must return bool

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -417,7 +417,7 @@ class BaseProvider(object):
         return details_page.infoblock.text(*ident)
 
     def load_all_provider_instances(self):
-        self.load_all_provider_vms()
+        return self.load_all_provider_vms()
 
     def load_all_provider_vms(self):
         """ Loads the list of instances that are running under the provider.


### PR DESCRIPTION
Apparently during provider unification, a return was forgotten, making some cloud tests fail because they expect boolean with success as a return value.