### PR TITLE
Snapshot flash messages fixed

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -183,6 +183,8 @@ def _t(t, root=None):
 @elements.method(set)
 def _l(l, **kwargs):
     """If we pass an iterable (non-tuple), just find everything relevant from it by all locators."""
+    if not l:
+        return []
     found = reduce(lambda a, b: a + b, map(lambda loc: elements(loc, **kwargs), l))
     seen = set([])
     result = []

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -227,24 +227,38 @@ class Vm(BaseVM, Common):
             toolbar.select('Delete Snapshots', 'Delete Selected Snapshot', invokes_alert=True)
             sel.handle_alert(cancel=cancel)
             if not cancel:
-                flash.assert_message_match(
-                    'Delete Snapshot initiated for 1 VM and Instance from the CFME Database')
+                if version.current_version() >= "5.5":
+                    flash.assert_message_match(
+                        'Remove Snapshot initiated for 1 VM and Instance from the CFME Database')
+                else:
+                    flash.assert_message_match(
+                        'Delete Snapshot initiated for 1 VM and Instance from the CFME Database')
 
         def delete_all(self, cancel=False):
             self._nav_to_snapshot_mgmt()
             toolbar.select('Delete Snapshots', 'Delete All Existing Snapshots', invokes_alert=True)
             sel.handle_alert(cancel=cancel)
             if not cancel:
-                flash.assert_message_match(
-                    'Delete All Snapshots initiated for 1 VM and Instance from the CFME Database')
+                if version.current_version() >= "5.5":
+                    flash.assert_message_match(
+                        'Remove All Snapshots initiated for 1 VM and Instance from the '
+                        'CFME Database')
+                else:
+                    flash.assert_message_match(
+                        'Delete All Snapshots initiated for 1 VM and Instance from the CFME '
+                        'Database')
 
         def revert_to(self, cancel=False):
             self._nav_to_snapshot_mgmt()
             snapshot_tree.click_path(*snapshot_tree.find_path_to(re.compile(self.name)))
             toolbar.select('Revert to selected snapshot', invokes_alert=True)
             sel.handle_alert(cancel=cancel)
-            flash.assert_message_match(
-                'Revert To A Snapshot initiated for 1 VM and Instance from the CFME Database')
+            if version.current_version() >= "5.5":
+                flash.assert_message_match(
+                    'Revert To Snapshot initiated for 1 VM and Instance from the CFME Database')
+            else:
+                flash.assert_message_match(
+                    'Revert To A Snapshot initiated for 1 VM and Instance from the CFME Database')
 
     # POWER CONTROL OPTIONS
     SUSPEND = "Suspend"

--- a/cfme/web_ui/flash.py
+++ b/cfme/web_ui/flash.py
@@ -92,9 +92,9 @@ def message(el):
 
 
 def get_messages():
-    """Return a list of flash messages"""
+    """Return a list of visible flash messages"""
     sel.wait_for_ajax()
-    return map(message, sel.elements(area.message))
+    return map(message, [e for e in sel.elements(area.message) if sel.is_displayed(e)])
 
 
 def dismiss():


### PR DESCRIPTION
+ flash messages now only read the visible elements and to be sure, elements() does not fail when empty list passed.

{{pytest: cfme/tests/infrastructure/test_snapshot.py -v --long-running }}