### PR TITLE
test_ssa_templates: skip 5.4 due to bz 1230248

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -101,6 +101,7 @@ class Provider(Pretty, CloudInfraProvider):
     string_name = "Cloud"
     page_name = "clouds"
     instances_page_name = "clouds_instances_by_provider"
+    templates_page_name = "clouds_images_by_provider"
     quad_name = "cloud_prov"
     vm_name = "Instances"
     template_name = "Images"

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -302,10 +302,13 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable):
         # paginator.results_per_page(1000)
         if use_search:
             try:
-                if not search.has_quick_search_box() and self.provider.instances_page_name:
+                if not search.has_quick_search_box():
                     # We don't use provider-specific page (vm_templates_provider_branch) here
                     # as those don't list archived/orphaned VMs
-                    sel.force_navigate(self.provider.instances_page_name)
+                    if self.is_vm:
+                        sel.force_navigate(self.provider.instances_page_name)
+                    else:
+                        sel.force_navigate(self.provider.templates_page_name)
                 search.normal_search(self.name)
             except Exception as e:
                 logger.warning("Failed to use search: {}".format(str(e)))

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -105,6 +105,7 @@ class Provider(Pretty, CloudInfraProvider):
     string_name = "Infrastructure"
     page_name = "infrastructure"
     instances_page_name = "infra_vm_and_templates"
+    templates_page_name = "infra_vm_and_templates"
     quad_name = "infra_prov"
     properties_form = properties_form
     add_provider_button = form_buttons.FormButton("Add this Infrastructure Provider")

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -333,7 +333,8 @@ def detect_system_type(vm):
 @pytest.mark.meta(blockers=[
     BZ(1311134, unblock=lambda provider: provider.type != 'rhevm'),
     BZ(1311218, unblock=lambda provider:
-        provider.type != 'virtualcenter' or provider.version < "6")])
+        provider.type != 'virtualcenter' or provider.version < "6"),
+    BZ(1320248, unblock=lambda provider: version.current_version() >= "5.5")])
 def test_ssa_template(request, local_setup_provider, provider, vm_analysis_new, soft_assert):
     """ Tests SSA can be performed on a template
 

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -345,22 +345,23 @@ def test_ssa_template(request, local_setup_provider, provider, vm_analysis_new, 
     template = Template.factory(template_name, provider, template=True)
 
     # Set credentials to all hosts set for this datastore
-    datastore_name = vm_analysis_new['datastore']
-    test_datastore = datastore.Datastore(datastore_name, provider.key)
-    host_list = cfme_data.get('management_systems', {})[provider.key].get('hosts', [])
-    host_names = test_datastore.get_hosts()
-    for host_name in host_names:
-        test_host = host.Host(name=host_name)
-        hosts_data = [x for x in host_list if x.name == host_name]
-        if len(hosts_data) > 0:
-            host_data = hosts_data[0]
+    if provider.type != 'openstack':
+        datastore_name = vm_analysis_new['datastore']
+        test_datastore = datastore.Datastore(datastore_name, provider.key)
+        host_list = cfme_data.get('management_systems', {})[provider.key].get('hosts', [])
+        host_names = test_datastore.get_hosts()
+        for host_name in host_names:
+            test_host = host.Host(name=host_name)
+            hosts_data = [x for x in host_list if x.name == host_name]
+            if len(hosts_data) > 0:
+                host_data = hosts_data[0]
 
-            if not test_host.has_valid_credentials:
-                creds = host.get_credentials_from_config(host_data['credentials'])
-                test_host.update(
-                    updates={'credentials': creds},
-                    validate_credentials=True
-                )
+                if not test_host.has_valid_credentials:
+                    creds = host.get_credentials_from_config(host_data['credentials'])
+                    test_host.update(
+                        updates={'credentials': creds},
+                        validate_credentials=True
+                    )
 
     template.smartstate_scan()
     wait_for(lambda: is_vm_analysis_finished(template_name),


### PR DESCRIPTION
This also removes settings creds for host/datastore for RHOS

{{pytest: cfme/tests/infrastructure/test_instance_analysis.py -k 'test_ssa_template' --use-provider='rhos7-ga' --long-running -v}}