### PR TITLE
Added Provider and Blocker skip filters to reports

### DIFF
--- a/data/templates/test_report.html
+++ b/data/templates/test_report.html
@@ -29,18 +29,22 @@
       {% if version %}<h2>Version: {{version}}</h2>{% endif %}
     </div>
     <div class="col-md-8 text-right">
-<form>User Filter:
-  <select class="toggle-user">
-    <option value="none" selected="selected">All</option>
-    {% for qac in qa %}<option value="{{qac}}">{{qac}}</option>{% endfor %}
-  </select>
-</form>
       <span class="label label-success">{{counts.passed}} Passed &nbsp;<input id="passed-check" type="checkbox" onclick="check_name('passed');"></span>
       <span class="label label-primary">{{counts.skipped}} Skipped &nbsp;<input id="skipped-check" type="checkbox" onclick="check_name('skipped');"></span>
       <span class="label label-warning">{{counts.failed}} Failed &nbsp;<input id="failed-check" type="checkbox" onclick="check_name('failed');" checked="checked"></span>
       <span class="label label-danger">{{counts.error}} Error &nbsp;<input id="error-check" type="checkbox" onclick="check_name('error');" checked="checked"></span>
       <span class="label label-danger">{{counts.xpassed}} XPassed &nbsp;<input id="xpassed-check" type="checkbox" onclick="check_name('xpassed');" checked="checked"></span>
       <span class="label label-success">{{counts.xfailed}} XFailed &nbsp;<input id="xfailed-check" type="checkbox" onclick="check_name('xfailed');"></span>
+    <br>
+    <form>User Filter:
+      <select class="toggle-user">
+        <option value="none" selected="selected">All</option>
+        {% for qac in qa %}<option value="{{qac}}">{{qac}}</option>{% endfor %}
+      </select> &nbsp;
+      Show Blocker Skips<input id="show-blockers" type="checkbox" onclick="check_blockers();">
+      &nbsp;
+      Show Provider Skips<input id="show-providers" type="checkbox" onclick="check_providers();">
+    </form>
     </div>
   </div>
   <div class="col-md-4">
@@ -51,15 +55,44 @@
     <div id="container">
       {{ndata}}
     </div>
+    <br>
+    <div>
+      {% if blocker_skip_count > 0 %}
+      <h3>Blocker Skips ({{blocker_skip_count}})</h3>
+      <table class="table table-striped">
+        <tr><td>Test</td><td>Blocker</td></tr>
+        {% for test in tests %}
+          {% if test.skip_blocker %}
+              <tr><td><a href="#{{test.name|e}}" data-toggle="tooltip" title="{{test.name}}">{{test.name|truncate(50)}}</a></td><td>
+                {% for blocker in test.skip_blocker %}
+                <a href="https://bugzilla.redhat.com/show_bug.cgi?id={{blocker}}">{{blocker}}</a><br>
+                {% endfor %}</td>
+          {% endif %}
+        {% endfor %}
+      </table>
+      {% endif %}
+      <br>
+      {% if provider_skip_count > 0 %}
+      <h3>Provider Skips ({{provider_skip_count}})</h3>
+      <table class="table table-striped">
+        <tr><td>Test</td><td>Provider</td></tr>
+        {% for test in tests %}
+          {% if test.skip_provider %}
+              <tr><td><a href="#{{test.name|e}}" data-toggle="tooltip" title="{{test.name}}">{{test.name|truncate(50)}}</a></td><td>{{test.skip_provider}}</td>
+          {% endif %}
+        {% endfor %}
+      </table>
+      {% endif %}
+    </div>
   </div>
   <div class="col-md-8">
     <p></p>
 {% for test in tests %}
