### PR TITLE
Introduce multi screenshot support and deobscurize errors hidden by appliance CM

### DIFF
--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -179,6 +179,17 @@ class Reporter(ArtifactorBasePlugin):
                     test_data['duration'] = time.time() - test['start_time']
                     test_data['in_progress'] = True
 
+            # Prepare screenshots
+            test_data["screenshots"] = []
+            for screenshot in test.get("screenshots", []):
+                new_dict = {}
+                for k, v in screenshot.iteritems():
+                    if isinstance(v, basestring):
+                        new_dict[k] = v.replace(log_dir, "")
+                    else:
+                        new_dict[k] = v
+                test_data["screenshots"].append(new_dict)
+
             # Set up destinations for the files
             for ident in test.get('files', []):
                 if "softassert" in ident:

--- a/artifactor/plugins/screenshots.py
+++ b/artifactor/plugins/screenshots.py
@@ -1,0 +1,101 @@
+""" Multi screenshot plugin for Artifactor
+
+This plugin enables you to store multiple screenshots inside your test run. Comes with a
+:py:func:`fixtures.screenshots.take_screenshot` fixture to take screenshots.
+
+Developed mainly for the :py:class:`utils.appliance.IPAppliance` which will destroy the browser
+once you exit the context manager, therefore obscuring the original error.
+
+Add a stanza to the artifactor config like this,
+artifactor:
+    log_dir: /home/username/outdir
+    per_run: test #test, run, None
+    overwrite: True
+    plugins:
+        screenshots:
+            enabled: True
+            plugin: screenshots
+
+Requires the filedump plugin
+"""
+
+from artifactor import ArtifactorBasePlugin
+
+from collections import namedtuple
+from utils import safe_string, normalize_text
+import os.path
+import os
+import re
+
+
+class MultiScreenshots(ArtifactorBasePlugin):
+    Screenshot = namedtuple("Screenshot", ["name", "screenshot", "screenshot_error", "traceback"])
+
+    class Result(object):
+        def __init__(self, name):
+            self.name = name
+            self.screenshot = None
+            self.traceback = None
+
+    def plugin_initialize(self):
+        self.register_plugin_hook('finish_test', self.finish_test)
+        self.register_plugin_hook('add_screenshot', self.add_screenshot)
+
+    def configure(self):
+        self.screenshots = {}
+        self.configured = True
+
+    @ArtifactorBasePlugin.check_configured
+    def add_screenshot(self, test_name, test_location, artifacts):
+        test_ident = "{}/{}".format(test_location, test_name)
+        if test_ident not in self.screenshots:
+            self.screenshots[test_ident] = []
+        self.screenshots[test_ident].append(
+            self.Screenshot(
+                artifacts["name"], artifacts.get("screenshot", None),
+                artifacts.get("screenshot_error", None), artifacts.get("traceback", None)))
+        return None, None
+
+    @ArtifactorBasePlugin.check_configured
+    def finish_test(self, artifact_path, test_name, test_location):
+        test_ident = "{}/{}".format(test_location, test_name)
+
+        artifacts = []
+        try:
+            screenshots = self.screenshots[test_ident]
+        except KeyError:
+            screenshots = []
+        for screenshot in screenshots:
+            name = screenshot.name
+            safe_name = re.sub(r"\s+", "_", normalize_text(safe_string(name)))
+            filename_mapping = {
+                "traceback": "multiss-{}.log".format(safe_name),
+                "screenshot": "multiss-{}.png".format(safe_name),
+                "screenshot_error": "multiss-{}.txt".format(safe_name),
+            }
+            result = {
+                "name": name,
+                "screenshot": None,
+                "traceback": None,
+            }
+            include_result = False
+            for attr_name, filename in filename_mapping.iteritems():
+                data = getattr(screenshot, attr_name, None)
+                if data:
+                    os_filename = os.path.join(artifact_path, filename)
+                    with open(os_filename, "wb") as f:
+                        f.write(data.decode("base64"))
+                    if attr_name == "traceback":
+                        result["traceback"] = os_filename
+                        include_result = True
+                    elif attr_name in {"screenshot", "screenshot_error"}:
+                        result["screenshot"] = os_filename
+                        include_result = True
+            if include_result:
+                artifacts.append(result)
+        try:
+            del self.screenshots[test_ident]
+        except KeyError:
+            pass
+
+        return None, {"artifacts": {test_ident: {"screenshots": artifacts}}}

--- a/data/templates/test_report.html
+++ b/data/templates/test_report.html
@@ -270,6 +270,20 @@
                 </div>
 		<br>
 	    {% endif %}
+            {% if test.screenshots %}
+            <h4>Captured screenshots (and tracebacks, if applicable)</h4>
+            <ul>
+            {% for screenshot in test.screenshots %}
+              <li>
+              <a href="{{screenshot.screenshot}}" class="btn btn-primary" role="button">Screenshot for {{screenshot.name}}</a>
+              {% if screenshot.traceback %}
+                <a href="{{screenshot.traceback}}" class="btn btn-danger" role="button">Traceback for {{screenshot.name}}</a>
+              {% endif %}
+              </li>
+            {% endfor %}
+            </ul>
+
+            {% endif %}
             <div>
                 <h3>Artifacts</h3>
                 {% if test.rbac_screenshot %}

