### PR TITLE
Able to override BZ stream detection in blocker

### DIFF
--- a/cfme/tests/configure/test_analysis_profiles.py
+++ b/cfme/tests/configure/test_analysis_profiles.py
@@ -5,6 +5,7 @@ import utils.error as error
 import cfme.fixtures.pytest_selenium as sel
 from cfme.configure.configuration import HostAnalysisProfile, VMAnalysisProfile
 from cfme.web_ui import Table, flash, toolbar as tb
+from utils.blockers import BZ
 from utils.update import update
 
 
@@ -33,7 +34,7 @@ def test_host_analysis_profile_crud():
     p.delete()
 
 
-@pytest.mark.meta(blockers=[1263073])
+@pytest.mark.meta(blockers=[BZ(1263073, forced_streams=["5.4"])])
 def test_vmanalysis_profile_description_validation():
     """ Test to validate description in vm profiles"""
     p = VMAnalysisProfile(

--- a/utils/bz.py
+++ b/utils/bz.py
@@ -135,8 +135,8 @@ class Bugzilla(object):
                 expanded.add(b)
         return found
 
-    def resolve_blocker(self, blocker, version=None, ignore_bugs=set([])):
-        # ignore_bugs is mutable but is not mutated here!
+    def resolve_blocker(self, blocker, version=None, ignore_bugs=set([]), force_block_streams=[]):
+        # ignore_bugs is mutable but is not mutated here! Same force_block_streams
         if isinstance(id, BugWrapper):
             bug = blocker
         else:
@@ -167,9 +167,16 @@ class Bugzilla(object):
                         "Ignoring bug #{}, appliance version not in bug release flag"
                         .format(variant.id))
             else:
-                logger.info("No release flags, wrogn versions, ignoring {}".format(variant.id))
+                logger.info("No release flags, wrong versions, ignoring {}".format(variant.id))
         if not filtered:
-            return None
+            # No appropriate bug was found
+            for forced_stream in force_block_streams:
+                # Find out if we force this bug.
+                if current_version().is_in_series(forced_stream):
+                    return bug
+            else:
+                # No bug, yipee :)
+                return None
         # First, use versions
         for bug in filtered:
             if ((bug.version is not None and bug.target_release is not None) and


### PR DESCRIPTION
If you want to make the bug skip for stream that is not cloned in BZ, you can use keyword parameter forced_streams=[] which takes the stream names in form of downstream-54z and so. It will then always care about htat bug in that stream no matter what do the bug's versions state. Use with caution though...