### PR TITLE
Fix for thread-unsafe yaycl

### DIFF
--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -110,7 +110,8 @@ def main(trackerbot_url, mark_usable=None):
 def get_provider_templates(provider_key, template_providers, unresponsive_providers, thread_lock):
     # functionalized to make it easy to farm this out to threads
     try:
-        provider_mgmt = get_mgmt(provider_key)
+        with thread_lock:
+            provider_mgmt = get_mgmt(provider_key)
         if cfme_data['management_systems'][provider_key]['type'] == 'ec2':
             # dirty hack to filter out ec2 public images, because there are literally hundreds.
             templates = provider_mgmt.api.get_all_images(owners=['self'],


### PR DESCRIPTION
yaycl is not thread safe, when trying to access the credentials conf
file with multiple threads, an empty dict was returned and in this case
it originally ended up disassociating the templates with the providers
and deleting the definitions.