### PR TITLE
Remove novaclient version hardcode

### DIFF
--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -122,7 +122,6 @@ def pytest_runtest_protocol(item):
             session_ver = 'Unknown'
         art_client.fire_hook('session_info', version=session_ver)
 
-
     name, location = get_test_idents(item)
     art_client.fire_hook('start_test', test_location=location, test_name=name,
                          slaveid=SLAVEID, ip=appliance_ip_address)

--- a/utils/mgmt_system/openstack.py
+++ b/utils/mgmt_system/openstack.py
@@ -10,7 +10,7 @@ from functools import partial
 from cinderclient.v2 import client as cinderclient
 from cinderclient import exceptions as cinder_exceptions
 from keystoneclient.v2_0 import client as oskclient
-from novaclient.v1_1 import client as osclient
+from novaclient import client as osclient
 from novaclient import exceptions as os_exceptions
 from novaclient.client import HTTPClient
 from requests.exceptions import Timeout


### PR DESCRIPTION
Novaclient was updated to v2 and the novaclient.client import is
hardcoded to v1_1 breaking the deploy script.

Replacing PR#2587 which targeted the wrong base branch