### PR TITLE
[WIP][NO TEST] Sprout - Better appliance salvage; Forbid renaming appliances without UUID

### DIFF
--- a/sprout/appliances/static/app-js/my_appliances.js
+++ b/sprout/appliances/static/app-js/my_appliances.js
@@ -13,7 +13,7 @@ myAppliancesApp.config(['$httpProvider', function($httpProvider) {
 }]);
 
 
-myAppliancesApp.controller('EditVmName', function ($scope, $http, $timeout) {
+myAppliancesApp.controller('EditVmName', function ($scope, $http, $timeout, $window) {
     $scope.$watch("applianceOriginalName", function(){
         $scope.saved = {"name": $scope.applianceOriginalName};
         $scope.vm = {"name": $scope.saved.name};
@@ -63,6 +63,11 @@ myAppliancesApp.controller('EditVmName', function ($scope, $http, $timeout) {
      };
 
     $scope.edit = function() {
+        if(! $scope.applianceHasUUID) {
+            // No change, we can edit only when we have UUID to be 100% sure
+            $window.alert("Appliance " + $scope.applianceOriginalName + " did not receive its UUID yet so it cannot be renamed.")
+            return;
+        }
         $scope.vm = angular.copy($scope.saved);
         $scope.editing = true;
     };

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -729,7 +729,8 @@ def clone_template_to_appliance__clone_template(self, appliance_id, lease_time_m
             # We cannot put it aside, so just try that again
             self.retry(args=(appliance_id, lease_time_minutes), exc=e, countdown=60, max_retries=5)
     else:
-        appliance.set_status("Template cloning finished.")
+        appliance.set_status("Template cloning finished. Refreshing provider VMs to get UUID.")
+        refresh_appliances_provider.delay(appliance.provider.id)
 
 
 @singleton_task()

--- a/sprout/appliances/templates/appliances/my_appliances.html
+++ b/sprout/appliances/templates/appliances/my_appliances.html
@@ -76,7 +76,8 @@
                 {% for appliance in pool.appliances %}
                 <tr id="appliance-{{ appliance.id }}">
                     <td>{{ appliance.id }}</td>
-                    <td style=" overflow: auto;" ng-controller="EditVmName" ng-init="applianceId = '{{ appliance.id }}'; apiURL = '{% url 'rename_appliance' %}'; taskResultURL = '{% url 'task_result' %}'; applianceOriginalName = '{{ appliance.name }}';">
+                    <!-- There's gotta be a better way to do this angular thing, but that probably involves REST. -->
+                    <td style=" overflow: auto;" ng-controller="EditVmName" ng-init="applianceId = '{{ appliance.id }}'; apiURL = '{% url 'rename_appliance' %}'; taskResultURL = '{% url 'task_result' %}'; applianceOriginalName = '{{ appliance.name }}'; applianceHasUUID = {{ appliance.has_uuid_angular }} ;">
                     {% if appliance.vnc_link %}<a href="{{ appliance.vnc_link }}" target="_blank"><img src={% static "img/console.png" %}></a>{% endif %}
                         <div ng-hide="editing" ng-click="edit()">
                             {[{ vm.name }]}
@@ -122,6 +123,8 @@
                                 {% endif %}
                                 {% if appliance.can_stop %}
                                     <a href="{% url 'appliance_action' appliance.id 'stop' %}" class="btn btn-danger btn-xs" onclick="return confirm('Are you sure?')"><span class="glyphicon glyphicon-off"></span> Stop</a>
+                                {% endif %}
+                                {% if appliance.can_reboot %}
                                     <a href="{% url 'appliance_action' appliance.id 'reboot' %}" class="btn btn-warning btn-xs" onclick="return confirm('Are you sure?')"><span class="glyphicon glyphicon-repeat"></span> Reboot</a>
                                 {% endif %}
                                 {% if appliance.can_suspend %}
@@ -234,7 +237,7 @@
                 <div class="col-md-4">
                     <div class="checkbox">
                       <label>
-                        <input type="checkbox" class="form-control" id="yum_update" name="yum_update" value="true">
+                        <input type="checkbox" class="form-control" id="yum_update" name="yum_update" value="true" disabled="true">
                       </label>
                     </div>
                 </div>


### PR DESCRIPTION
* It now ignores the appliances that have bad power state.
* UI does not allow renaming appliances without UUID
* UUID refresh initiated after appliance provisioned.
* give_to_pool does better checking.