### PR TITLE
Fix infra tile and list default view

### DIFF
--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -113,6 +113,8 @@ def test_tile_defaultview(request, setup_a_provider, key):
     default_view = get_default_view(name[0])
     set_tile_view(name[0])
     sel.force_navigate(name[1])
+    if name[1] == "infrastructure_providers":
+        tb.set_vms_tile_view()
     assert tb.is_vms_tile_view(), "Tile Default view setting failed"
     reset_default_view(name[0], default_view)
 
@@ -123,6 +125,8 @@ def test_list_defaultview(request, setup_a_provider, key):
     default_view = get_default_view(name[0])
     set_list_view(name[0])
     sel.force_navigate(name[1])
+    if name[1] == "infrastructure_providers":
+        tb.set_vms_list_view()
     assert tb.is_vms_list_view(), "List Default view setting failed"
     reset_default_view(name[0], default_view)
 


### PR DESCRIPTION
The default navigation for infrastructure provider sets it to grid view so need to reset the views.

{{pytest: -v  cfme/tests/configure/test_default_views_infra.py  -k  'test_tile_defaultview or test_list_defaultview'}}