### PR TITLE
New test distributor changes

### DIFF
--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -1559,6 +1559,10 @@ class IPAppliance(object):
             if not quiet:
                 raise
 
+    def delete_all_providers(self):
+        for prov in self.rest_api.collections.providers:
+            prov.action.delete()
+
 
 class ApplianceSet(object):
     """Convenience class to ease access to appliances in appliance_set


### PR DESCRIPTION
We found the old test distributor did nasty things, namely it allowed
slaves to die when there was still work to do. The cause of this is
disproportionate testing of providers, some providers have many tests,
others have few.

To combat this we have now set a limit to the number of providers an
appliance can manage. Does this mean the appliance _can_ be asked by the
framework to use more? Yes! Is this a test distribution issue? No! The
problem is that some test_groups have tests which are not all destined
for the same provider. I have not yet looked into this. There are also
random tests, where we cannot predict what providers will be used.

However, we now set a limit and unless there are no others tests, the
appliance will be cleansed of its providers before we send more tests.