### PR TITLE
varmeth module

### DIFF
--- a/utils/tests/test_varmeth.py
+++ b/utils/tests/test_varmeth.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from utils.varmeth import variable
+
+
+class _TestClass(object):
+    secret = 42
+
+    @variable
+    def meth1(self):
+        return "default"
+
+    @meth1.variant("a")
+    def m1_va(self):
+        return "a"
+
+    @meth1.variant("b")
+    def m1_vb(self):
+        return "b"
+
+    @variable
+    def meth2(self, a):
+        return a
+
+    @meth2.variant("a")
+    def m2_va(self, a, b):
+        return a, b
+
+    @meth2.variant("b")
+    def m2_vb(self):
+        return "b"
+
+    @variable
+    def can_reach_secret(self):
+        return self.secret
+
+
+@pytest.fixture(scope="function")
+def o():
+    return _TestClass()
+
+
+def test_proper_self(o):
+    assert o.can_reach_secret() == o.secret
+
+
+def test_default_noparam(o):
+    assert o.meth1() == "default"
+
+
+@pytest.mark.parametrize("v", ["a", "b"])
+def test_variants_noparam(o, v):
+    assert o.meth1(method=v) == v
+
+
+def test_raises_attrerror(o):
+    with pytest.raises(AttributeError):
+        o.meth1(method="I'm not here!")
+
+
+def test_default_withparam(o):
+    assert o.meth2(1) == 1
+
+
+@pytest.mark.parametrize(
+    ["v", "params", "returns"],
+    [
+        ("a", [1, 2], (1, 2)),
+        ("b", [], "b")],
+    ids=["a", "b"])
+def test_variants_withparam(o, v, params, returns):
+    assert o.meth2(*params, method=v) == returns

--- a/utils/varmeth.py
+++ b/utils/varmeth.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Method variant decorator. You specify the desired method variant by a kwarg.
+
+.. code-block:: python
+
+    from utils.varmeth import variable
+
+    class SomeClass(object):
+        secret = 42
+
+        @variable
+        def mymethod(self):
+            print "I am default!"
+
+        @mymethod.variant("foo")
+        def i_foo(self):
+            print "I foo!"
+
+        @mymethod.variant("bar")
+        def in_bar(self):
+            print "In bar!"
+
+    s = SomeClass()
+    s.mymethod()  # => I am default!
+    s.mymethod(method="foo")  # => I foo!
+    s.mymethod(method="bar")  # => In bar!
+    s.mymethod(method="baz")  # => AttributeError
+
+Original idea:
+    Pete Savage
+
+Implementation:
+    Milan Falešník
+"""
+
+
+class variable(object):
+    """Create a new variable method."""
+
+    def __init__(self, f):
+        self._name = f.__name__
+        self._mapping = {'default': f}
+
+    def __get__(self, obj, objtype):
+        def caller(*args, **kwargs):
+            method = kwargs.pop("method", 'default')
+            try:
+                method = self._mapping[method]
+            except KeyError:
+                raise AttributeError(
+                    "Method {} does not have a variant for {}, valid variants are {}".format(
+                        self._name, method, ", ".join(self._mapping.keys())))
+            return method(obj, *args, **kwargs)
+        return caller
+
+    def variant(self, name):
+        """Register a new variant of a method under a name."""
+        def g(f):
+            self._mapping[name] = f
+
+        return g


### PR DESCRIPTION
Originally an idea by Pete, I implemented it using descriptors. Allows us to perform certain actions slightly different way.

There is one possible future feature, to be able to specify that "this variant wants a callback to the default function" to be able to make eg. the default function do some significant logic and the variants could do some wrapping of that logic without copying code.

{{pytest: utils/tests/test_varmeth.py -v}}