### PR TITLE
Rest api terminate method for instances

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -285,6 +285,7 @@ class EC2Instance(Instance):
     STATE_ON = "on"
     STATE_OFF = "off"
     STATE_SUSPENDED = "suspended"
+    STATE_TERMINATED = "terminated"
     STATE_UNKNOWN = "unknown"
 
     def create(self, email=None, first_name=None, last_name=None, availability_zone=None,


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_instance_power_control.py -k "test_terminate_via_rest" -v --long-running}}