### PR TITLE
Fix couple of things around update_rhel

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1405,7 +1405,4 @@ def disconnect_direct_lun(self, appliance_id):
 @singleton_task()
 def appliance_yum_update(self, appliance_id):
     appliance = Appliance.objects.get(id=appliance_id)
-    if appliance.preconfigured:
-        appliance.ipapp.update_rhel(setup_repos=False, reboot=False)
-    else:
-        appliance.ipapp.update_rhel(setup_repos=True, reboot=False)
+    appliance.ipapp.update_rhel(reboot=False)

--- a/utils/log.py
+++ b/utils/log.py
@@ -178,7 +178,7 @@ class logger_wrap(object):
             if not cb:
                 cb = logger.info
             kwargs['log_callback'] = lambda msg: cb(self.args[0].format(msg))
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         return newfunc
 
 

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -118,6 +118,10 @@ class SSHClient(paramiko.SSHClient):
             # Only install ssh keys if they aren't installed (or currently being installed)
             return super(SSHClient, self).connect(**self._connect_kwargs)
 
+    def open_sftp(self, *args, **kwargs):
+        self.connect()
+        return super(SSHClient, self).open_sftp(*args, **kwargs)
+
     def get_transport(self, *args, **kwargs):
         if self.connected:
             logger.trace('reusing ssh transport')


### PR DESCRIPTION
* First, the logger_wrap decorator threw away results.
* SSH's open_sftp() needed some care in order to work properly.
* Added a separate yaml key for rhel7 updates
* Abstracted the work with repo files. Now the framework can read what products are set up as repos, their versions, if you add the same URL again it won't create a new repo, if you add an url that is an update for a product it will delete repos for the product that were there before, and so...