### PR TITLE
disable soap tests for 5.5/upstream

### DIFF
--- a/cfme/tests/test_soap.py
+++ b/cfme/tests/test_soap.py
@@ -15,6 +15,7 @@ pytest_generate_tests = testgen.generate(
     scope="class"
 )
 
+pytestmark = [pytest.mark.ignore_stream("5.5", "upstream")]
 
 @pytest.fixture(scope="class")
 def setup_a_provider():


### PR DESCRIPTION
Soap API was deprecated in v3.2 (5.4) and removed in v4.0 (5.5)