### PR TITLE
Fix toolbar name collision

### DIFF
--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -146,9 +146,13 @@ def old_select(root, sub=None, invokes_alert=False):
     else:
         search = root_loc(root)
 
-    try:
-        idd = sel.get_attribute(search, 'idd')
-    except sel.NoSuchElementException:
+    eles = sel.elements(search)
+
+    for ele in eles:
+        idd = sel.get_attribute(ele, 'idd')
+        if idd:
+            break
+    else:
         raise ToolbarOptionGreyedOrUnavailable(
             "Toolbar button {}/{} is greyed or unavailable!".format(root, sub))
 


### PR DESCRIPTION
A strange situation occured where the locator for the sub actually
matched the main link element for the Timelines page. Subsequently when
we were trying to select the timelines toolbar for monitoring, the first
element being returned was actually the element from hte main nav, which
didn't have the 'idd' attribute. So we now see if multiple elements were
found, which one has the idd element.

{{pytest: -k timelines --use-provider vsphere55}}