### PR TITLE
API change proposal

### DIFF
--- a/cfme/containers/provider.py
+++ b/cfme/containers/provider.py
@@ -7,6 +7,7 @@ from cfme.web_ui.menu import nav
 from utils.browser import ensure_browser_open
 from utils.db import cfmedb
 from utils.pretty import Pretty
+from utils.varmeth import variable
 
 from . import cfg_btn, mon_btn, pol_btn
 
@@ -116,65 +117,87 @@ class Provider(BaseProvider, Pretty):
             "AND ext_management_systems.name='{1}'".format(table_str, self.name))
         return int(res.first()[0])
 
-    def num_project(self, db=True):
-        if db:
-            return self._num_db_generic('container_projects')
-        else:
-            return int(self.get_detail("Relationships", "Projects"))
+    @variable(alias='db')
+    def num_project(self):
+        return self._num_db_generic('container_projects')
 
-    def num_service(self, db=True):
-        if db:
-            return self._num_db_generic('container_services')
-        else:
-            return int(self.get_detail("Relationships", "Services"))
+    @num_project.variant('ui')
+    def num_project_ui(self):
+        return int(self.get_detail("Relationships", "Projects"))
 
-    def num_replication_controller(self, db=True):
-        if db:
-            return self._num_db_generic('container_replicators')
-        else:
-            return int(self.get_detail("Relationships", "Replicators"))
+    @variable(alias='db')
+    def num_service(self):
+        return self._num_db_generic('container_services')
 
-    def num_container_group(self, db=True):
-        if db:
-            return self._num_db_generic('container_groups')
-        else:
-            return int(self.get_detail("Relationships", "Pods"))
+    @num_service.variant('ui')
+    def num_service_ui(self):
+        return int(self.get_detail("Relationships", "Services"))
 
-    def num_pod(self, db=True):
+    @variable(alias='db')
+    def num_replication_controller(self):
+        return self._num_db_generic('container_replicators')
+
+    @num_replication_controller.variant('ui')
+    def num_replication_controller_ui(self):
+        return int(self.get_detail("Relationships", "Replicators"))
+
+    @variable(alias='db')
+    def num_container_group(self):
+        return self._num_db_generic('container_groups')
+
+    @num_container_group.variant('ui')
+    def num_container_group_ui(self):
+        return int(self.get_detail("Relationships", "Pods"))
+
+    @variable(alias='db')
+    def num_pod(self):
         # potato tomato
-        return self.num_container_group(db)
+        return self.num_container_group()
 
-    def num_node(self, db=True):
-        if db:
-            return self._num_db_generic('container_nodes')
-        else:
-            return int(self.get_detail("Relationships", "Nodes"))
+    @num_pod.variant('ui')
+    def num_pod_ui(self):
+        # potato tomato
+        return self.num_container_group(method='ui')
 
-    def num_container(self, db=True):
-        if db:
-            # Containers are linked to providers through container definitions and then through pods
-            res = cfmedb().engine.execute(
-                "SELECT count(*) "
-                "FROM ext_management_systems, container_groups, container_definitions, containers "
-                "WHERE containers.container_definition_id=container_definitions.id "
-                "AND container_definitions.container_group_id=container_groups.id "
-                "AND container_groups.ems_id=ext_management_systems.id "
-                "AND ext_management_systems.name='{}'".format(self.name))
-            return int(res.first()[0])
-        else:
-            return int(self.get_detail("Relationships", "Containers"))
+    @variable(alias='db')
+    def num_node(self):
+        return self._num_db_generic('container_nodes')
 
-    def num_image(self, db=True):
-        if db:
-            return self._num_db_generic('container_images')
-        else:
-            return int(self.get_detail("Relationships", "Images"))
+    @num_node.variant('ui')
+    def num_node_ui(self):
+        return int(self.get_detail("Relationships", "Nodes"))
 
-    def num_image_registry(self, db=True):
-        if db:
-            return self._num_db_generic('container_image_registries')
-        else:
-            return int(self.get_detail("Relationships", "Image Registries"))
+    @variable(alias='db')
+    def num_container(self):
+        # Containers are linked to providers through container definitions and then through pods
+        res = cfmedb().engine.execute(
+            "SELECT count(*) "
+            "FROM ext_management_systems, container_groups, container_definitions, containers "
+            "WHERE containers.container_definition_id=container_definitions.id "
+            "AND container_definitions.container_group_id=container_groups.id "
+            "AND container_groups.ems_id=ext_management_systems.id "
+            "AND ext_management_systems.name='{}'".format(self.name))
+        return int(res.first()[0])
+
+    @num_container.variant('ui')
+    def num_container_ui(self):
+        return int(self.get_detail("Relationships", "Containers"))
+
+    @variable(alias='db')
+    def num_image(self):
+        return self._num_db_generic('container_images')
+
+    @num_image.variant('ui')
+    def num_image_ui(self):
+        return int(self.get_detail("Relationships", "Images"))
+
+    @variable(alias='db')
+    def num_image_registry(self):
+        return self._num_db_generic('container_image_registries')
+
+    @num_image_registry.variant('ui')
+    def num_image_registry_ui(self):
+        return int(self.get_detail("Relationships", "Image Registries"))
 
 
 class KubernetesProvider(Provider):
