### PR TITLE
Work around the importerror with yaml files

### DIFF
--- a/utils/log.py
+++ b/utils/log.py
@@ -394,7 +394,13 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
     if relpath:
         # Only show warnings from inside this project
         message = "%s from %s:%d: %s" % (category.__name__, relpath, lineno, message)
-        logger.warning(message)
+        try:
+            logger.warning(message)
+        except ImportError:
+            # In case we have both credentials.eyaml and credentials.yaml, it gets in an import loop
+            # Therefore it would raise ImportError for art_client. Let's don't bother and just spit
+            # it out. This should reduce number of repeated questions down by 99%.
+            print "[WARNING] {}".format(message)
 
 
 def format_marker(mstring, mark="-"):


### PR DESCRIPTION
When there are both yaml and eyaml files, it tries to print out a warning that it ignores the encrypted yaml during the import. However, as this is happening during the import, the module with the yaml is not loaded yet and the warning print gets delegated to artifactor, which will then also try loading the same config file (credentials), resulting in import error.