### PR TITLE
Added bz blocker 1276135 to group test cases

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -214,6 +214,7 @@ def test_current_user_login_delete(request):
 
 
 # Group test cases
+@pytest.mark.meta(blockers=[1276135])
 def test_group_crud():
     group = new_group()
     group.create()
@@ -222,6 +223,7 @@ def test_group_crud():
     group.delete()
 
 
+@pytest.mark.meta(blockers=[1276135])
 def test_group_duplicate_name():
     group = new_group()
     group.create()
@@ -229,6 +231,7 @@ def test_group_duplicate_name():
         group.create()
 
 
+@pytest.mark.meta(blockers=[1276135])
 def test_group_edit_tag():
     group = new_group()
     group.create()
@@ -240,6 +243,7 @@ def test_group_edit_tag():
     group.delete()
 
 
+@pytest.mark.meta(blockers=[1276135])
 def test_group_remove_tag():
     group = new_group()
     group.create()
@@ -253,6 +257,7 @@ def test_group_remove_tag():
     group.delete()
 
 
+@pytest.mark.meta(blockers=[1276135])
 def test_description_required_error_validation():
     group = ac.Group(description=None, role='EvmRole-approver')
     with error.expected("Description can't be blank"):
@@ -271,6 +276,7 @@ def test_delete_default_group():
     flash.assert_message_match(flash_msg.format(group.description))
 
 
+@pytest.mark.meta(blockers=[1276135])
 def test_delete_group_with_assigned_user():
     flash_msg = \
         'EVM Group "{}": Error during \'destroy\': Still has users assigned'
@@ -292,6 +298,7 @@ def test_edit_default_group():
     flash.assert_message_match(flash_msg.format(group.description))
 
 
+@pytest.mark.meta(blockers=[1276135])
 def test_edit_sequence_usergroups(request):
     """Test for editing the sequence of user groups for LDAP lookup.
 
@@ -353,6 +360,7 @@ def test_edit_default_roles():
     flash.assert_message_match("Read Only Role \"{}\" can not be edited" .format(role.name))
 
 
+@pytest.mark.meta(blockers=[1276135])
 def test_delete_roles_with_assigned_group():
     flash_msg = \
         'Role "{}": Error during \'destroy\': Cannot delete record because of dependent miq_groups'


### PR DESCRIPTION
{{pytest: -v -k 'test_group_crud or test_group_duplicate_name or test_group_edit_tag or test_group_remove_tag or test_description_required_error_validation or test_delete_group_with_assigned_user or test_edit_sequence_usergroups or test_delete_roles_with_assigned_group'}}