--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -129,7 +129,7 @@ def pytest_runtest_setup(item):
 
     name, location = get_test_idents(item)
     test_location = location
-    test_name = test_name
+    test_name = name
     art_client.fire_hook('start_test', test_location=location, test_name=name,
                          slaveid=SLAVEID, ip=appliance_ip_address)
     yield

--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -116,7 +116,8 @@ def pytest_configure(config):
     yield
 
 
-def pytest_runtest_protocol(item):
+@pytest.mark.hookwrapper
+def pytest_runtest_setup(item):
     global session_ver
 
     if not session_ver:
@@ -131,6 +132,7 @@ def pytest_runtest_protocol(item):
     test_name = test_name
     art_client.fire_hook('start_test', test_location=location, test_name=name,
                          slaveid=SLAVEID, ip=appliance_ip_address)
+    yield
 
 
 def pytest_runtest_teardown(item, nextitem):

--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -84,6 +84,10 @@ if env.get('slaveid', None):
 appliance_ip_address = urlparse(env['base_url']).netloc
 session_ver = None
 
+# Used for the multiscreenshots
+test_location = None
+test_name = None
+
 
 def pytest_addoption(parser):
     parser.addoption("--run-id", action="store", default=None,
@@ -119,17 +123,26 @@ def pytest_runtest_protocol(item):
         session_ver = str(version.current_version())
         art_client.fire_hook('session_info', version=session_ver)
 
+    global test_name
+    global test_location
+
     name, location = get_test_idents(item)
+    test_location = location
+    test_name = test_name
     art_client.fire_hook('start_test', test_location=location, test_name=name,
                          slaveid=SLAVEID, ip=appliance_ip_address)
 
 
 def pytest_runtest_teardown(item, nextitem):
+    global test_name
+    global test_location
     name, location = get_test_idents(item)
     art_client.fire_hook('finish_test', test_location=location, test_name=name,
                          slaveid=SLAVEID, ip=appliance_ip_address)
     art_client.fire_hook('sanitize', test_location=location, test_name=name,
                          fd_idents=['func_trace'], words=words)
+    test_name = None
+    test_location = None
 
 
 def pytest_runtest_logreport(report):

--- a/fixtures/screenshots.py
+++ b/fixtures/screenshots.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Taking screenshots inside tests!
+
+If you want to take a screenshot inside your test, just do it like this:
+
+.. code-block:: python
+    def test_my_test(take_screenshot):
+        # do something
+        take_screenshot("Particular name for the screenshot")
+        # do something else
+
+"""
+import pytest
+
+from fixtures.artifactor_plugin import art_client
+from utils.log import logger
+
+
+@pytest.fixture(scope="function")
+def take_screenshot(request):
+    def _take_screenshot(name):
+        test_name = request.node.location[2]
+        test_location = request.node.location[0]
+        logger.info("Taking a screenshot named {}".format(name))
+        ss, ss_error = pytest.sel.take_screenshot()
+        if ss_error:
+            ss_error = ss_error.encode("base64")
+        artifacts = {
+            'name': name,
+            'screenshot': ss,
+            'screenshot_error': ss_error}
+
+        art_client.fire_hook(
+            'add_screenshot',
+            test_name=test_name,
+            test_location=test_location,
+            artifacts=artifacts)
+
+    return _take_screenshot

--- a/utils/artifactor_start.py
+++ b/utils/artifactor_start.py
@@ -2,7 +2,8 @@
 
 from artifactor import Artifactor, initialize
 import argparse
-from artifactor.plugins import merkyl, logger, video, filedump, reporter, post_result, softassert
+from artifactor.plugins import (
+    merkyl, logger, video, filedump, reporter, post_result, softassert, screenshots)
 from artifactor import parse_setup_dir
 from utils.conf import env
 from utils.path import log_path
@@ -27,6 +28,7 @@ def run(port, run_id=None):
     art.register_plugin(video.Video, "video")
     art.register_plugin(filedump.Filedump, "filedump")
     art.register_plugin(softassert.SoftAssert, "softassert")
+    art.register_plugin(screenshots.MultiScreenshots, "screenshots")
     art.register_plugin(reporter.Reporter, "reporter")
     art.register_plugin(post_result.PostResult, "post-result")
     art.register_hook_callback('filedump', 'pre', parse_setup_dir,
@@ -39,6 +41,7 @@ def run(port, run_id=None):
     art.configure_plugin('video')
     art.configure_plugin('filedump')
     art.configure_plugin('softassert')
+    art.configure_plugin('screenshots')
     art.configure_plugin('reporter')
     art.configure_plugin('post-result')
     art.fire_hook('start_session', run_id=run_id)


### PR DESCRIPTION
* Introduce functionality for taking multiple screenshots (and tracebacks) for the report.
* Teach appliance class to use this functionality when leaving the CM inside of the test run.

{{pytest: cfme/tests/distributed/test_appliance_replication.py -v --long-running}}