### PR TITLE
check_fixed_in: make sure fixed_in is Version not a string

### DIFF
--- a/utils/bz.py
+++ b/utils/bz.py
@@ -196,6 +196,8 @@ def check_fixed_in(fixed_in, version_series):
     # used to check if the bug belongs to that series
     if fixed_in is None:
         return True
+    if not isinstance(fixed_in, Version):
+        fixed_in = Version(fixed_in)
     return fixed_in.is_in_series(version_series)
 
 


### PR DESCRIPTION
```
_________________________________________________________________ ERROR at setup of test_certificates_present __________________________________________________________________

item = <Function 'test_certificates_present'>

    def pytest_runtest_setup(item):
>       run_plugins(item, plugin.SETUP)

markers/meta.py:167: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
markers/meta.py:160: in run_plugins
    plug.function(**env)
../lib/python2.7/site-packages/kwargify.py:33: in wrapper
    return wrapped(*pass_args)
metaplugins/blockers.py:86: in resolve_blockers
    if blocker.blocks:
utils/blockers.py:156: in blocks
    bug = self.data
utils/blockers.py:145: in data
    self.bug_id, ignore_bugs=self.ignore_bugs, force_block_streams=self.forced_streams)
utils/bz.py:183: in resolve_blocker
    check_fixed_in(bug.fixed_in, version_series) and
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

fixed_in = '5.5.0.11', version_series = '5.5'

    def check_fixed_in(fixed_in, version_series):
        # used to check if the bug belongs to that series
        if fixed_in is None:
            return True
>       return fixed_in.is_in_series(version_series)
E       AttributeError: 'str' object has no attribute 'is_in_series'
```

{{pytest: -v -m smoke}}