### PR TITLE
Fix test_scope_windows_registry_stuck

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -310,10 +310,13 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable):
             return InfoBlock.text(*properties)
 
     @classmethod
-    def get_first_vm_title(cls, do_not_navigate=False):
+    def get_first_vm_title(cls, do_not_navigate=False, provider=None):
         """Get the title of first VM/Instance."""
         if not do_not_navigate:
-            sel.force_navigate(cls.ALL_LIST_LOCATION)
+            if provider is None:
+                sel.force_navigate(cls.ALL_LIST_LOCATION)
+            else:
+                provider.load_all_provider_vms()
         return Quadicon.get_first_quad_title()
 
     @property

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -47,7 +47,7 @@ def test_scope_windows_registry_stuck(request, setup_a_provider):
     request.addfinalizer(lambda: profile.delete() if profile.exists else None)
     profile.create()
     # Now assign this malformed profile to a VM
-    vm = VM.factory(Vm.get_first_vm_title(), setup_a_provider)
+    vm = VM.factory(Vm.get_first_vm_title(provider=setup_a_provider), setup_a_provider)
     vm.assign_policy_profiles(profile.description)
     # It should be screwed here, but do additional check
     pytest.sel.force_navigate("dashboard")


### PR DESCRIPTION
{{pytest: cfme/tests/control/test_bugs.py -v -k scope_windows_registry_stuck --long-running}}