### PR TITLE
Summary and Comparable mixins

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -22,7 +22,7 @@ from utils.stats import tol_check
 from utils.update import Updateable
 from utils.varmeth import variable
 
-from . import PolicyProfileAssignable, Taggable
+from . import PolicyProfileAssignable, Taggable, SummaryMixin
 
 cfg_btn = partial(tb.select, 'Configuration')
 
@@ -63,7 +63,7 @@ credential_form = TabStripForm(
     ])
 
 
-class BaseProvider(Taggable, Updateable):
+class BaseProvider(Taggable, Updateable, SummaryMixin):
     # List of constants that every non-abstract subclass must have defined
     STATS_TO_MATCH = []
     string_name = ""

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -21,7 +21,7 @@ from utils.update import Updateable
 from utils.virtual_machines import deploy_template
 from utils.wait import wait_for, TimedOutError
 
-from . import PolicyProfileAssignable, Taggable
+from . import PolicyProfileAssignable, Taggable, SummaryMixin
 
 cfg_btn = partial(toolbar.select, "Configuration")
 lcl_btn = partial(toolbar.select, "Lifecycle")
@@ -44,7 +44,7 @@ class _TemplateMixin(object):
     pass
 
 
-class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable):
+class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin):
     """Base VM and Template class that holds the largest common functionality between VMs,
     instances, templates and images.
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -56,9 +56,31 @@ def at_exit(f, *args, **kwargs):
     return atexit.register(lambda: diaper(f, *args, **kwargs))
 
 
+def _prenormalize_text(text):
+    """Makes the text lowercase and removes all characters that are not digits, alphas, or spaces"""
+    return re.sub(r"[^a-z0-9 ]", "", text.strip().lower())
+
+
+def _replace_spaces_with(text, delim):
+    """Contracts spaces into one character and replaces it with a custom character."""
+    return re.sub(r"\s+", delim, text)
+
+
 def normalize_text(text):
-    text = re.sub(r"[^a-z0-9 ]", "", text.strip().lower())
-    return re.sub(r"\s+", " ", text)
+    """Converts a string to a lowercase string containing only letters, digits and spaces.
+
+    The space is always one character long if it is present.
+    """
+    return _replace_spaces_with(_prenormalize_text(text), ' ')
+
+
+def attributize_string(text):
+    """Converts a string to a lowercase string containing only letters, digits and underscores.
+
+    Usable for eg. generating object key names.
+    The underscore is always one character long if it is present.
+    """
+    return _replace_spaces_with(_prenormalize_text(text), '_')
 
 
 def tries(num_tries, exceptions, f, *args, **kwargs):


### PR DESCRIPTION
Introducing Summary and Comparable mixins. Comparable mixin serves as a automatic `__eq__` handling for object fields. Summary mixin serves as a convenient way to read object properties from its summray page, representing them in OOP way and it also injects some data into them so you can also read the image link and get the clickable link from it.

Example usage:
```python
from utils.provider import get_crud
from cfme.common.vm import BaseVM

p = get_crud('someprovider')
vm = BaseVM.factory('somevm', p)

print p.summary.smart_management.managed_by_zone 
# => 'default'    # This is the repr of the object, so ...
print p.summary.smart_management.managed_by_zone.value
# => 'default'    # This is the processed value
print p.summary.smart_management.my_company_tags[0].img
 # => ParseResult(scheme=u'https', netloc=u'ipaddr', path=u'/images/icons/new/smarttag.png', params='', query='', fragment='')
print p.summary.relationships.datastores
# => '17'   # the repr
print p.summary.relationships.datastores.text_value
# => '17'
print p.summary.relationships.datastores.value
# => 17    # The value is processed now as a number.
print p.summary.relationships.datastores.link
# => element(('xpath', './td'), root=element(('xpath', '../../../tbody/tr'), root=element(('xpath', '//th[@align="left"]'))))
print p.summary
# => <Summary properties status relationships smart_management>
print p.summary.relationships
# => <SummaryTable 'Relationships' hosts_clusters='Available' vms_templates='Available' clusters=2 hosts=5 datastores=17 vms_and_instances=296 templates=121>
```

Not all tables get parsed, the Normal Operating Ranges table type is not parsed yet, but that is todo since I don't see that kind of table a priority.