### PR TITLE
API fix

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -64,7 +64,7 @@ class API(object):
         while retries:
             try:
                 return func()
-            except requests.ConnectionException as e:
+            except requests.ConnectionError as e:
                 last_connection_exception = e
                 retries -= 1
         raise last_connection_exception


### PR DESCRIPTION
{{pytest: cfme/tests/test_rest.py -v --long-running}}

Scan test was nuked because it duplicates one for SSA.