### PR TITLE
Add seal argument in templatize method, tweak appliance script

### DIFF
--- a/scripts/appliance.py
+++ b/scripts/appliance.py
@@ -62,6 +62,27 @@ def main():
     return exit
 
 
+def process_arg(arg):
+    """Parse either number or a well-known values. Otherwise pass through."""
+    try:
+        return int(arg)
+    except ValueError:
+        pass
+    if arg == "True":
+        return True
+    elif arg == "False":
+        return False
+    elif arg == "None":
+        return None
+    else:
+        return arg
+
+
+def process_args(args):
+    """We need to pass more than just strings."""
+    return map(process_arg, args)
+
+
 def call_appliance(provider_name, vm_name, action, *args):
     # Given a provider class, find the named method and call it with
     # *args. This could possibly be generalized for other CLI tools.
@@ -74,7 +95,7 @@ def call_appliance(provider_name, vm_name, action, *args):
     if isinstance(getattr(type(appliance), action), property):
         return call
     else:
-        return call(*args)
+        return call(*process_args(args))
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/scripts/tests/test_appliance.py
+++ b/scripts/tests/test_appliance.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""Tests for appliance.py script."""
+import pytest
+
+from scripts import appliance
+
+
+@pytest.mark.parametrize(
+    ('input', 'output'), [
+        ([], []),
+        (['a', 'b', 'c'], ['a', 'b', 'c']),
+        (['1', 'True', 'False', 'None'], [1, True, False, None]),
+    ])
+def test_process_args(input, output):
+    assert appliance.process_args(input) == output

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -271,13 +271,22 @@ class Appliance(object):
         self.provider.start_vm(self.vm_name)
         self.provider.wait_vm_running(self.vm_name)
 
-    def templatize(self):
+    def templatize(self, seal=True):
         """Marks the appliance as a template. Destroys the original VM in the process.
+
+        By default it runs the sealing process. If you have done it differently, you can opt out.
+
+        Args:
+            seal: Whether to run the sealing process (making the VM 'universal').
         """
-        if not self.is_running:
-            self.start()
-        self.ipapp.seal_for_templatizing()
-        self.stop()
+        if seal:
+            if not self.is_running:
+                self.start()
+            self.ipapp.seal_for_templatizing()
+            self.stop()
+        else:
+            if self.is_running:
+                self.stop()
         self.provider.mark_as_template(self.vm_name)
 
     @property


### PR DESCRIPTION
I need to opt out with the sealing when using inside CFME because I do it in a different state machine. This also requires me to add some code that processes some known strings into actual values, like boolean. I changed it to run for booleans and none too. This code should be later extracted out into some tools if we find use for that. Added a small unit test for the argument processor.