### PR TITLE
Add check for untested templates before wait.

### DIFF
--- a/scripts/latest_template_tester_report.py
+++ b/scripts/latest_template_tester_report.py
@@ -116,13 +116,17 @@ def templates_uploaded(api, stream):
     return False
 
 
-def get_untested_templates(api, stream_group):
-    return api.untestedtemplate.get(template__group__name=stream_group).get('objects', [])
+def get_untested_templates(api, stream_group, appliance_template=None):
+    return api.untestedtemplate.get(
+        template__group__name=stream_group, template=appliance_template).get('objects', [])
 
 
 def generate_html_report(api, stream, filename, appliance_template):
 
     number_of_images_before = len(images_uploaded(stream))
+    if get_untested_templates(api, stream, appliance_template):
+        print('report will not be generated, proceed with the next untested provider')
+        sys.exit()
     stream_data = get_latest_tested_template_on_stream(api, stream)
 
     if len(images_uploaded(stream)) > number_of_images_before:


### PR DESCRIPTION
  * check if any untested templates are available, if untested
    providers are avialable then proceed with next template_tester job.
  * if no untested template providers then, wait for the upload and
    test to finish(if any pending).