### PR TITLE
Fix the datastore deletion test

### DIFF
--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -9,7 +9,7 @@ import ui_navigate as nav
 # needed before grafting
 import cfme.web_ui.menu  # noqa
 
-from cfme.exceptions import CandidateNotFound
+from cfme.exceptions import CandidateNotFound, ListAccordionLinkNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import Quadicon, Region, listaccordion as list_acc, toolbar as tb, paginator as pg
 from functools import partial
@@ -142,7 +142,7 @@ class Datastore(Pretty):
                     version.LOWEST: "Show all registered VMs",
                     "5.3": "Show registered VMs"})
                 list_acc.select('Relationships', path)
-            except sel.NoSuchElementException:
+            except (sel.NoSuchElementException, ListAccordionLinkNotFound):
                 return []
         return [q.name for q in Quadicon.all("vm")]
 

--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -111,8 +111,8 @@ def test_delete_datastore(setup_provider, provider, remove_test):
     """
     data_store = remove_test['datastore']
     test_datastore = datastore.Datastore(name=data_store)
-    host_count = test_datastore.get_hosts()
-    vm_count = test_datastore.get_vms()
+    host_count = len(test_datastore.get_hosts())
+    vm_count = len(test_datastore.get_vms())
     if host_count != 0:
         test_datastore.delete_all_attached_hosts()
         test_datastore.wait_for_delete_all()


### PR DESCRIPTION
* A new error was being raised which was not NoElementException this is
  now handled

{{pytest: cfme/tests/infrastructure/test_delete_infra_object.py -k test_delete_datastore}}