### PR TITLE
Fixed template tracker to be slightly more robust

### DIFF
--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -109,8 +109,8 @@ def main(trackerbot_url, mark_usable=None):
 
 def get_provider_templates(provider_key, template_providers, unresponsive_providers, thread_lock):
     # functionalized to make it easy to farm this out to threads
-    provider_mgmt = get_mgmt(provider_key)
     try:
+        provider_mgmt = get_mgmt(provider_key)
         if cfme_data['management_systems'][provider_key]['type'] == 'ec2':
             # dirty hack to filter out ec2 public images, because there are literally hundreds.
             templates = provider_mgmt.api.get_all_images(owners=['self'],


### PR DESCRIPTION
KeyError in the credentials file was causing all templates to be
disassociated from the providers which caused major headaches. This
fixes the error by moving all possible interactivity inside the
try/except clause and therefore guarding against a bad key discarding
all templates.