-    <div data="{{test.outcomes['overall']}}" {% if test.qa_contact %} data-qa="{{test.qa_contact[0][0]}}" {% else %} data-qa="Unknown" {% endif %} class="panel panel-inverse panel-{{test.color}}" data-test="test">
+    <div data="{{test.outcomes['overall']}}" {% if test.qa_contact %} data-qa="{{test.qa_contact[0][0]}}" {% else %} data-qa="Unknown" {% endif %} {% if test.skip_blocker %} data-blocker="{{test.skip_blocker}}" {% else %} data-blocker="None" {% endif %} {% if test.skip_provider %} data-provider="{{test.skip_provider}}" {% else %} data-provider="None" {% endif %} class="panel panel-inverse panel-{{test.color}}" data-test="test">
         <div class="panel-heading">
             <div class="row">
                 <div class="col-md-10">
-                    <a id="{{test.name|e}}" href="#{{test.name|e}}"><strong>{{test.name}}</strong></a>
+                    <a id="{{test.name|e}}" href="#{{test.name|e}}" data-toggle="tooltip" title="{{test.name|e}}"><strong>{{test.name|truncate(150)}}</strong></a>
                     <br>
                     {% if test.in_progress %}
                         <strong>IN PROGRESS...</strong>
@@ -78,6 +111,20 @@
                       {% for contact in test.qa_contact %}
                         {{contact[0]}} ({{contact[1]}}),&nbsp;
                       {% endfor %}
+                      </em>
+                    {% endif %}
+                    {% if test.skip_blocker %}
+                    <br>
+                    <strong>BLOCKERS:</strong> <em>
+                      {% for blocker in test.skip_blocker %}
+                      <a href="https://bugzilla.redhat.com/show_bug.cgi?id={{blocker}}">{{blocker}}</a>,
+                      {% endfor %}
+                      </em>
+                    {% endif %}
+                    {% if test.skip_provider %}
+                    <br>
+                    <strong>PROVDER_FAIL:</strong> <em>
+                      {{ test.skip_provider }}
                       </em>
                     {% endif %}
                     {% if test.composite %}
@@ -258,12 +305,44 @@
 
 toggle_state = ['failed', 'error', 'xpassed']
 toggle_user = "none"
+toggle_blockers = false
+toggle_providers = false
+
+function check_blockers()
+{
+  if ($('#show-blockers').is(":checked"))
+  {
+    toggle_blockers = true
+  }
+  else
+  {
+    toggle_blockers = false
+  }
+  update_display()
+}
+
+function check_providers()
+{
+  if ($('#show-providers').is(":checked"))
+  {
+    toggle_providers = true
+  }
+  else
+  {
+    toggle_providers = false
+  }
+  update_display()
+}
 
 function check_name(name)
 {
   if ($('#'+name+'-check').is(":checked"))
   {
-    toggle_state.push(name)
+    idx = toggle_state.indexOf(name)
+    if (idx == -1)
+    {
+      toggle_state.push(name)
+    }
   }
   else
   {
@@ -279,15 +358,28 @@ function check_name(name)
 function update_display()
 {
   $('[data-test="test"]').each(function(item){
-    if (toggle_state.indexOf($(this).attr('data')) > -1)
+    if (toggle_state.indexOf($(this).attr('data')) == -1)
     {
-      if (toggle_user == "none" || $(this).attr('data-qa') == toggle_user)
-      {
-        $(this).show()
-        return
-      }
+      $(this).hide()
+      return
     }
-    $(this).hide()
+    if (toggle_user != "none" && $(this).attr('data-qa') != toggle_user)
+    {
+      $(this).hide()
+      return
+    }
+    if (toggle_blockers == false && $(this).attr('data-blocker') != "None")
+    {
+      $(this).hide()
+      return
+    }
+    if (toggle_providers == false && $(this).attr('data-provider') != "None")
+    {
+      $(this).hide()
+      return
+    }
+    $(this).show()
+    return
   })
 }
 
@@ -330,6 +422,15 @@ $(function() {
     }, 250);
   });
 });
