### PR TITLE
SSA: prepare test_instance_analysis for FW 3.0

### DIFF
--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -11,7 +11,9 @@ import cfme.web_ui.menu  # noqa
 
 from cfme.exceptions import CandidateNotFound, ListAccordionLinkNotFound
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import Quadicon, Region, listaccordion as list_acc, toolbar as tb, paginator as pg
+from cfme.web_ui import (
+    Quadicon, Region, listaccordion as list_acc, toolbar as tb, paginator as pg, flash
+)
 from cfme.web_ui.form_buttons import FormButton
 from functools import partial
 from utils.pretty import Pretty
@@ -190,6 +192,18 @@ class Datastore(Pretty):
                 return True
         except sel.NoSuchElementException:
             return False
+
+    def run_smartstate_analysis(self):
+        """ Runs smartstate analysis on this host
+
+        Note:
+            The host must have valid credentials already set up for this to work.
+        """
+        sel.force_navigate('infrastructure_datastore', context={
+            'datastore': self, 'provider': self.provider})
+        tb.select('Configuration', 'Perform SmartState Analysis', invokes_alert=True)
+        sel.handle_alert()
+        flash.assert_message_contain('"{}": scan successfully initiated'.format(self.name))
 
 
 def get_all_datastores(do_not_navigate=False):

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -247,7 +247,10 @@ def do_vm_provisioning(template_name, provider, vm_name, provisioning_data, requ
     except Exception as e:
         requests.debug_requests()
         raise e
-    assert row.last_message.text == 'Vm Provisioned Successfully'
+    assert row.last_message.text == version.pick({
+        version.LOWEST: 'Vm Provisioned Successfully',
+        '5.6': 'VM Provisioning completed'
+    })
 
     if smtp_test:
         # Wait for e-mails to appear

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -96,7 +96,7 @@ def pytest_generate_tests(metafunc):
                     continue
 
             # Set VM name here
-            vm_name = 'ssa_{}-{}'.format(fauxfactory.gen_alphanumeric(), vm_analysis_key)
+            vm_name = 'test_ssa_{}-{}'.format(fauxfactory.gen_alphanumeric(), vm_analysis_key)
             vm_analysis_data['vm_name'] = vm_name
 
             new_idlist.append('{}-{}'.format(idlist[i], vm_analysis_key))

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -997,7 +997,7 @@ class PagedTable(Table):
     """
     def find_row_on_all_pages(self, header, value):
         from cfme.web_ui import paginator
-        for page in paginator.pages():
+        for _ in paginator.pages():
             sel.wait_for_element(self)
             row = self.find_row(header, value)
             if row is not None:

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -1145,7 +1145,8 @@ class IPAppliance(object):
         return result
 
     @logger_wrap("Install VDDK: {}")
-    def install_vddk(self, reboot=True, force=False, vddk_url=None, log_callback=None):
+    def install_vddk(self, reboot=True, force=False, vddk_url=None, log_callback=None,
+                     wait_for_web_ui_after_reboot=False):
         """Install the vddk on a appliance"""
 
         def log_raise(exception_class, message):
@@ -1199,7 +1200,8 @@ class IPAppliance(object):
 
                 # reboot
                 if reboot:
-                    self.reboot(log_callback=log_callback, wait_for_web_ui=False)
+                    self.reboot(log_callback=log_callback,
+                                wait_for_web_ui=wait_for_web_ui_after_reboot)
                 else:
                     log_callback('A reboot is required before vddk will work')
 


### PR DESCRIPTION
This includes:
 * appliance: allow waiting for web UI after reboot
 * remove sel invocation and unclear wait for browser to open
 * move is_vm_analysis_finished helper to cfme.configure.tasks
 * use PagedTable/SplitPagedTable classes

{{pytest: cfme/tests/infrastructure/test_instance_analysis.py --use-provider 'vsphere55' -v --long-running -k "test_ssa_vm"}}