### PR TITLE
Fix .format()'s handling of {}

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -153,10 +153,10 @@ VOLUME_METHOD = ("""
 prov = $evm.root["miq_provision"]
 prov.set_option(
     :clone_options,
-    {:block_device_mapping => [{}]})
+    {{ :block_device_mapping => [{}] }})
 """)
 
-ONE_FIELD = """{:volume_id => "{}", :device_name => "{}"}"""
+ONE_FIELD = """{{:volume_id => "{}", :device_name => "{}"}}"""
 
 
 @pytest.fixture(scope="module")
@@ -287,17 +287,17 @@ def test_provision_with_boot_volume(request, setup_provider, provider, provision
         with update(method):
             method.data = dedent('''\
                 $evm.root["miq_provision"].set_option(
-                    :clone_options, {
+                    :clone_options, {{
                         :image_ref => nil,
-                        :block_device_mapping_v2 => [{
+                        :block_device_mapping_v2 => [{{
                             :boot_index => 0,
                             :uuid => "{}",
                             :device_name => "vda",
                             :source_type => "volume",
                             :destination_type => "volume",
                             :delete_on_termination => false
-                        }]
-                    }
+                        }}]
+                    }}
                 )
             '''.format(volume))
 
@@ -361,9 +361,9 @@ def test_provision_with_additional_volume(request, setup_provider, provisioning,
     with update(method):
         method.data = dedent('''\
             $evm.root["miq_provision"].set_option(
-              :clone_options, {
+              :clone_options, {{
                 :image_ref => nil,
-                :block_device_mapping_v2 => [{
+                :block_device_mapping_v2 => [{{
                   :boot_index => 0,
                   :uuid => "{}",
                   :device_name => "vda",
@@ -371,8 +371,8 @@ def test_provision_with_additional_volume(request, setup_provider, provisioning,
                   :destination_type => "volume",
                   :volume_size => 3,
                   :delete_on_termination => false
-                }]
-              }
+                }}]
+              }}
         )
         '''.format(image_id))
 

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -66,7 +66,7 @@ def test_add_vm_to_service(myservice, request, copy_domain):
         user    = $evm.root['user']
 
     if service && vm
-        $evm.log('info', "XXXXXXXX Attaching Service to VM: [#{service.name}][#{vm.name}]")
+        $evm.log('info', "XXXXXXXX Attaching Service to VM: [#{{service.name}}][#{{vm.name}}]")
         vm.add_to_service(service)
         vm.owner = user if user
         vm.group = user.miq_group if user

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2522,7 +2522,7 @@ class ScriptBox(Pretty):
     def workaround_save_issue(self):
         # We need to fire off the handlers manually in some cases ...
         sel.execute_script(
-            "{}._handlers.change.map(function(handler) { handler() });".format(self.name))
+            "{}._handlers.change.map(function(handler) {{ handler() }});".format(self.name))
         sel.wait_for_ajax()
 
 


### PR DESCRIPTION
During the % -> .format conversion, it was not regarded to the formatting of ruby code which contains {}.

There is possibly something left.