### PR TITLE
openstack: set 'Non-SSL' security protocol by default

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -53,6 +53,7 @@ properties_form = Form(
             }
         )),
         ("api_version", AngularSelect("api_version"), {"appeared_in": "5.5"}),
+        ('sec_protocol', AngularSelect("security_protocol"), {"appeared_in": "5.5"}),
         ('infra_provider', {
             version.LOWEST: None,
             "5.4": Select("select#provider_id"),
@@ -138,13 +139,14 @@ class EC2Provider(Provider):
 
 class OpenStackProvider(Provider):
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
-                 ip_address=None, api_port=None, infra_provider=None):
+                 ip_address=None, api_port=None, sec_protocol=None, infra_provider=None):
         super(OpenStackProvider, self).__init__(name=name, credentials=credentials,
                                                 zone=zone, key=key)
         self.hostname = hostname
         self.ip_address = ip_address
         self.api_port = api_port
         self.infra_provider = infra_provider
+        self.sec_protocol = sec_protocol
 
     def create(self, *args, **kwargs):
         # Override the standard behaviour to actually create the underlying infra first.
@@ -166,6 +168,7 @@ class OpenStackProvider(Provider):
                 'hostname_text': kwargs.get('hostname'),
                 'api_port': kwargs.get('api_port'),
                 'ipaddress_text': kwargs.get('ip_address'),
+                'sec_protocol': kwargs.get('sec_protocol'),
                 'infra_provider': "---" if infra_provider is False else infra_provider}
 
 

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -605,6 +605,7 @@ def get_crud(provider_config_name):
             credentials={'default': credentials},
             zone=prov_config['server_zone'],
             key=provider_config_name,
+            sec_protocol=prov_config.get('sec_protocol', "Non-SSL"),
             infra_provider=prov_config.get('infra_provider'))
     elif prov_type == 'virtualcenter':
         return VMwareProvider(name=prov_config['name'],


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_providers.py --use-provider 'rhos7-ga' -v}}