### PR TITLE
Prallelizing Template tester execution

### DIFF
--- a/scripts/template_tester.py
+++ b/scripts/template_tester.py
@@ -17,18 +17,20 @@ import sys
 from utils import trackerbot
 
 
-def get(api):
+def get(api, request_type=None):
     try:
-        template, provider_key, stream = trackerbot.templates_to_test(api, limit=1)[0]
+        template, provider_key, stream, provider_type =\
+            trackerbot.templates_to_test(api, request_type=request_type, limit=1)[0]
     except (IndexError, TypeError):
-        # No untested providertemplates, all is well
+        # No untested provider templates, all is well
         return 0
 
     # Print envvar exports to be eval'd
     export(
         appliance_template=template,
         provider_key=provider_key,
-        stream=stream
+        stream=stream,
+        provider_type=provider_type
     )
 
 
@@ -84,6 +86,7 @@ if __name__ == '__main__':
 
     parse_get = subs.add_parser('get', help='get a template to test')
     parse_get.set_defaults(func=get)
+    parse_get.add_argument('request_type', help='get a teamplate based on provider type')
 
     parse_latest = subs.add_parser('latest', help='get the latest usable template for a provider')
     parse_latest.set_defaults(func=latest)
@@ -107,7 +110,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     api = trackerbot.api(args.trackerbot_url)
     func_map = {
-        get: lambda: get(api),
+        get: lambda: get(api, args.request_type),
         latest: lambda: latest(api, args.stream, args.provider_key),
         mark: lambda: mark(api, args.provider_key, args.template, args.usable, args.diagnose),
         retest: lambda: retest(api, args.provider_key, args.template),

--- a/utils/trackerbot.py
+++ b/utils/trackerbot.py
@@ -189,19 +189,24 @@ def latest_template(api, group, provider_key=None):
         return response['latest_templates'][group['name']]
 
 
-def templates_to_test(api, limit=1):
+def templates_to_test(api, limit=1, request_type=None):
     """get untested templates to pass to jenkins
 
     Args:
         limit: max number of templates to pull per request
+        request_type: request the provider_key of specific type
+        e.g openstack
 
     """
     templates = []
-    for pt in api.untestedtemplate.get(limit=limit, tested=False).get('objects', []):
+    for pt in api.untestedtemplate.get(
+            limit=limit, tested=False, provider__type=request_type).get(
+            'objects', []):
         name = pt['template']['name']
         group = pt['template']['group']['name']
         provider = pt['provider']['key']
-        templates.append([name, provider, group])
+        request_type = pt['provider']['type']
+        templates.append([name, provider, group, request_type])
     return templates
 
 


### PR DESCRIPTION
      * added the 'request_type' paramater for get(api, request_type) to filter the templates
        on provider type.
      * templates. 'request_type' parameter has been added to parse.
      * the 'provider_type' attribute is fetched from untested templates and exported as env..
      * updated trackerbot.py to fetch the provider_type and return the template list to get(api, type)