### PR TITLE
Introduce deferred_verpick

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -10,7 +10,7 @@ from cfme.web_ui import (
     accordion, fill, flash, paginator, toolbar, CheckboxTree, Form, Region, Select, Tree, Quadicon)
 from cfme.web_ui.menu import nav
 from functools import partial
-from utils import version
+from utils import deferred_verpick, version
 from utils.wait import wait_for
 
 
@@ -240,11 +240,11 @@ class OpenStackInstance(Instance):
     STATE_ON = "on"
     STATE_OFF = "off"
     STATE_ERROR = "non-operational"
-    STATE_PAUSED = version.pick({
+    STATE_PAUSED = deferred_verpick({
         version.LOWEST: "off",
         "5.4": "paused",
     })
-    STATE_SUSPENDED = version.pick({
+    STATE_SUSPENDED = deferred_verpick({
         version.LOWEST: "off",
         "5.4": "suspended",
     })

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -201,3 +201,16 @@ def read_env(file):
                 env_vars[key] = value.strip()
         stdout, stderr = proc.communicate()
     return env_vars
+
+
+def deferred_verpick(version_d):
+    """This turns a dictionary for verpick to a class property.
+
+    Useful for verpicked constants.
+    """
+    from utils.version import pick as _version_pick
+
+    @classproperty
+    def getter(self):
+        return _version_pick(version_d)
+    return getter


### PR DESCRIPTION
Introduced deferred_verpick, a classproperty creator that turns a verpick dictionaries into a classproperty so the verpicking happens only when the value is requested.