### PR TITLE
toolbar: select either <i> or <img> when selecting a view 

### DIFF
--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -112,7 +112,7 @@ def pf_select(root, sub=None, invokes_alert=False):
                         "return $('button:contains({})').trigger('click')".format(q_root))
                 except sel.NoSuchElementException:
                     # The view selection buttons?
-                    sel.click("//li/a[@title={}]/i/../..".format(q_root))
+                    sel.click("//li/a[@title={}]/*[self::i or self::img]/../..".format(q_root))
 
     if not invokes_alert:
         sel.wait_for_ajax()


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_provisioning_dialog.py -v --long-running}}