### PR TITLE
Fix error for not existing container_providers

### DIFF
--- a/utils/providers.py
+++ b/utils/providers.py
@@ -361,7 +361,7 @@ def _setup_providers(prov_class, validate, check_existing):
             'list': list_infra_providers
         },
         'container': {
-            'navigate': 'container_providers',
+            'navigate': 'containers_providers',
             'quad': None,
             'list': list_container_providers
         }


### PR DESCRIPTION
The right key name should be containers_providers

[ticket: n/a]