### PR TITLE
Another load of jenkins fixes

### DIFF
--- a/cfme/automate/explorer.py
+++ b/cfme/automate/explorer.py
@@ -1,5 +1,6 @@
 from copy import copy
 from functools import partial
+from xml.sax.saxutils import quoteattr
 
 import cfme.fixtures.pytest_selenium as sel
 from cfme.web_ui.menu import nav
@@ -26,7 +27,10 @@ cfg_btn = partial(tb.select, 'Configuration')
 
 
 def datastore_checkbox(name):
-    return "//img[contains(@src, 'chk') and ../../td[normalize-space(.)='%s']]" % name
+    return version.pick({
+        version.LOWEST: "//img[contains(@src, 'chk') and ../../td[normalize-space(.)={}]]",
+        "5.5": "//input[@type='checkbox' and ../../td[normalize-space(.)={}]]"
+    }).format(quoteattr(name))
 
 
 def table_select(name):

--- a/cfme/automate/service_dialogs.py
+++ b/cfme/automate/service_dialogs.py
@@ -50,9 +50,7 @@ element_form = Form(fields=[
         version.LOWEST: Select("//select[@id='field_typ']"),
         "5.5": AngularSelect("field_typ")}),
     ('default_text_box', Input("field_default_value")),
-    ('field_required', {
-        version.LOWEST: Input("field_required"),
-        "5.5": AngularSelect("field_required")}),
+    ('field_required', Input("field_required")),
     ('field_past_dates', Input("field_past_dates")),
     ('field_entry_point', Input("field_entry_point")),
     ('field_show_refresh_button', Input("field_show_refresh_button")),

--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -1,13 +1,10 @@
-""" A model of Instances page in CFME
-
-:var edit_form: A :py:class:`cfme.web_ui.Form` object describing the instance edit form.
-"""
+""" A model of Instances page in CFME."""
 from cfme.common.vm import VM, Template
 from cfme.exceptions import InstanceNotFound, OptionNotAvailable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.services import requests
 from cfme.web_ui import (
-    accordion, fill, flash, paginator, toolbar, CheckboxTree, Form, Region, Select, Tree, Quadicon)
+    accordion, fill, flash, paginator, toolbar, CheckboxTree, Region, Tree, Quadicon)
 from cfme.web_ui.menu import nav
 from functools import partial
 from utils import deferred_verpick, version
@@ -35,19 +32,6 @@ manage_policies_tree = CheckboxTree(
         "5.3": "//div[@id='protect_treebox']/ul"
     }
 )
-
-# Forms
-edit_form = Form(
-    fields=[
-        ('custom_ident', "//*[@id='custom_1']"),
-        ('description_tarea', "//textarea[@id='description']"),
-        ('parent_sel', Select("//select[@name='chosen_parent']")),
-        ('child_sel', Select("//select[@id='kids_chosen']", multi=True)),
-        ('vm_sel', Select("//select[@id='choices_chosen']", multi=True)),
-        ('add_btn', "//img[@alt='Move selected VMs to left']"),
-        ('remove_btn', "//img[@alt='Move selected VMs to right']"),
-        ('remove_all_btn', "//img[@alt='Move all VMs to right']"),
-    ])
 
 
 nav.add_branch(

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -9,8 +9,8 @@ from cfme.exceptions import (
     VmOrInstanceNotFound, TemplateNotFound, OptionNotAvailable, UnknownProviderType)
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
-    AngularCalendarInput, Form, InfoBlock, Quadicon, Select, fill, flash, form_buttons, paginator,
-    toolbar)
+    AngularCalendarInput, AngularSelect, Form, InfoBlock, Input, Quadicon, Select, fill, flash,
+    form_buttons, paginator, toolbar)
 from utils import version
 from utils.log import logger
 from utils.mgmt_system import ActionNotSupported, VMInstanceNotFound
@@ -50,6 +50,21 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable):
     """
     pretty_attrs = ['name', 'provider', 'template_name']
     _registered_types = {}
+
+    # Forms
+    edit_form = Form(
+        fields=[
+            ('custom_ident', Input("custom_1")),
+            ('description_tarea', "//textarea[@id='description']"),
+            ('parent_sel', {
+                version.LOWEST: Select("//select[@name='chosen_parent']"),
+                "5.5": AngularSelect("chosen_parent")}),
+            ('child_sel', Select("//select[@id='kids_chosen']", multi=True)),
+            ('vm_sel', Select("//select[@id='choices_chosen']", multi=True)),
+            ('add_btn', "//img[@alt='Move selected VMs to left']"),
+            ('remove_btn', "//img[@alt='Move selected VMs to right']"),
+            ('remove_all_btn', "//img[@alt='Move all VMs to right']"),
+        ])
 
     ###
     # Factory class methods

--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -466,7 +466,11 @@ class AnalysisProfile(Pretty, Updateable):
             ("description", "input#description")],
         tab_fields={
             "Category": [
-                ("categories", CheckboxSelect("table#formtest")),
+                ("categories", CheckboxSelect({
+                    version.LOWEST: "table#formtest",
+                    "5.5":
+                    "//h3[normalize-space(.)='Category Selection']/.."
+                    "//div[contains(@class, 'col-md-8')]"})),
             ],
             "File": [
                 ("files", DynamicTable(

--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -620,7 +620,12 @@ def text(loc, **kwargs):
 
     Returns: A string containing the text of the element.
     """