+
+states = ["passed", "failed", "xpassed", "xfailed", "skipped", "error"]
+toggle_user = $(".toggle-user").val()
+check_providers()
+check_blockers()
+for (state in states){
+  check_name(states[state])
+}
+
 update_display()
 })
 

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -10,6 +10,7 @@ using the provider.
 """
 import pytest
 
+from fixtures.artifactor_plugin import art_client, get_test_idents
 from utils import providers
 from utils.log import logger
 
@@ -17,8 +18,14 @@ from utils.log import logger
 _failed_providers = set()
 
 
-def _setup_provider(provider_key):
+def _setup_provider(provider_key, request=None):
     def skip(provider_key, previous_fail=False):
+        if request:
+            node = request.node
+            name, location = get_test_idents(node)
+            skip_data = {'type': 'provider', 'reason': provider_key}
+            art_client.fire_hook('skip_test', test_location=location, test_name=name,
+                skip_data=skip_data)
         if previous_fail:
             raise pytest.skip('Provider {} failed to set up previously in another test, '
                               'skipping test'.format(provider_key))
@@ -40,25 +47,25 @@ def _setup_provider(provider_key):
 
 
 @pytest.fixture(scope='function')
-def setup_provider(provider):
+def setup_provider(request, provider):
     """Function-scoped fixture to set up a provider"""
-    _setup_provider(provider.key)
+    _setup_provider(provider.key, request)
 
 
 @pytest.fixture(scope='module')
-def setup_provider_modscope(provider):
+def setup_provider_modscope(request, provider):
     """Function-scoped fixture to set up a provider"""
-    _setup_provider(provider.key)
+    _setup_provider(provider.key, request)
 
 
 @pytest.fixture(scope='class')
-def setup_provider_clsscope(provider):
+def setup_provider_clsscope(request, provider):
     """Module-scoped fixture to set up a provider"""
-    _setup_provider(provider.key)
+    _setup_provider(provider.key, request)
 
 
 @pytest.fixture
-def setup_provider_funcscope(provider):
+def setup_provider_funcscope(request, provider):
     """Function-scoped fixture to set up a provider
 
     Note:
@@ -67,7 +74,7 @@ def setup_provider_funcscope(provider):
         be module-scoped the majority of the time.
 
     """
-    _setup_provider(provider.key)
+    _setup_provider(provider.key, request)
 
 
 @pytest.fixture(scope="session")

--- a/metaplugins/blockers.py
+++ b/metaplugins/blockers.py
@@ -38,6 +38,7 @@ import pytest
 
 from kwargify import kwargify as _kwargify
 
+from fixtures.artifactor_plugin import art_client, get_test_idents
 from markers.meta import plugin
 from utils import version
 from utils.blockers import Blocker
@@ -105,6 +106,11 @@ def resolve_blockers(item, blockers):
             action(**local_env)
     # And then skip
     if use_blockers:
+        name, location = get_test_idents(item)
+        bugs = [bug.bug_id for bug in use_blockers]
+        skip_data = {'type': 'blocker', 'reason': bugs}
+        art_client.fire_hook('skip_test', test_location=location, test_name=name,
+            skip_data=skip_data)
         pytest.skip("Skipping due to these blockers:\n{}".format(
             "\n".join(
                 "- {}".format(str(blocker))


### PR DESCRIPTION
* Artifactor reporter plugin gains new hook (skip_test)
* Reporter plugin now configures test report with a table of blocked and
  provider_error skips
* Report now includes checkboxes for show/hiding blocker and provider
  skips
* Report now correctly handles reloading the page, before boxes that
  were checked before a page reload were ignored when the page was
  reloaded. This has been fixed.
* Blocker metaplugin now sends out to artifactor when a test has been
  skipped due to a blocker
* Provider fixture now sends out to artifactor when a test has been
  skipped dur to a provider setup failure

{{pytest: -k utils/tests/test_wait.py}}