### PR TITLE
Add new events table

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -92,7 +92,6 @@ def count_events(instance_name, nav_step):
 
 def db_event(db, provider):
     # Get event count from the DB
-
     logger.info("Getting event count from the DB for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
     ems_events_table_name = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -23,7 +23,7 @@ pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="module"
 def delete_fx_provider_event(db, provider):
     logger.info("Deleting timeline events for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
+    ems_events = version.pick({version.LOWEST: db['ems_events'], '5.5': db['event_streams']})
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)
@@ -94,7 +94,7 @@ def db_event(db, provider):
 
     logger.info("Getting event count from the DB for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
+    ems_events = version.pick({version.LOWEST: db['ems_events'], '5.5': db['event_streams']})
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -5,6 +5,7 @@ from cfme.cloud.instance import Instance
 from cfme.web_ui import InfoBlock, toolbar, jstimelines
 from cfme.exceptions import ToolbarOptionGreyed
 from utils import testgen
+from utils import version
 from utils.blockers import BZ
 from utils.log import logger
 from utils.version import current_version
@@ -22,7 +23,7 @@ pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="module"
 def delete_fx_provider_event(db, provider):
     logger.info("Deleting timeline events for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = db['ems_events']
+    ems_events = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)
@@ -93,7 +94,7 @@ def db_event(db, provider):
 
     logger.info("Getting event count from the DB for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = db['ems_events']
+    ems_events = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -23,7 +23,8 @@ pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="module"
 def delete_fx_provider_event(db, provider):
     logger.info("Deleting timeline events for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = version.pick({version.LOWEST: db['ems_events'], '5.5': db['event_streams']})
+    ems_events_table_name = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
+    ems_events = db[ems_events_table_name]
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)
@@ -94,7 +95,8 @@ def db_event(db, provider):
 
     logger.info("Getting event count from the DB for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = version.pick({version.LOWEST: db['ems_events'], '5.5': db['event_streams']})
+    ems_events_table_name = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
+    ems_events = db[ems_events_table_name]
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -35,6 +35,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="module")
 def vm_name():
+    # We have to use "tt" here to avoid name truncating in the timelines view
     return "test_tt_" + fauxfactory.gen_alphanumeric(length=4)
 
 

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -3,8 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme.common.vm import VM
-from cfme.infrastructure.virtual_machines import details_page
-from cfme.web_ui import toolbar, jstimelines
+from cfme.web_ui import InfoBlock, toolbar, jstimelines
 from cfme.exceptions import ToolbarOptionGreyed
 from utils import testgen
 from utils.log import logger
@@ -95,7 +94,7 @@ def test_host_event(provider, gen_events, test_vm):
     """
     def nav_step():
         test_vm.load_details()
-        pytest.sel.click(details_page.infoblock.element('Relationships', 'Host'))
+        pytest.sel.click(InfoBlock.element('Relationships', 'Host'))
         toolbar.select('Monitoring', 'Timelines')
     wait_for(count_events, [test_vm.name, nav_step], timeout=60, fail_condition=0,
              message="events to appear")
@@ -122,7 +121,7 @@ def test_cluster_event(provider, gen_events, test_vm):
     """
     def nav_step():
         test_vm.load_details()
-        pytest.sel.click(details_page.infoblock.element('Relationships', 'Cluster'))
+        pytest.sel.click(InfoBlock.element('Relationships', 'Cluster'))
         toolbar.select('Monitoring', 'Timelines')
     wait_for(count_events, [test_vm.name, nav_step], timeout=60, fail_condition=0,
              message="events to appear")

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -17,7 +17,7 @@ pytestmark = [pytest.mark.ignore_stream("upstream")]
 def delete_fx_provider_event(db, provider):
     logger.debug("Deleting timeline events for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
+    ems_events = version.pick({version.LOWEST: db['ems_events'], '5.5': db['event_streams']})
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -6,6 +6,7 @@ from cfme.common.vm import VM
 from cfme.web_ui import InfoBlock, toolbar, jstimelines
 from cfme.exceptions import ToolbarOptionGreyed
 from utils import testgen
+from utils import version
 from utils.log import logger
 from utils.wait import wait_for
 
@@ -16,7 +17,7 @@ pytestmark = [pytest.mark.ignore_stream("upstream")]
 def delete_fx_provider_event(db, provider):
     logger.debug("Deleting timeline events for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = db['ems_events']
+    ems_events = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -17,7 +17,8 @@ pytestmark = [pytest.mark.ignore_stream("upstream")]
 def delete_fx_provider_event(db, provider):
     logger.debug("Deleting timeline events for provider name {}".format(provider.name))
     ems = db['ext_management_systems']
-    ems_events = version.pick({version.LOWEST: db['ems_events'], '5.5': db['event_streams']})
+    ems_events_table_name = version.pick({version.LOWEST: 'ems_events', '5.5': 'event_streams'})
+    ems_events = db[ems_events_table_name]
     with db.transaction:
         providers = (
             db.session.query(ems_events.id)


### PR DESCRIPTION
The "ems_events" DB table has been replaced with the "event_streams" DB table in the upstream/5.5 build.These code changes have been made to address this.