### PR TITLE
Force BZ Blocker on ec2 for CFME 5.5

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -108,7 +108,8 @@ def db_event(db, provider):
 
 
 @pytest.mark.meta(
-    blockers=[BZ(1201923, unblock=lambda provider: provider.type != 'ec2'), 1265404, 1281746]
+    blockers=[BZ(1201923, unblock=lambda provider: provider.type != 'ec2', forced_streams=["5.5"]),
+    1265404, 1281746]
 )
 @pytest.mark.uncollectif(
     lambda provider: current_version() < "5.4" and provider.type != 'openstack')
@@ -126,7 +127,8 @@ def test_provider_event(setup_provider, provider, gen_events, test_instance):
 
 
 @pytest.mark.meta(
-    blockers=[BZ(1201923, unblock=lambda provider: provider.type != 'ec2'), 1281746]
+    blockers=[BZ(1201923, unblock=lambda provider: provider.type != 'ec2', forced_streams=["5.5"]),
+    1281746]
 )
 @pytest.mark.uncollectif(
     lambda provider: current_version() < "5.4" and provider.type != 'openstack')


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_cloud_timelines.py -v -k "not test_vm_event"}}

Found that a few tests that should be skipped are not being skipped because the BZ in question is now slated for a 5.6 release.The tests have been failing ever since the Release Flag was changed from 5.5 to 5.6.

BZ Blocker is being forced on test_provider_event() and test_azone_event() for the 5.5 stream for ec2 only through 'forced_streams'..So,those tests get skipped for ec2 only  on 5.4, 5.5.

The RHOS tests will not be impacted by this and will continue to be run.