### PR TITLE
Fix syntax highlighter confusion

### DIFF
--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -536,7 +536,7 @@ class IPAppliance(object):
         # Currently parses the os version out of redhat release file to allow for
         # rhel and centos appliances
         res = self.ssh_client.run_command(
-            r"cat /etc/redhat-release | sed 's/.* release \(.*\) (.*/\1/'")
+            r"cat /etc/redhat-release | sed 's/.* release \(.*\) (.*/\1/' #)")
         if res.rc != 0:
             raise RuntimeError('Unable to retrieve appliance OS version')
         return Version(res.output)


### PR DESCRIPTION
At least sublime text has issues with its python highlighter, because it looks for matching ), which is not there because it is not a python regexp. I have put a ) in the comment so it does not affect anything but it makes the syntax highlighting work again properly.