### PR TITLE
Handle the postgres version bump upstream

### DIFF
--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -11,7 +11,7 @@ from cfme.infrastructure.virtual_machines import Vm
 import cfme.fixtures.pytest_selenium as sel
 from time import sleep
 from urlparse import urlparse
-from utils import testgen, version
+from utils import db, testgen, version
 from utils.appliance import provision_appliance
 from utils.conf import credentials
 from utils.log import logger
@@ -65,14 +65,14 @@ def get_ssh_client(hostname):
 
 def stop_db_process(address):
     with get_ssh_client(address) as ssh:
-        assert ssh.run_command('service postgresql92-postgresql stop')[0] == 0,\
-            "Could not stop postgres process on {}".format(address)
+        assert ssh.run_command('service {}-postgresql stop')[0] == 0,\
+            "Could not stop postgres process on {}".format(db.scl_name(), address)
 
 
 def start_db_process(address):
     with get_ssh_client(address) as ssh:
-        assert ssh.run_command('service postgresql92-postgresql start')[0] == 0,\
-            "Could not start postgres process on {}".format(address)
+        assert ssh.run_command('service {}-postgresql start')[0] == 0,\
+            "Could not start postgres process on {}".format(db.scl_name(), address)
 
 
 def update_appliance_uuid(address):

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -4,7 +4,7 @@
 import pytest
 import re
 
-from utils import version
+from utils import db, version
 
 pytestmark = pytest.mark.smoke
 
@@ -68,10 +68,12 @@ def test_evm_running(ssh_client):
     'evminit',
     'sshd',
     'iptables',
-    'postgresql92-postgresql',
+    'postgresql',
 ])
 def test_service_enabled(ssh_client, service):
     """Verifies if key services are configured to start on boot up"""
+    if service == 'postgresql':
+        service = '{}-postgresql'.format(db.scl_name())
     if pytest.store.current_appliance.os_version >= '7':
         cmd = 'systemctl is-enabled {}'.format(service)
     else:

--- a/scripts/data/enable-internal-db.rbt
+++ b/scripts/data/enable-internal-db.rbt
@@ -25,8 +25,8 @@ config.post_activation
 # bash-fu to put an appliance into a testing state for this script
 # assumes sdb, update disk device as needed
 service evmserverd stop
-/etc/init.d/postgresql92-postgresql stop
-umount /opt/rh/postgresql92/root/var/lib/pgsql/data/
+/etc/init.d/${scl_name}-postgresql stop
+umount /opt/rh/${scl_name}/root/var/lib/pgsql/data/
 lvremove -f vg_data/lv_pg
 vgremove vg_data
 pvremove /dev/sdb1

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -2,9 +2,11 @@
 # coding: utf-8
 
 import logging
+import subprocess
 import time
 from optparse import OptionParser
-import subprocess as sub
+
+from utils import db
 
 parser = OptionParser()
 parser.add_option('--backupfile', help='backup file to be restored')
@@ -25,7 +27,7 @@ logger = logging.getLogger('migration')
 # Execute command
 def run_command(cmd):
     logger.info('Running: %s' % cmd)
-    process = sub.Popen(cmd, shell=True, stdout=sub.PIPE, stderr=sub.PIPE)
+    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, error = process.communicate()
     logger.info("\nSTDOUT:\n%s" % output)
     if process.returncode != 0:
@@ -50,7 +52,7 @@ psql_output = run_command('psql -d vmdb_production -U root -c ' +
 count = psql_output.split("\n")[2].strip()
 if count > 2:
     logger.info("Too many postgres threads(" + str(count) + ")... restarting")
-    run_command("service postgresql92-postgresql restart")
+    run_command("service {}-postgresql restart".format(db.scl_name()))
     time.sleep(60)
 run_command("cd /var/www/miq/vmdb/backup_and_restore/;./miq_vmdb_background_restore " +
     options.backupfile + " > /tmp/restore.out 2>&1")

--- a/utils/db.py
+++ b/utils/db.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import Pool
 
 from fixtures.pytest_store import store
-from utils import conf, lazycache, ports
+from utils import conf, lazycache, ports, version
 from utils.datafile import load_data_file
 from utils.log import logger
 from utils.path import data_path
@@ -39,6 +39,15 @@ def ping_connection(dbapi_connection, connection_record, connection_proxy):
     except StandardError:
         raise DisconnectionError
     cursor.close()
+
+
+def scl_name():
+    # postgres's version is in the service name and file paths when we pull it from SCL,
+    # so this is a little resolver to help keep the version picking centralized
+    return version.pick({
+        version.LOWEST: 'postgresql92',
+        '5.5': 'rh-postgresql94'
+    })
 
 
 class Db(Mapping):


### PR DESCRIPTION
scl_name added to utils.db, evern instance of 'postgresql92' that I
could find in the project was replaced with a call scl_name