### PR TITLE
[WIP][NO TEST] Sprout - Remove deprecated configuration value

### DIFF
--- a/sprout/sprout/settings.py
+++ b/sprout/sprout/settings.py
@@ -26,8 +26,6 @@ SECRET_KEY = credentials["sprout"]["key"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DJANGO_DEBUG", "false") == "true"
 
-TEMPLATE_DEBUG = True
-
 ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1"
@@ -79,6 +77,7 @@ TEMPLATES = [
                 'appliances.context_processors.hubber_url',
                 'appliances.context_processors.sprout_needs_update',
             ],
+            'debug': True,
         },
     },
 ]


### PR DESCRIPTION
Future versions of Django will get rid of TEMPLATE_* configuration values and will use the TEMPLATES dictionary exclusively. Now it writes a warning, so I just want it to shaddap.

*Not very important, will merge it together with some bigger update*