### PR TITLE
Fix up the no template power control test

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -678,13 +678,13 @@ def get_all_vms(do_not_navigate=False):
         sel.force_navigate('infra_vms')
     vms = set([])
 
-    title_attr = version.pick({
-        version.LOWEST: "title",
-        "5.5": "data-original-title"})
-
+    # This is really stupid, but I cannot come up with better getting of the attributes :(
     if not paginator.page_controls_exist():
         for title in sel.elements(QUADICON_TITLE_LOCATOR):
-            vms.add(sel.get_attribute(title, title_attr))
+            title_value = sel.get_attribute(title, "title")
+            if not title_value:
+                title_value = sel.get_attribute(title, "data-original-title")
+            vms.add(title_value)
         return vms
 
     paginator.results_per_page(1000)
@@ -692,7 +692,10 @@ def get_all_vms(do_not_navigate=False):
         try:
             for page in paginator.pages():
                 for title in sel.elements(QUADICON_TITLE_LOCATOR):
-                    vms.add(sel.get_attribute(title, title_attr))
+                    title_value = sel.get_attribute(title, "title")
+                    if not title_value:
+                        title_value = sel.get_attribute(title, "data-original-title")
+                    vms.add(title_value)
         except sel.NoSuchElementException:
             pass
     return vms

--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -86,7 +86,7 @@ def pf_select(root, sub=None, invokes_alert=False):
     sel.wait_for_ajax()
     if isinstance(root, dict):
         root = version.pick(root)
-    if sub is not None and isinstance(sub, dict):
+    if isinstance(sub, dict):
         sub = version.pick(sub)
 
     if sub:
@@ -106,8 +106,13 @@ def pf_select(root, sub=None, invokes_alert=False):
                 sel.execute_script(
                     "return $('button[title={}]').trigger('click')".format(q_root))
             except sel.NoSuchElementException:
-                sel.execute_script(
-                    "return $('button:contains({})').trigger('click')".format(q_root))
+                try:
+                    sel.element("//button[contains(@title, {})]".format(q_root))
+                    sel.execute_script(
+                        "return $('button:contains({})').trigger('click')".format(q_root))
+                except sel.NoSuchElementException:
+                    # The view selection buttons?
+                    sel.click("//li/a[@title={}]/i/../..".format(q_root))
 
     if not invokes_alert:
         sel.wait_for_ajax()
@@ -212,3 +217,31 @@ def refresh():
         sel.click("//div[@title='Reload current display']")
     else:
         sel.refresh()
+
+
+def exists(root, sub=None, and_is_not_greyed=False):
+    """ Checks presence and usability of toolbar buttons.
+
+    By default it checks whether the button is available, not caring whether it is greyed or not.
+    You can optionally enable check for greyedness.
+
+    Args:
+        root: Button name.
+        sub: Item name (optional)
+        and_is_not_greyed: Check if the button is available to click.
+
+    """
+    sel.wait_for_ajax()
+    if isinstance(root, dict):
+        root = version.pick(root)
+    if isinstance(sub, dict):
+        sub = version.pick(sub)
+
+    try:
+        greyed = is_greyed(root, sub)
+        if and_is_not_greyed:
+            return not greyed
+        else:
+            return True
+    except sel.NoSuchElementException:
+        return False


### PR DESCRIPTION
Required couple of changes around:
* Add exists() to toolbar. It is also able to check greyedness in it.
* Fix the get-all_vms to try both title and data-original-title (>_<)
* Rewrite the asserts in the test to soft_asserts using exists()
* Documented the test.
* Toolbar did not work properly with the new grid view buttons, this adds yet another exception handler specific for the buttons.

Closes #2414

{{pytest: cfme/tests/infrastructure/test_vm_power_control.py -v -k no_template_power_control --long-running }}