-    return move_to_element(loc, **kwargs).text
+    try:
+        return move_to_element(loc, **kwargs).text
+    except exceptions.CannotScrollException:
+        # Work around, the element is not movable to
+        el = element(loc, **kwargs)
+        return execute_script("return arguments[0].textContent || arguments[0].innerText;", el)
 
 
 def text_sane(loc, **kwargs):

--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -979,6 +979,10 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
     # Set this to True in the handlers below to trigger a browser restart
     recycle = False
 
+    # Set this to True in handlers to restart evmserverd on the appliance
+    # Includes recycling so you don't need to specify recycle = False
+    restart_evmserverd = False
+
     # remember the current user, if any
     current_user = store.user
 
@@ -1106,6 +1110,15 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
                 cfme_exc.cfme_exception_text()
             ))
             recycle = True
+        elif is_displayed("//body/h1[normalize-space(.)='Proxy Error']"):
+            # 502
+            logger.exception("Proxy error detected. Killing browser and restarting evmserverd.")
+            req = elements("/html/body/p[1]//a")
+            req = text(req[0]) if req else "No request stated"
+            reason = elements("/html/body/p[2]/strong")
+            reason = text(reason[0]) if reason else "No reason stated"
+            logger.info("Proxy error: {} / {}".format(req, reason))
+            restart_evmserverd = True
         elif is_displayed("//body[./h1 and ./p and ./hr and ./address]", _no_deeper=True):
             # 503 and similar sort of errors
             title = text("//body/h1")
@@ -1137,7 +1150,12 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
                 'service evmserverd status').output)
             raise
 
-    if recycle:
+    if restart_evmserverd:
+        logger.info("evmserverd restart requested")
+        store.current_appliance.restart_evm_service()
+        store.current_appliance.wait_for_web_ui()
+
+    if recycle or restart_evmserverd:
         browser().quit()  # login.current_user() will be retained for next login
         logger.debug('browser killed on try %d' % _tries)
         # If given a "start" nav destination, it won't be valid after quitting the browser

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -3,7 +3,6 @@ import fauxfactory
 import pytest
 
 from cfme.common.vm import VM
-from cfme.cloud.instance import edit_form
 from utils import testgen
 from utils.providers import is_cloud_provider
 
@@ -76,7 +75,7 @@ def test_vm_genealogy_detected(
 
     if from_edit:
         vm_crud.open_edit()
-        parent = pytest.sel.text(edit_form.parent_sel.first_selected_option).strip()
+        parent = pytest.sel.text(vm_crud.edit_form.parent_sel.first_selected_option).strip()
         assert parent.startswith(small_template), "The parent template not detected!"
     else:
         vm_crud_ancestors = vm_crud.genealogy.ancestors

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -27,8 +27,11 @@ def test_providers_summary(soft_assert, setup_a_provider):
             continue
         provider_fake_obj = Provider(name=provider["Name"])
         sel.force_navigate("infrastructure_provider", context={"provider": provider_fake_obj})
+        hostname = version.pick({
+            version.LOWEST: ("Hostname", "Hostname"),
+            "5.5": ("Host Name", "Hostname")})
         soft_assert(
-            provider_props("Hostname") == provider["Hostname"],
+            provider_props(hostname[0]) == provider[hostname[1]],
             "Hostname does not match at {}".format(provider["Name"]))
 
         if version.current_version() < "5.4":


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_snapshot.py cfme/tests/intelligence/test_chargeback_assignments.py cfme/tests/intelligence/reports/test_canned_corresponds.py cfme/tests/configure/test_analysis_profiles.py cfme/tests/automate/test_service_dialog.py cfme/tests/cloud_infra_common/test_genealogy.py -k 'snapshot_via_ae or assign_storage_tagged_datastores or providers_summary or vm_analysis_profile_crud or tagcontrol_dialog_element or genealogy_detected' -v --long-running}}