### PR TITLE
Fix Dockerbot API usage

### DIFF
--- a/utils/trackerbot.py
+++ b/utils/trackerbot.py
@@ -223,7 +223,7 @@ def _as_providertemplate(provider, template):
 def post_task_result(tid, result, output=None):
     if not output:
         output = "No output capture"
-    api().task(tid).put({'result': result, 'output': output})
+    api().task(tid).patch({'result': result, 'output': output})
 
 
 def post_jenkins_result(job_name, number, stream, date, template,


### PR DESCRIPTION
* When Dockerbot was coded, one of two things happened, either:
 1) psav didn't read the tastypie manual properly
 2) Something changed in version 0.13.3
 Either way, upgrading tastypie from 0.13.1 to 0.13.3 broke trackerbot
 usage for PRT. 'Put'ing a resource without supplying all fields causes
 unpredictable results. This worked in 0.13.1 and fails in 0.13.3. This
 change adds the missing fields into every put in cfme_tests, all of
 these tend to refer to PRT, which means that 1) is the most likely
 cause of this.