### PR TITLE
[WIP] [NO TEST] Add support for non-standart ports

### DIFF
--- a/conf/credentials.yaml.template
+++ b/conf/credentials.yaml.template
@@ -32,6 +32,7 @@ netapp-storage:
 database:
     username: root
     password: password
+    port: 5432
 bad_credentials:
     username: bad
     password: reallybad

--- a/conf/env.yaml.template
+++ b/conf/env.yaml.template
@@ -9,3 +9,8 @@ browser:
 github:
     default_repo: foo/bar
     token: abcdef0123456789
+custom_ports:
+    ssh: 22
+    database: 5432
+ssh:
+    look_for_keys: true

--- a/utils/db.py
+++ b/utils/db.py
@@ -96,6 +96,9 @@ class Db(Mapping):
             self.hostname = hostname
 
         self.credentials = credentials or conf.credentials['database']
+        self.credentials['port'] = ports.DB
+        if 'custom_ports' in conf.env and 'database' in conf.env['custom_ports']:
+            self.credentials['port'] = conf.env['custom_ports']['database']
 
     def __getitem__(self, table_name):
         """Access tables as items contained in this db
@@ -213,7 +216,7 @@ class Db(Mapping):
     def db_url(self):
         """The connection URL for this database, including credentials"""
         template = "postgresql://{username}:{password}@{host}:{port}/vmdb_production"
-        result = template.format(host=self.hostname, port=ports.DB, **self.credentials)
+        result = template.format(host=self.hostname, **self.credentials)
         logger.info("[DB] db_url is {}".format(result))
         return result
 

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -48,11 +48,15 @@ class SSHClient(paramiko.SSHClient):
             'hostname': parsed_url.hostname,
             'timeout': 10,
             'allow_agent': False,
+            'port': ports.SSH,
             'look_for_keys': False,
             'gss_auth': False
         }
+        if 'ssh' in conf.env and 'look_for_keys' in conf.env['ssh']:
+            default_connect_kwargs['look_for_keys'] = conf.env['ssh'].get('look_for_keys', False)
 
-        default_connect_kwargs["port"] = ports.SSH
+        if 'custom_ports' in conf.env and 'ssh' in conf.env['custom_ports']:
+            default_connect_kwargs['port'] = conf.env['custom_ports'].get('ssh', ports.SSH)
 
         # Overlay defaults with any passed-in kwargs and store
         default_connect_kwargs.update(connect_kwargs)


### PR DESCRIPTION
This enables the tests to use non-standard ports for ssh and postgresql. This is a precondition to run tests on containerized appliance.

This also makes sure that look_for_keys for SSH connection is taken from config