### PR TITLE
Fix ssh_client cache invalidation

### DIFF
--- a/utils/ports.py
+++ b/utils/ports.py
@@ -18,8 +18,8 @@ class Ports(object):
     def __setattr__(self, attr, value):
         super(self.__class__, self).__setattr__(attr, value)
         if self.store.any_appliance:
-            self.logger.info("Cleaning up the current_appliance object")
-            self.store.current_appliance._ssh_client = None
+            self.logger.info("Invalidating lazy_cache ssh_client current_appliance object")
+            del(self.store.current_appliance.ssh_client)
 
 
 sys.modules[__name__] = Ports()


### PR DESCRIPTION
This is a quick fix to invalidate the ssh_client cache instead of
setting the attribute to None. Setting to None does not allow the
ssh_client to retry the operation with the new port. This was probably
leftover from an earlier appliance makeup.

Proposal that we go through and actually make this fire a signal to
invalidate the proper cache settings, rather than just the SSH, ie, the
DB would probably need invalidating too to make things _right_.