@@ -214,8 +237,10 @@ class OpenshiftProvider(Provider):
                 'port_text': kwargs.get('port'),
                 'zone_select': kwargs.get('zone')}
 
-    def num_route(self, db=True):
-        if db:
-            return self._num_db_generic('container_routes')
-        else:
-            return int(self.get_detail("Relationships", "Routes"))
+    @variable(alias='db')
+    def num_route(self):
+        return self._num_db_generic('container_routes')
+
+    @num_route.variant('ui')
+    def num_route_ui(self):
+        return int(self.get_detail("Relationships", "Routes"))

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -85,7 +85,7 @@ def test_provider_crud(provider):
         test_flag: crud
     """
     provider.create()
-    provider.validate(db=False)
+    provider.validate_stats(ui=True)
 
     old_name = provider.name
     with update(provider):

--- a/cfme/tests/containers/test_provider_crud.py
+++ b/cfme/tests/containers/test_provider_crud.py
@@ -24,7 +24,7 @@ def test_provider_crud(request, provider):
         test_flag: crud
     """
     provider.create()
-    provider.validate(db=False)
+    provider.validate_stats(ui=True)
 
     old_name = provider.name
     with update(provider):

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -99,4 +99,4 @@ def setup_provider(provider, original_provider_key):
 
 def test_validate(provider, setup_provider, provider_data):
     """Since the provider (host) gets added in the fixture, nothing special has to happen here."""
-    provider.validate(db=False)
+    provider.validate(ui=True)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -167,7 +167,7 @@ def test_provider_crud(provider):
     """
     provider.create()
     # Fails on upstream, all provider types - BZ1087476
-    provider.validate(db=False)
+    provider.validate_stats(ui=True)
 
     old_name = provider.name
     with update(provider):

--- a/utils/api.py
+++ b/utils/api.py
@@ -7,6 +7,7 @@ import re
 import requests
 import simplejson
 from copy import copy
+from fixtures.pytest_store import store
 from utils.log import logger
 from utils.version import Version
 from utils.wait import wait_for
@@ -282,7 +283,7 @@ class Entity(object):
     # TODO: Extend these fields
     TIME_FIELDS = {
         "updated_on", "created_on", "last_scan_attempt_on", "state_changed_on", "lastlogon",
-        "updated_at", "created_at", "last_scan_on", "last_sync_on"}
+        "updated_at", "created_at", "last_scan_on", "last_sync_on", "last_refresh_date"}
     COLLECTION_MAPPING = dict(
         ems_id="providers",
         storage_id="data_stores",
@@ -512,3 +513,7 @@ class Action(object):
 
     def __repr__(self):
         return "<Action {} {}#{}>".format(self._method, self._container._obj._href, self._name)
+
+
+def rest_api():
+    return store.current_appliance.rest_api

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 from time import sleep
 from urlparse import ParseResult, urlparse
 
+import dateutil.parser
 import requests
 
 from cfme.common.vm import VM
@@ -1017,6 +1018,14 @@ class IPAppliance(object):
             self.reboot(wait_for_web_ui=False, log_callback=log_callback)
 
         return result
+
+    def utc_time(self):
+        client = self.ssh_client
+        status, output = client.run_command('date --iso-8601=seconds -u')
+        if not status:
+            return dateutil.parser.parse(output)
+        else:
+            raise Exception("Couldn't get datetime: {}".format(output))
 
     @logger_wrap("Patch ajax wait: {}")
     def patch_ajax_wait(self, reverse=False, log_callback=None):

--- a/utils/varmeth.py
+++ b/utils/varmeth.py
@@ -73,6 +73,8 @@ class variable(object):
     def __get__(self, obj, objtype):
         def caller(*args, **kwargs):
             method = kwargs.pop("method", _default)
+            if not method:
+                method = _default
             try:
                 method = self._mapping[method]
             except KeyError:


### PR DESCRIPTION
This commit focuses on the introduction of the REST API and variable
methods into the provider framework.

* Updated varmeth to use the default if method is explicitly set to None
* Added utc_time() method to IPAppliance to return the UTC time for the
  appliance
* Updated REST API to recognise the "last_refresh_date" as a valid date
  field
* Made REST module follow convention of supplying the current
  appliance's REST API with a module rest_api() function
* Provider base gain some new methods:
  * refresh_provider_relationships_ui() - this was a migration of the
    original function, the original name is now used for the faster
    default REST version.
  * refresh_provider_relationships() - this is now REST by default
  * last_refresh_date() - this uses the REST API to collect the
    last_refresh_time. Currently there is no UI method, because it
    probably wouldn't be used.
  * is_refreshed() - a validate-esque compatible method to check if
    the provider has been refreshed recently, takes a refresh_timer so
    it can initiate a refresh before running
  * validate() - this method moved into validate_stats() and is replaced
    by a version which checks the last refresh time instead of
    validating all the stats.
  * all exisiting stats methods where possible have had REST versions attached

{{pytest: -k test_provider_crud -v --long-running }}