### PR TITLE
Fix rhev34 ci

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -566,6 +566,9 @@ class VM(BaseVM):
                     logger.debug("Powering up VM %s to shut it down correctly on %s." %
                                  (self.name, self.provider.key))
                     self.provider.mgmt.start_vm(self.name)
+                    self.provider.mgmt.wait_vm_steady(self.name)
+                    self.provider.mgmt.stop_vm(self.name)
+                    self.provider.mgmt.wait_vm_steady(self.name)
             except ActionNotSupported:
                 # Action is not supported on mgmt system. Simply continue
                 pass

--- a/utils/mgmt_system/__init__.py
+++ b/utils/mgmt_system/__init__.py
@@ -23,6 +23,56 @@ from ovirtsdk.xml import params
 
 
 class RHEVMSystem(RHEVMSystemBase):
+
+    def start_vm(self, vm_name=None, **kwargs):
+        self.wait_vm_steady(vm_name)
+        self.logger.info(' Starting RHEV VM %s' % vm_name)
+        vm = self._get_vm(vm_name)
+        if vm.status.get_state() == 'up':
+            self.logger.info(' RHEV VM %s os already running.' % vm_name)
+            return True
+        else:
+            if 'initialization' in kwargs:
+                vm.start(kwargs['initialization'])
+            else:
+                vm.start()
+            self.wait_vm_running(vm_name)
+            return True
+
+    def deploy_template(self, template, *args, **kwargs):
+        import pdb
+        pdb.set_trace()
+        self.logger.debug(' Deploying RHEV template %s to VM %s' % (template, kwargs["vm_name"]))
+        timeout = kwargs.pop('timeout', 900)
+        power_on = kwargs.pop('power_on', True)
+        vm_kwargs = {
+            'name': kwargs['vm_name'],
+            'cluster': self.api.clusters.get(kwargs['cluster']),
+            'template': self.api.templates.get(template)
+        }
+
+        if 'placement_policy_host' in kwargs and 'placement_policy_affinity' in kwargs:
+            host = params.Host(name=kwargs['placement_policy_host'])
+            policy = params.VmPlacementPolicy(host=host,
+                affinity=kwargs['placement_policy_affinity'])
+            vm_kwargs['placement_policy'] = policy
+        vm = params.VM(**vm_kwargs)
+        self.api.vms.add(vm)
+        self.wait_vm_stopped(kwargs['vm_name'], num_sec=timeout)
+        if power_on:
+            version = self.api.get_product_info().get_full_version()
+            if template.startswith("cfme-55") and version.startswith("3.4"):
+                action = params.Action(vm=params.VM(initialization=params.Initialization(
+                    cloud_init=params.CloudInit(users=params.Users(
+                        user=[params.User(user_name="root", password="smartvm")])))))
+                ciargs = {}
+                ciargs['initialization'] = action
+                self.start_vm(vm_name=kwargs['vm_name'], **ciargs)
+                pdb.set_trace()
+            else:
+                self.start_vm(vm_name=kwargs['vm_name'])
+        return kwargs['vm_name']
+
     def connect_direct_lun_to_appliance(self, vm_name, disconnect):
         """Connects or disconnects the direct lun disk to an appliance.
 


### PR DESCRIPTION
On RHEV 3.4, you can;t ssh into a VM if the template you are cloning/starting has the cloud-init rpm and you don;t specifically pass in cloud-init customization.  :\  This should work around it for the automation, users manually creating any such VMs will just have to know what to do, use run once.  Also sneaking in some logic to help vm_analysis getting random errors deleting suspended vms.