### PR TITLE
artifactor plugin: always assume we have a valid item.location

### DIFF
--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -42,11 +42,7 @@ for cred in credentials:
 
 
 def get_test_idents(item):
-
-    if getattr(item, 'location', None):
-        return item.location[2], item.location[0]
-    else:
-        return item.name, item.parent.name
+    return item.location[2], item.location[0]
 
 
 class DummyClient(object):


### PR DESCRIPTION
this is a experiment to see why the workaround was added to begin with