### PR TITLE
Fix incorrect behavior for dropdown selector in ftp test_log_depot 

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -610,6 +610,13 @@ class ServerLogDepot(Pretty):
                     nfs="NFS",
                     smb="Samba",
                     dropbox="Red Hat Dropbox",
+                ),
+                "5.5": dict(
+                    anon_ftp=sel.ByValue("Anonymous FTP"),
+                    ftp=sel.ByValue("FTP"),
+                    nfs=sel.ByValue("NFS"),
+                    smb=sel.ByValue("Samba"),
+                    dropbox=sel.ByValue("Red Hat Dropbox")
                 )
             })
 


### PR DESCRIPTION
change p_type for 5.5 to select ByValue to use method select_by_value instead of incorrect working in this case select_by_visible_text


{{pytest: -v -k test_log_depot}}