### PR TITLE
Fix toolbar JS quoting

### DIFF
--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -87,16 +87,18 @@ def pf_select(root, sub=None, invokes_alert=False):
         sub = version.pick(sub)
 
     if sub:
+        q_sub = quoteattr(sub).replace("'", "\\'")
         sel.execute_script(
-            "return $('a:contains({})').trigger('click')".format(quoteattr(sub)))
+            "return $('a:contains({})').trigger('click')".format(q_sub))
     else:
+        q_root = quoteattr(root).replace("'", "\\'")
         try:
-            sel.element("//button[@data-original-title = {}]".format(quoteattr(root)))
+            sel.element("//button[@data-original-title = {}]".format(q_root))
             sel.execute_script(
-                "return $('*[data-original-title={}]').trigger('click')".format(quoteattr(root)))
+                "return $('*[data-original-title={}]').trigger('click')".format(q_root))
         except sel.NoSuchElementException:
             sel.execute_script(
-                "return $('button:contains({})').trigger('click')".format(quoteattr(root)))
+                "return $('button:contains({})').trigger('click')".format(q_root))
 
     if not invokes_alert:
         sel.wait_for_ajax()


### PR DESCRIPTION
The latest toolbar update did not take strings with '-s in it into an account. This simple fix tries to escape any of them before use.

{{pytest: cfme/tests/control/test_actions.py -v -k prevent --long-running }}