### PR TITLE
Sprout - Fix 500 and mute emails till the solution is found

### DIFF
--- a/sprout/appliances/admin.py
+++ b/sprout/appliances/admin.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from functools import wraps
 from celery import chain
-from django import forms
 from django.contrib import admin
-from django.contrib.admin.helpers import ActionForm
 from django.contrib.auth.admin import UserAdmin
 from django.db.models.query import QuerySet
 
@@ -153,28 +151,9 @@ class AppliancePoolAdmin(Admin):
         return instance.current_count
 
 
-class GroupProvisionAppliancePoolRequestForm(ActionForm):
-    number_appliances = forms.IntegerField(required=True, min_value=1)
-
-
 @register_for(Group)
 class GroupAdmin(Admin):
-    action_form = GroupProvisionAppliancePoolRequestForm
-    objectactions = ["request_pool"]
-    actions = objectactions
-
-    @action("Request appliances", "Request appliances pool")
-    def request_pool(self, request, groups):
-        number_appliances = int(request.POST.get('number_appliances', 1))
-        if number_appliances < 1:
-            self.message_user(request, "Number of appliances should >= 1!")
-            return
-        for group in groups:
-            pool = AppliancePool.create(request.user, group, num_appliances=number_appliances)
-            self.message_user(request, "Appliance pool {} was requested!".format(pool.id))
-            self.logger.info(
-                "User {}/{} requested appliance pool {}".format(
-                    request.user.pk, request.user.username, pool.id))
+    pass
 
 
 @register_for(Provider)

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1454,7 +1454,8 @@ def pick_templates_for_deletion(self):
                         to_mail[group.id][zstream][version] = []
                     to_mail[group.id][zstream][version].append(
                         "{} @ {}".format(template.name, template.provider.id))
-    if to_mail:
+    # TODO: Figure out why it was spamming
+    if to_mail and False:
         data = yaml.safe_dump(to_mail, default_flow_style=False)
         email_body = """\
 Hello,
@@ -1473,7 +1474,7 @@ Sprout.
             if user.email:
                 user_mails.append(user.email)
         send_mail(
-            "Possible candidates for tempalte deletion",
+            "Possible candidates for template deletion",
             email_body,
             "sprout-template-deletion-suggest@example.com",
             user_mails,


### PR DESCRIPTION
* Template deletion suggester kept spamming on version.
* django_object_actions apparently does not work entirely properly with newer admin, Groups were throwing 500.