### PR TITLE
Removed continue flag when provider equaled scvmm

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -35,9 +35,6 @@ def pytest_generate_tests(metafunc):
             # No provisioning data available
             continue
 
-        if args['provider'].type == "scvmm":
-            continue
-
         # required keys should be a subset of the dict keys set
         if not {'template', 'host', 'datastore'}.issubset(args['provisioning'].viewkeys()):
             # Need all three for template provisioning

--- a/scripts/template_upload_scvmm.py
+++ b/scripts/template_upload_scvmm.py
@@ -60,7 +60,7 @@ def make_template(client, hostname, name, library, network, ostype, username_scv
     script2 = "$JobGroupId01 = [Guid]::NewGuid().ToString();"
     script2 += "$LogNet = Get-SCLogicalNetwork -Name '" + network + "';"
     script2 += "New-SCVirtualNetworkAdapter -JobGroup $JobGroupID01 \
-            -MACAddressType Dynamic -LogicalNetwork $LogNet;"
+            -MACAddressType Dynamic -LogicalNetwork $LogNet -Synthetic;"
     script2 += "New-SCVirtualSCSIAdapter -JobGroup $JobGroupID01 -AdapterID 6 -Shared $False;"
     script2 += "New-SCHardwareProfile -Name '" + name + "' -Owner '" + username_scvmm + "' \
         -Description 'Temp profile used to create a VM Template' -MemoryMB  " + str(ram) + " \


### PR DESCRIPTION
Just removed the lines that bypassed the scvmm crud operations.

{{pytest: -k test_provision_from_template --use-provider scvmm}}