### PR TITLE
Remove the repeated blocker occurences

### DIFF
--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -148,6 +148,11 @@ class ReporterBase(object):
                     blocker_skip_count += 1
                     test_data['skip_blocker'] = test['skipped'].get('reason', None)
 
+            if 'skip_blocker' in test_data:
+                # Fix the inconveniently long list of repeated blockers until we sort out sets
+                # in riggerlib somehow.
+                test_data['skip_blocker'] = sorted(set(test_data['skip_blocker']))
+
             if test.get('old', False):
                 test_data['old'] = True
 


### PR DESCRIPTION
This is caused by an internal design deficiency which does not enable us to use sets in the data, because JSON. Working aroudn by set()'ing it inside the template data generator.

{{pytest: cfme/tests/services/test_service_catalogs.py -k test_edit_catalog_after_deleting_provider -v --long-running --use-provider complete }}