### PR TITLE
remove bz blocker for copy orchestration template

### DIFF
--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -73,7 +73,6 @@ def test_orchestration_template_crud(provisioning):
     template.delete()
 
 
-@pytest.mark.meta(blockers=[1271723])
 def test_copy_template(provisioning):
     template_type = provisioning['stack_provisioning']['template_type']
     template = OrchestrationTemplate(template_type=template_type,


### PR DESCRIPTION
{{pytest: -v -k 'test_copy_template'}}