### PR TITLE
Added composite run option

### DIFF
--- a/artifactor/__init__.py
+++ b/artifactor/__init__.py
@@ -166,7 +166,8 @@ class Artifactor(Rigger):
             'artifactor_config': self.config,
             'log_dir': self.log_dir.strpath,
             'artifact_dir': self.artifact_dir.strpath,
-            'artifacts': dict()
+            'artifacts': dict(),
+            'old_artifacts': dict()
         }
 
     def handle_failure(self, exc):
@@ -194,6 +195,8 @@ def initialize(artifactor):
                                       name="default_finish_test")
     artifactor.register_hook_callback('start_session', 'pre', start_session,
                                       name="default_start_session")
+    artifactor.register_hook_callback('build_report', 'pre', merge_artifacts,
+                                      name="merge_artifacts")
     artifactor.initialized = True
 
 
@@ -202,6 +205,15 @@ def start_session(run_id=None):
     Convenience fire_hook for built in hook
     """
     return None, {'run_id': run_id}
+
+
+def merge_artifacts(old_artifacts, artifacts):
+    """
+    This is extremely important and merges the old_Artifacts from a composite-uncollect build
+    with the new artifacts for this run
+    """
+    old_artifacts.update(artifacts)
+    return {'old_artifacts': old_artifacts}, None
 
 
 def parse_setup_dir(test_name, test_location, artifactor_config, artifact_dir, run_id):

--- a/data/templates/test_report.html
+++ b/data/templates/test_report.html
@@ -32,13 +32,20 @@
       <h1>Test Report</h1>
       {% if version %}<h2>Version: {{version}}</h2>{% endif %}
     </div>
-    <div class="col-md-8 text-right">
+    <div class="col-md-8 text-right">Composite Run:
       <span class="label label-success">{{counts.passed}} Passed &nbsp;<input id="passed-check" type="checkbox" onclick="check_name('passed');"></span>
       <span class="label label-primary">{{counts.skipped}} Skipped &nbsp;<input id="skipped-check" type="checkbox" onclick="check_name('skipped');"></span>
       <span class="label label-warning">{{counts.failed}} Failed &nbsp;<input id="failed-check" type="checkbox" onclick="check_name('failed');" checked="checked"></span>
       <span class="label label-danger">{{counts.error}} Error &nbsp;<input id="error-check" type="checkbox" onclick="check_name('error');" checked="checked"></span>
       <span class="label label-danger">{{counts.xpassed}} XPassed &nbsp;<input id="xpassed-check" type="checkbox" onclick="check_name('xpassed');" checked="checked"></span>
-      <span class="label label-success">{{counts.xfailed}} XFailed &nbsp;<input id="xfailed-check" type="checkbox" onclick="check_name('xfailed');"></span>
+      <span class="label label-success">{{counts.xfailed}} XFailed &nbsp;<input id="xfailed-check" type="checkbox" onclick="check_name('xfailed');"></span><br>
+      This Run:
+      <span class="label label-success">{{current_counts.passed}} Passed &nbsp;<input id="passed-check" type="checkbox" onclick="check_name('passed');"></span>
+      <span class="label label-primary">{{current_counts.skipped}} Skipped &nbsp;<input id="skipped-check" type="checkbox" onclick="check_name('skipped');"></span>
+      <span class="label label-warning">{{current_counts.failed}} Failed &nbsp;<input id="failed-check" type="checkbox" onclick="check_name('failed');" checked="checked"></span>
+      <span class="label label-danger">{{current_counts.error}} Error &nbsp;<input id="error-check" type="checkbox" onclick="check_name('error');" checked="checked"></span>
+      <span class="label label-danger">{{current_counts.xpassed}} XPassed &nbsp;<input id="xpassed-check" type="checkbox" onclick="check_name('xpassed');" checked="checked"></span>
+      <span class="label label-success">{{current_counts.xfailed}} XFailed &nbsp;<input id="xfailed-check" type="checkbox" onclick="check_name('xfailed');"></span>
     <br>
     <form>User Filter:
       <select class="toggle-user">
@@ -48,6 +55,8 @@
       Show Blocker Skips<input id="show-blockers" type="checkbox" onclick="check_blockers();">
       &nbsp;
       Show Provider Skips<input id="show-providers" type="checkbox" onclick="check_providers();">
+      &nbsp;
+      Show Old Tests<input id="show-old" type="checkbox" onclick="check_old();">
     </form>
     </div>
   </div>
@@ -112,7 +121,7 @@
   <div class="col-md-8">
     <p></p>
 {% for test in tests %}
-    <div data="{{test.outcomes['overall']}}" {% if test.qa_contact %} data-qa="{{test.qa_contact[0][0]}}" {% else %} data-qa="Unknown" {% endif %} {% if test.skip_blocker %} data-blocker="{{test.skip_blocker}}" {% else %} data-blocker="None" {% endif %} {% if test.skip_provider %} data-provider="{{test.skip_provider}}" {% else %} data-provider="None" {% endif %} class="panel panel-inverse panel-{{test.color}}" data-test="test">
+    <div data="{{test.outcomes['overall']}}" {% if test.qa_contact %} data-qa="{{test.qa_contact[0][0]}}" {% else %} data-qa="Unknown" {% endif %} {% if test.skip_blocker %} data-blocker="{{test.skip_blocker}}" {% else %} data-blocker="None" {% endif %} {% if test.old %} data-old="{{test.old}}" {% else %} data-old="None" {% endif %} {% if test.skip_provider %} data-provider="{{test.skip_provider}}" {% else %} data-provider="None" {% endif %} class="panel panel-inverse panel-{{test.color}}" data-test="test">
         <div class="panel-heading">
             <div class="row">
                 <div class="col-md-10">
@@ -331,6 +340,20 @@ toggle_state = ['failed', 'error', 'xpassed']
 toggle_user = "none"
 toggle_blockers = false
 toggle_providers = false
+toggle_old = false
+
+function check_old()
+{
+  if ($('#show-old').is(":checked"))
+  {
+    toggle_old = true
+  }
+  else
+  {
+    toggle_old = false
+  }
+  update_display()
+}
 
 function check_blockers()
 {
@@ -402,6 +425,11 @@ function update_display()
       $(this).hide()
       return
     }
+    if (toggle_old == false && $(this).attr('data-old') != "None")
+    {
+      $(this).hide()
+      return
+    }
     $(this).show()
     return
   })
@@ -451,6 +479,7 @@ states = ["passed", "failed", "xpassed", "xfailed", "skipped", "error"]
 toggle_user = $(".toggle-user").val()
 check_providers()
 check_blockers()
+check_old()
 for (state in states){
   check_name(states[state])
 }

--- a/markers/composite.py
+++ b/markers/composite.py
@@ -1,0 +1,78 @@
+from fixtures.artifactor_plugin import get_test_idents
+from utils.composite import ReportCompile
+from fixtures.pytest_store import store
+from fixtures.artifactor_plugin import art_client
+from utils.log import logger
+from utils import version
+from utils.trackerbot import api
+
+
+def pytest_addoption(parser):
+    parser.addoption("--composite-uncollect", action="store_true", default=False,
+                     help="Enables composite uncollecting")
+    parser.addoption("--composite-job-name", action="store", default=None,
+                     help="Overrides the default job name which is derived from the appliance")
+    parser.addoption("--composite-template-name", action="store", default=None,
+                     help="Overrides the default template name which is obtained from trackerbot")
+
+
+def pytest_collection_modifyitems(session, config, items):
+    if not config.getvalue('composite_uncollect'):
+        return
+
+    len_collected = len(items)
+
+    new_items = []
+
+    try:
+        stream_name = version.get_stream(version.current_version())
+        job_name = config.getvalue('composite_job_name') or "{}-tests".format(stream_name)
+        template_name = config.getvalue('composite_template_name') or \
+            api().group.get(name=stream_name)['objects'][0]['latest_template']
+        store.terminalreporter.write(
+            "Trying to collect composite results for "
+            "stream [{}], template [{}] and job [{}]\n".format(
+                stream_name, template_name, job_name))
+        if stream_name == "upstream":
+            rc = ReportCompile(job_name=job_name, template=template_name, num_builds=5)
+        else:
+            rc = ReportCompile(job_name=job_name, template=template_name)
+        pl = rc.compile()
+    except Exception as e:
+        store.terminalreporter.write("Stream collection failed: {}\n".format(e))
+        pl = None
+
+    if pl:
+        for test in pl['tests']:
+            pl['tests'][test]['old'] = True
+
+        # Here we pump into artifactor
+        art_client.fire_hook('composite_pump', old_artifacts=pl['tests'])
+        for item in items:
+            try:
+                name, location = get_test_idents(item)
+                test_ident = "{}/{}".format(location, name)
+                status = pl['tests'][test_ident]['statuses']['overall']
+
+                if status == 'passed':
+                    logger.info('Uncollecting {} as it passed last time'.format(item.name))
+                    continue
+                else:
+                    print item.name
+                    new_items.append(item)
+            except:
+                print item.name
+                new_items.append(item)
+
+        items[:] = new_items
+
+    len_filtered = len(items)
+    filtered_count = len_collected - len_filtered
+
+    if filtered_count:
+        # A warning should go into log/cfme.log when a test has this mark applied.
+        # It might be good to write uncollected test names out via terminalreporter,
+        # but I suspect it would be extremely spammy. It might be useful in the
+        # --collect-only output?
+        store.terminalreporter.write(
+            '{} tests uncollected because they previously passed'.format(filtered_count), bold=True)

--- a/utils/composite.py
+++ b/utils/composite.py
@@ -1,0 +1,310 @@
+import json
+import socket
+from argparse import ArgumentParser
+from collections import OrderedDict
+from Queue import Queue
+from threading import Lock, Thread
+
+from paramiko import SSHException
+from progress.bar import IncrementalBar as Bar
+from py.path import local
+from scp import SCPClient, SCPException
+
+from artifactor.plugins import reporter
+from artifactor.plugins.post_result import test_counts
+from utils.conf import composite, credentials
+from utils import trackerbot
+from utils.ssh import SSHClient
+
+lock = Lock()
+# These should pretty much never change...
+jenkins_host = composite['jenkins_host']
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument('job_name')
+    parser.add_argument('template')
+    parser.add_argument('--no-artifacts', '-a', default=True,
+        help='Download the artifacts for the reports', action="store_true")
+    parser.add_argument('--work-dir', '-d', default=None,
+        help='Directory to use for caching work (a random dir will be used if missing)')
+    parser.add_argument('--num-builds', '-n', type=int, default=0,
+        help='Limit considered builds (after exclusions) to this number')
+    parser.add_argument('--minimum-build', '-m', type=int, default=0,
+        help='Do not consider build numbers lower than this')
+    parser.add_argument('--exclude-builds', '-x', type=int, nargs='+', default=[],
+        help='Exclude the given build number, multiple builds can be specified')
+    args = parser.parse_args()
+    return args
+
+
+def _queue_worker(rc):
+    # multithreaded file puller, takes tuples of remote, local, item, items_done
+    # pulls the files and then updates the progress meter
+    client = rc.ssh_client
+    client.connect(jenkins_host, username=credentials['jenkins-result']['username'],
+            password=credentials['jenkins-result']['password'],
+            timeout=10,
+            allow_agent=False,
+            look_for_keys=False,
+            gss_auth=False)
+    scp = None
+
+    while True:
+        source, destination, item, items_done = rc._queue.get()
+        destination = local(destination)
+        destination_dir = local(destination.dirname)
+        destination_dir.ensure(dir=True)
+        if not destination.check():
+            if scp is None:
+                scp = SCPClient(client.get_transport())
+            try:
+                scp.get(source, destination.strpath)
+            except SCPException:
+                # remote destination didn't exist
+                pass
+            except (SSHException, socket.timeout):
+                # SSH blew up :(
+                rc._queue.put((source, destination, item, items_done))
+                rc._queue.task_done()
+                continue
+        rc._progress_update(item, items_done)
+        rc._queue.task_done()
+
+
+class ReportCompile(object):
+    def __init__(self, job_name, template, **kwargs):
+        self.job_name = job_name
+        self.template = template
+        self.no_artifacts = kwargs.get('no_artifacts', True)
+        self.num_builds = int(kwargs.get('num_builds', composite['num_builds']))
+        self.minimum_build = int(kwargs.get('minimum_build', composite['min_build']))
+        self.exclude_builds = [int(xb) for xb in kwargs.get('exclude_builds', [])]
+        try:
+            self.work_dir = local(kwargs.get('work_dir', composite['work_dir']))
+            self.work_dir.ensure(dir=True)
+        except KeyError:
+            self.work_dir = local.mkdtemp()
+            print 'Writing composite report to {}'.format(self.work_dir.strpath)
+        self._progress = None
+        self._queue = Queue()
+        num_workers = 4
+        for __ in xrange(num_workers):
+            worker = Thread(target=_queue_worker, args=(self,))
+            worker.daemon = True
+            worker.start()
+
+    @property
+    def ssh_client(self):
+        c = SSHClient()
+        return c
+
+    @staticmethod
+    def _best_result(*results):
+        # results should be a list of (result_id, result_value) tuples
+        # result ranking, best to worst
+        results_ranking = ('passed', 'xfailed', 'failed', 'xpassed', 'skipped', 'error')
+        # Go through all the results, returning the best outcome based on results_ranking
+        for result in results_ranking:
+            for result_id, result_value in reversed(sorted(results, key=lambda r: r[0])):
+                if result_value == result:
+                    return (result_id, result_value)
+
+    @staticmethod
+    def _streak(*results):
+        sorted_results = sorted(results, key=lambda r: r[0])
+        # the value of the highest numbered (and therefore more recent) build
+        latest_result = sorted_results[-1][1]
+        streak = 0
+        for __, result_value in reversed(sorted_results):
+            if result_value == latest_result:
+                streak += 1
+            else:
+                break
+        return {'latest_result': latest_result, 'count': streak}
+
+    def _progress_update(self, item, items_done):
+        if self._progress is None:
+            self._progress = Bar()
+            self._progress.message = '%(index)d/%(max)d'
+            self._progress.suffix = ''
+        if item:
+            items_done[item] = True
+        self._progress.max = len(items_done)
+        self._progress.index = len(filter(None, items_done.values()))
+        with lock:
+            try:
+                self._progress.update()
+            except ZeroDivisionError:
+                pass
+
+    def _progress_finish(self):
+        self._progress.finish()
+        self._progress = None
+
+    def compile(self):
+        return self.composite_report()
+
+    def build_numbers(self):
+        api = trackerbot.api()
+        builds = trackerbot.depaginate(api,
+            api.build.get(job_name=self.job_name, template=self.template)
+        )
+        build_numbers = []
+        # XXX relying on trackerbot giving us the most recent builds first, should be explicit
+        for build in builds.get('objects', []):
+            if (build['number'] not in self.exclude_builds
+                    and build['number'] >= self.minimum_build):
+                build_numbers.append(build['number'])
+                if self.num_builds and len(build_numbers) == self.num_builds:
+                    break
+        if build_numbers:
+            print 'Pulling reports from builds {}'.format(
+                ', '.join([str(n) for n in build_numbers]))
+        return build_numbers
+
+    def template_log_dirs(self):
+        log_dir_tpl = composite['log_dir_tpl']
+        log_dirs = []
+        for build_number in self.build_numbers():
+            log_dirs.append((build_number, log_dir_tpl.format(self.job_name, build_number)))
+        return log_dirs
+
+    def test_reports(self):
+        print 'Collecting test reports to determine best build nodes'
+        log_dirs = self.template_log_dirs()
+        reports = {}
+        c = self.ssh_client
+        c.connect(jenkins_host, username=credentials['jenkins-result']['username'],
+            password=credentials['jenkins-result']['password'],
+            timeout=10,
+            allow_agent=False,
+            look_for_keys=False,
+            gss_auth=False)
+        builds_done = {}
+        self._progress_update(None, builds_done)
+        for build_number, log_dir in log_dirs:
+            build_work_dir = local(self.work_dir.join(str(build_number)))
+            build_work_dir.ensure(dir=True)
+            _remote = local(log_dir).join('test-report.json').strpath
+            _local = build_work_dir.join('test-report.json').strpath
+            builds_done[build_number] = False
+            self._progress_update(None, builds_done)
+            self._queue.put((_remote, _local, build_number, builds_done))
+        self._queue.join()
+        self._progress_finish()
+        for build_number, __ in log_dirs:
+            build_work_dir = local(self.work_dir.join(str(build_number)))
+            for path in build_work_dir.visit('*/test-report.json'):
+                try:
+                    report = json.load(path.open())
+                    reports[build_number] = report
+                except:
+                    # invalid json, skip this report
+                    pass
+        return reports
+
+    def composite_status(self, reports=None):
+        reports = reports or self.test_reports()
+        results = {}
+        # results dict structure:
+        # {
+        #   nodeid: {
+        #     'build_results': {build_id_1: build_id_1_result, build_id_2: ...}
+        #     'best_result': (best_build_id, best_build_result)
+        #     'result_url': http://jenkins/path/to/build
+        #     'streak': (latest_build_result, number_of_results_in_a_row)
+        #   },
+        #   nodeid: {
+        #     ...
+        #   }
+        # }
+        for build_number, report in reports:
+            for nodeid, nodedata in report.get('tests', {}).items():
+                try:
+                    # Try to pull the build statuses, skip the node if we can't
+                    node_results_temp = nodedata['statuses']['overall']
+                    node_results = results.setdefault(nodeid, {'build_results': {}})
+                    node_results['build_results'][build_number] = node_results_temp
+                except KeyError:
+                    continue
+        for nodeid, nodedata in results.items():
+            node_results = nodedata['build_results'].items()
+            nodedata['best_result'] = self._best_result(*node_results)
+            nodedata['result_url'] = 'https://{}/job/{}/{}/'.format(
+                jenkins_host, self.job_name, nodedata['best_result'][0]
+            )
+            nodedata['streak'] = self._streak(*node_results)
+            test_counts[nodedata['best_result'][1]] += 1
+        return results
+
+    def composite_report(self):
+        reports = self.test_reports()
+        composite_status = self.composite_status(reports.iteritems())
+        composite_report = {
+            'test_counts': test_counts,
+            'tests': OrderedDict()
+        }
+
+        print 'Collecting artifacts from best build nodes'
+        # tracking dict for file pull progress
+        remotes_done = {}
+        self._progress_update(None, remotes_done)
+        for nodeid, nodedata in sorted(composite_status.items(),
+                key=lambda s: s[1]['streak']['count'], reverse=True):
+            best_build_number = nodedata['best_result'][0]
+            best_build_test = reports[best_build_number]['tests'][nodeid]
+            composite_report['tests'][nodeid] = best_build_test
+            composite_report['tests'][nodeid]['composite'] = nodedata
+            files = reports[best_build_number]['tests'][nodeid].setdefault('files', {})
+            for plugin, artifacts in files.items():
+                if plugin == 'softassert':
+                    # softassert is nested artifacts, which this doesn't deal with (yet)
+                    continue
+                new_artifacts = []
+                for artifact in artifacts:
+                    _remote, _local = self._translate_artifacts_path(artifact, best_build_number)
+                    remotes_done[_remote] = False
+                    if not self.no_artifacts:
+                        self._queue.put((_remote, _local, _remote, remotes_done))
+                        new_artifacts.append(_local)
+                reports[best_build_number]['tests'][nodeid]['files'][plugin] = new_artifacts
+        # wait for all the files to arrive before building the report
+        self._queue.join()
+        self._progress_finish()
+        json.dump(composite_report, self.work_dir.join('composite-report.json').open('w'),
+            indent=1)
+        try:
+            passing_percent = (100. * (test_counts['passed'] + test_counts['skipped']
+                + test_counts['xfailed'])) / sum(test_counts.values())
+            print 'Passing percent:', passing_percent
+            # XXX: Terrible artifactor spoofing happens here.
+            print 'Running artifactor reports'
+            r = reporter.Reporter('{} composite'.format(self.template), {})
+            r.configure()
+            reports_done = {'composite': False, 'provider': False}
+            self._progress_update(None, reports_done)
+            r.run_report(composite_report['tests'], self.work_dir.strpath)
+            self._progress_update('composite', reports_done)
+            r.run_provider_report(composite_report['tests'], self.work_dir.strpath)
+            self._progress_update('provider', reports_done)
+            self._progress_finish()
+        except ZeroDivisionError:
+            print 'No tests collected from test reports (?!)'
+        return composite_report
+
+    def _translate_artifacts_path(self, artifact_path, build_number):
+        preamble = composite['preamble'].format(self.job_name)
+        replacement = composite['replacement'].format(self.job_name, build_number)
+        artifact_remote = artifact_path.replace(preamble, replacement)
+        artifact_local = self.work_dir.join(str(build_number), artifact_path[len(preamble):])
+        try:
+            assert artifact_remote.startswith(composite['remote_sw'])
+            assert artifact_local.strpath.startswith(self.work_dir.strpath)
+        except AssertionError:
+            print 'wat?'
+            print 'path', artifact_path
+            print 'remote', artifact_remote
+            print 'local', artifact_local.strpath
+        return artifact_remote, artifact_local.strpath


### PR DESCRIPTION
Big changes here

* If supplied with the --composite-uncollect option we will now try to
  contact jenkins with the data supplied in the composite.yaml. This is
  option is only intended for cfme-qe.
* The --composite-job-name and --composite-template-name options are
  overides only and should never usualy be supplied.
* If the option is passed we connect to the jenkins instance, download
  the composite json files of the last runs and combine them to create a
  composite build which can be reported on each time we run, giving
  better results, or at least more accurate results.
* One major change in artifactor is the way that we use the artifacts
  attribute. This has been modified to pump in an old artifacts to use
  for combining. Currently this only works for the main report, thought
  other reports should still run fine due to the empty dict usage.
* A new filter has been added to the report which allows filtering out
  of "old" tests
* A second set of stats is available to differentiate between the new
  and old results.
* This option should never be used on PRT, unless making changes to the
  uncollector itself.

{{pytest: -k test_repository_crud --composite-uncollect}}