### PR TITLE
menu: click on 'Grid View' only if it exists

### DIFF
--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -22,7 +22,8 @@ def get_current_toplevel_name():
 def _tree_func_with_grid(*args):
     def f():
         accordion.tree(*args)
-        toolbar.select('Grid View')
+        if toolbar.exists('Grid View'):
+            toolbar.select('Grid View')
     return f
 
 # Dictionary of (nav destination name, section title) section tuples


### PR DESCRIPTION
Due to https://bugzilla.redhat.com/show_bug.cgi?id=1289248 we shouldn't assume that the button exists

{{ pytest: cfme/tests/infrastructure/test_provisioning_dialog.py -v --long-running }}