### PR TITLE
idempotent cached property invalidation

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -26,8 +26,17 @@ from utils.version import current_version
 
 @on_signal("server_details_changed")
 def invalidate_server_details():
-    del store.current_appliance.configuration_details
-    del store.current_appliance.zone_description
+    # TODO: simplify after idempotent cached property is availiable
+    # https://github.com/pydanny/cached-property/issues/31
+    try:
+        del store.current_appliance.configuration_details
+    except AttributeError:
+        pass
+    try:
+        del store.current_appliance.zone_description
+    except AttributeError:
+        pass
+
 
 access_tree = partial(accordion.tree, "Access Control")
 database_tree = partial(accordion.tree, "Database")

--- a/utils/db.py
+++ b/utils/db.py
@@ -22,7 +22,10 @@ from utils.ssh import SSHClient
 
 @on_signal("server_config_changed")
 def invalidate_server_config():
-    del store.current_appliance.db_yamls
+    try:
+        del store.current_appliance.db_yamls
+    except AttributeError:
+        pass  # cache is not populated, ignore
 
 
 @event.listens_for(Pool, "checkout")

--- a/utils/signals.py
+++ b/utils/signals.py
@@ -10,9 +10,16 @@ caches have become stale and need to be invalidated. The example below shows thi
    from fixtures.pytest_store import store
 
    def invalidate_server_details():
-       del store.current_appliance.configuration_details
-       del store.current_appliance.zone_description
-
+       # TODO: simplify after idempotent cached property is availiable
+       # https://github.com/pydanny/cached-property/issues/31
+       try:
+           del store.current_appliance.configuration_details
+       except AttributeError:
+           pass
+       try:
+           del store.current_appliance.zone_description
+       except AttributeError:
+           pass
 
    signals.register_callback('server_details_changed', invalidate_server_details)
 
@@ -25,8 +32,17 @@ Or by using a decorator:
 
    @on_signal("server_details_changed")
    def invalidate_server_details():
-       del store.current_appliance.configuration_details
-       del store.current_appliance.zone_description
+       # TODO: simplify after idempotent cached property is availiable
+       # https://github.com/pydanny/cached-property/issues/31
+       try:
+           del store.current_appliance.configuration_details
+       except AttributeError:
+           pass
+       try:
+           del store.current_appliance.zone_description
+       except AttributeError:
+           pass
+
 
 Here we create a function to do the work of invalidating the cache and register it
 to the signal name 'server_details_changed'. Now whenever something in the framework


### PR DESCRIPTION
this is a workaround until cached_property itself provides a idempotent cached property
see https://github.com/pydanny/cached-property/issues/31

until cache invalidation is idempotent we need to catch attribute errors
when invalidating the instance cache, since invalidation on missing cache
triggers a attribute error