### PR TITLE
Mark advanced search tests as affected with bug 1283554

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -125,6 +125,7 @@ def test_filter_save_cancel(hosts, hosts_with_vm_count, host_with_median_vm):
         search.load_filter(filter_name)  # does not exist
 
 
+@pytest.mark.meta(blockers=[1283554])
 @pytest.mark.requires("test_can_open_advanced_search")
 def test_filter_save_and_load(request, hosts, hosts_with_vm_count, host_with_median_vm):
     sel.force_navigate("infrastructure_hosts")
@@ -144,6 +145,7 @@ def test_filter_save_and_load(request, hosts, hosts_with_vm_count, host_with_med
     assert len(more_than_median_hosts) == len(host.get_all_hosts(do_not_navigate=True))
 
 
+@pytest.mark.meta(blockers=[1283554])
 @pytest.mark.requires("test_can_open_advanced_search")
 def test_filter_save_and_cancel_load(request, hosts, hosts_with_vm_count, host_with_median_vm):
     sel.force_navigate("infrastructure_hosts")
@@ -166,6 +168,7 @@ def test_filter_save_and_cancel_load(request, hosts, hosts_with_vm_count, host_w
     assert_no_cfme_exception()
 
 
+@pytest.mark.meta(blockers=[1283554])
 @pytest.mark.requires("test_can_open_advanced_search")
 def test_filter_save_and_load_cancel(request, hosts, hosts_with_vm_count, host_with_median_vm):
     sel.force_navigate("infrastructure_hosts")
@@ -224,6 +227,7 @@ def test_quick_search_with_filter(request, hosts, hosts_with_vm_count, host_with
     assert len(all_hosts_visible) == 1 and median_host in all_hosts_visible
 
 
+@pytest.mark.meta(blockers=[1283554])
 def test_can_delete_filter():
     sel.force_navigate("infrastructure_hosts")
     filter_name = fauxfactory.gen_alphanumeric()
@@ -238,7 +242,7 @@ def test_can_delete_filter():
     assert_no_cfme_exception()
 
 
-@pytest.mark.meta(blockers=[1097150])
+@pytest.mark.meta(blockers=[1097150, 1283554])
 def test_delete_button_should_appear_after_save(request):
     """Delete button appears only after load, not after save"""
     sel.force_navigate("infrastructure_hosts")
@@ -255,7 +259,7 @@ def test_delete_button_should_appear_after_save(request):
         pytest.fail("Could not delete filter right after saving!")
 
 
-@pytest.mark.meta(blockers=[1097150])
+@pytest.mark.meta(blockers=[1097150, 1283554])
 def test_cannot_delete_more_than_once(request):
     """When Delete button appars, it does not want to go away"""
     sel.force_navigate("infrastructure_hosts")

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -29,7 +29,7 @@ def pytest_runtest_setup(item):
 
 def pytest_exception_interact(node, call, report):
     name, location = get_test_idents(node)
-    val = unicode(call.excinfo.value)
+    val = unicode(call.excinfo.value.message.decode('utf-8'))
     short_tb = '%s\n%s' % (call.excinfo.type.__name__, val.encode('ascii', 'ignore'))
     art_client.fire_hook('filedump', test_location=location, test_name=name,
                   filename="traceback.txt", contents=str(report.longrepr), fd_ident="tb")

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -29,8 +29,8 @@ def pytest_runtest_setup(item):
 
 def pytest_exception_interact(node, call, report):
     name, location = get_test_idents(node)
-    val = unicode(call.excinfo.value.message.decode('utf-8'))
-    short_tb = '%s\n%s' % (call.excinfo.type.__name__, val.encode('ascii', 'ignore'))
+    val = call.excinfo.value.message.decode('utf-8', 'ignore')
+    short_tb = '%s\n%s' % (call.excinfo.type.__name__, val.encode('ascii', 'xmlcharrefreplace'))
     art_client.fire_hook('filedump', test_location=location, test_name=name,
                   filename="traceback.txt", contents=str(report.longrepr), fd_ident="tb")
     art_client.fire_hook('filedump', test_location=location, test_name=name,

--- a/utils/log.py
+++ b/utils/log.py
@@ -476,7 +476,7 @@ class ArtifactorLoggerAdapter(logging.LoggerAdapter):
             message = str(message)
         art_log_record = {
             'level': level_name,
-            'message': message.decode('utf-8').encode("ascii", "xmlcharrefreplace"),
+            'message': message.decode('utf-8', "ignore").encode("ascii", "xmlcharrefreplace"),
             'extra': kwargs.get('extra', '')
         }
         self.artifactor.fire_hook('log_message', log_record=art_log_record, slaveid=self.slaveid)

--- a/utils/log.py
+++ b/utils/log.py
@@ -476,7 +476,7 @@ class ArtifactorLoggerAdapter(logging.LoggerAdapter):
             message = str(message)
         art_log_record = {
             'level': level_name,
-            'message': message.encode("ascii", "xmlcharrefreplace"),
+            'message': message.decode('utf-8').encode("ascii", "xmlcharrefreplace"),
             'extra': kwargs.get('extra', '')
         }
         self.artifactor.fire_hook('log_message', log_record=art_log_record, slaveid=self.slaveid)


### PR DESCRIPTION
This also fixes several utf-8 decode problems in logging - this is required for other advanced search tests to pass

{{pytest: -v --long-running cfme/tests/infrastructure/test_advanced_search_host.py }}