### PR TITLE
safe_string() introduced

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -214,3 +214,24 @@ def deferred_verpick(version_d):
     def getter(self):
         return _version_pick(version_d)
     return getter
+
+
+def safe_string(o):
+    """This will make string out of ANYTHING without having to worry about the stupid Unicode errors
+
+    This function tries to make str/unicode out of ``o`` unless it already is one of those and then
+    it processes it so in the end there is a harmless ascii string.
+
+    Args:
+        o: Anything.
+    """
+    if not isinstance(o, basestring):
+        if hasattr(o, "__unicode__"):
+            o = unicode(o)
+        else:
+            o = str(o)
+    if isinstance(o, str):
+        o = o.decode('utf-8', "ignore")
+    if isinstance(o, unicode):
+        o = o.encode("ascii", "xmlcharrefreplace")
+    return o

--- a/utils/log.py
+++ b/utils/log.py
@@ -143,7 +143,7 @@ from traceback import extract_tb, format_tb
 
 import psphere
 
-from utils import conf, lazycache
+from utils import conf, lazycache, safe_string
 from utils.path import get_rel_path, log_path
 
 MARKER_LEN = 80
@@ -470,13 +470,9 @@ class ArtifactorLoggerAdapter(logging.LoggerAdapter):
         return SLAVEID or ""
 
     def art_log(self, level_name, message, kwargs):
-        if not isinstance(message, basestring):
-            # INTERNALERROR>     'message': message.encode("ascii", "xmlcharrefreplace"),
-            # INTERNALERROR> AttributeError: ReprExceptionInfo instance has no attribute 'encode'
-            message = str(message)
         art_log_record = {
             'level': level_name,
-            'message': message.decode('utf-8', "ignore").encode("ascii", "xmlcharrefreplace"),
+            'message': safe_string(message),
             'extra': kwargs.get('extra', '')
         }
         self.artifactor.fire_hook('log_message', log_record=art_log_record, slaveid=self.slaveid)

--- a/utils/tests/test_safe_string.py
+++ b/utils/tests/test_safe_string.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from utils import safe_string
+
+
+@pytest.mark.parametrize("source, result", [
+    (u'\u25cf', '&#9679;'),
+    (u'ěšč', '&#283;&#353;&#269;'),
+    (u'взорваться', '&#1074;&#1079;&#1086;&#1088;&#1074;&#1072;&#1090;&#1100;&#1089;&#1103;'),
+    (4, '4')],
+    ids=['ugly_nonunicode_character', 'latin_diacritics', 'cyrillic', 'non_string'])
+def test_safe_string(source, result):
+    assert safe_string(source) == result


### PR DESCRIPTION
Introduced a safe_string() function that is used in the art_log to polish the strings. Also added a test for it.

{{pytest: utils/tests/test_safe_string.py -v}}