### PR TITLE
Fix the is_dimmed() function in paginator.

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2180,7 +2180,7 @@ class Quadicon(Pretty):
         self._name = name
         self.qtype = qtype
 
-    @property
+    @classmethod
     def title_name(self):
         if version.current_version() > '5.5.0.7':
             return 'data-original-title'
@@ -2203,7 +2203,7 @@ class Quadicon(Pretty):
     def checkbox(self):
         """ Returns:  a locator for the internal checkbox for the quadicon"""
         return "//input[@type='checkbox' and ../../..//a[@{}={}]]".format(
-            self.title_name, quoteattr(self._name))
+            self.title_name(), quoteattr(self._name))
 
     @property
     def exists(self):
@@ -2218,14 +2218,14 @@ class Quadicon(Pretty):
         try:
             return sel.move_to_element('div/a',
                 root="//div[@id='quadicon' and ../../..//a[@{}={}]]".format(
-                    self.title_name, quoteattr(self._name)))
+                    self.title_name(), quoteattr(self._name)))
         except sel.NoSuchElementException:
             quads = sel.elements("//div[@id='quadicon']/../../../tr/td/a")
             if not quads:
                 raise sel.NoSuchElementException("Quadicon {} not found. No quads present".format(
                     self._name))
             else:
-                quad_names = [sel.get_attribute(quad, self.title_name) for quad in quads]
+                quad_names = [sel.get_attribute(quad, self.title_name()) for quad in quads]
                 raise sel.NoSuchElementException(
                     "Quadicon {} not found. These quads are present:\n{}".format(
                         self._name, ", ".join(quad_names)))
@@ -2233,7 +2233,7 @@ class Quadicon(Pretty):
     def _locate_quadrant(self, corner):
         """ Returns: a locator for the specific quadrant"""
         return "//div[contains(@class, {}) and ../../../..//a[@{}={}]]".format(
-            quoteattr("{}72".format(corner)), self.title_name,
+            quoteattr("{}72".format(corner)), self.title_name(),
             quoteattr(self._name))
 
     def __getattr__(self, name):
@@ -2283,7 +2283,7 @@ class Quadicon(Pretty):
             pages = paginator.pages()
         for page in pages:
             for href in sel.elements("//div[@id='quadicon']/../../../tr/td/a"):
-                yield cls(sel.get_attribute(href, cls.title_name), qtype)
+                yield cls(sel.get_attribute(href, cls.title_name()), qtype)
 
     @classmethod
     def first(cls, qtype=None):

--- a/cfme/web_ui/paginator.py
+++ b/cfme/web_ui/paginator.py
@@ -23,7 +23,7 @@ def page_controls_exist():
 
 
 def _page_nums():
-    return sel.element(_locator + _page_cell).text
+    return sel.text(_locator + _page_cell)
 
 
 def check_all():
@@ -32,8 +32,13 @@ def check_all():
 
 
 def is_dimmed(btn):
-    class_att = btn.get_attribute('class').split(" ")
-    if {"dimmed", "disabled"}.intersection(set(class_att)):
+    tag = sel.tag(btn)
+    if tag == "li":
+        class_attr = sel.get_attribute(btn, "class")
+    elif tag == "span":
+        class_attr = sel.get_attribute(sel.element("..", root=btn), "class")
+    class_att = set(re.split(r"\s+", class_attr))
+    if {"dimmed", "disabled"}.intersection(class_att):
         return True
 
 
@@ -91,8 +96,12 @@ def sort_by(sort):
 
 def rec_offset():
     """ Returns the first record offset."""
-    offset = re.search('\((Item|Items)*\s*(\d+)', _page_nums())
-    return offset.groups()[1]
+    if version.current_version() > "5.5.0.7":
+        offset = re.search(r"Showing\s*(\d+)-", _page_nums())
+        return offset.groups()[0]
+    else:
+        offset = re.search('\((Item|Items)*\s*(\d+)', _page_nums())
+        return offset.groups()[1]
 
 
 def rec_end():
@@ -106,7 +115,10 @@ def rec_end():
 
 def rec_total():
     """ Returns the total number of records."""
-    offset = re.search('(\d+)\)', _page_nums())
+    if version.current_version() > "5.5.0.7":
+        offset = re.search(r"of\s*(\d+)\s*(?:items?)?", _page_nums())
+    else:
+        offset = re.search('(\d+)\)', _page_nums())
     if offset:
         return offset.groups()[0]
     else:


### PR DESCRIPTION
Last modification of the paginator locators changed the target element from the 'li' to the one-level deeper 'span'. is_dimmed() checked the class attribute of the element for presence of the dimmed/disabled class, but that is only in the 'li', not in 'span', so I added a check that if it is a span, go one level up and check it there.

{{pytest: -k visual -v --long-running}}