### PR TITLE
New menu system

### DIFF
--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -1,9 +1,9 @@
-import ui_navigate as nav
 import cfme.fixtures.pytest_selenium as sel
 from cfme.web_ui import Quadicon, Region, SplitTable, flash, Form, fill, form_buttons, Table
 from utils.pretty import Pretty
 from functools import partial
 from cfme.web_ui import toolbar as tb
+from cfme.web_ui.menu import nav
 from cfme import web_ui as ui
 from xml.sax.saxutils import quoteattr
 from cfme.exceptions import CFMEException

--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -22,7 +22,8 @@ page = Region(
         'user_dropdown': {
             version.LOWEST: '//div[@id="page_header_div"]//li[contains(@class, "dropdown")]',
             '5.4': '//nav//ul[contains(@class, "navbar-utility")]'
-                   '/li[contains(@class, "dropdown")]/a'
+                   '/li[contains(@class, "dropdown")]/a',
+            '5.6.0.1': '//nav//a[@id="dropdownMenu2"]'
         }
     },
     identifying_loc='reset_widgets_button')

--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -956,6 +956,8 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
     from cfme import login
     # Import the top-level nav menus for convenience
     from cfme.web_ui import menu
+    # Collapse the stack
+    menu.nav.initialize()
 
     # browser fixture should do this, but it's needed for subsequent calls
     ensure_browser_open()

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -5,7 +5,7 @@
            Cluster pages.
 """
 
-import ui_navigate as nav
+from cfme.web_ui.menu import nav
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import Quadicon, Region, listaccordion as list_acc, paginator, toolbar as tb
 from functools import partial

--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -1,10 +1,9 @@
 from functools import partial
 from cached_property import cached_property
-import ui_navigate as nav
 import cfme
 import cfme.fixtures.pytest_selenium as sel
 import cfme.web_ui.flash as flash
-import cfme.web_ui.menu
+from cfme.web_ui.menu import nav
 import cfme.web_ui.tabstrip as tabs
 import cfme.web_ui.toolbar as tb
 from cfme.web_ui import (

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -5,9 +5,7 @@
            Datastores pages.
 """
 
-import ui_navigate as nav
-# needed before grafting
-import cfme.web_ui.menu  # noqa
+from cfme.web_ui.menu import nav
 
 from cfme.exceptions import CandidateNotFound, ListAccordionLinkNotFound
 from cfme.fixtures import pytest_selenium as sel

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -9,12 +9,10 @@
 
 from functools import partial
 
-import ui_navigate as nav
-
 import cfme
 import cfme.fixtures.pytest_selenium as sel
+from cfme.web_ui.menu import nav
 import cfme.web_ui.flash as flash
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
 import cfme.web_ui.toolbar as tb
 import utils.conf as conf
 from cfme.exceptions import HostNotFound
@@ -89,23 +87,23 @@ pow_btn = partial(tb.select, 'Power')
 lif_btn = partial(tb.select, 'Lifecycle')
 
 nav.add_branch('infrastructure_hosts',
-               {'infrastructure_host_new': lambda _: cfg_btn(
-                   version.pick({version.LOWEST: 'Add a New Host',
-                                 '5.4': 'Add a New item'})),
-                'infrastructure_host_discover': lambda _: cfg_btn(
-                    'Discover Hosts'),
-                'infrastructure_host': [lambda ctx: sel.click(Quadicon(ctx['host'].name,
-                                                                      'host')),
-                                   {'infrastructure_host_edit':
-                                    lambda _: cfg_btn(
-                                        version.pick({version.LOWEST: 'Edit this Host',
-                                                      '5.4': 'Edit this item'})),
-                                    'infrastructure_host_policy_assignment':
-                                    lambda _: pol_btn('Manage Policies'),
-                                    'infrastructure_provision_host':
-                                    lambda _: lif_btn(
-                                        version.pick({version.LOWEST: 'Provision this Host',
-                                                      '5.4': 'Provision this item'}))}]})
+             {'infrastructure_host_new': lambda _: cfg_btn(
+                 version.pick({version.LOWEST: 'Add a New Host',
+                               '5.4': 'Add a New item'})),
+              'infrastructure_host_discover': lambda _: cfg_btn(
+                  'Discover Hosts'),
+              'infrastructure_host': [lambda ctx: sel.click(Quadicon(ctx['host'].name,
+                                                                     'host')),
+                                      {'infrastructure_host_edit':
+                                       lambda _: cfg_btn(
+                                           version.pick({version.LOWEST: 'Edit this Host',
+                                                         '5.4': 'Edit this item'})),
+                                       'infrastructure_host_policy_assignment':
+                                       lambda _: pol_btn('Manage Policies'),
+                                       'infrastructure_provision_host':
+                                       lambda _: lif_btn(
+                                           version.pick({version.LOWEST: 'Provision this Host',
+                                                         '5.4': 'Provision this item'}))}]})
 
 
 class Host(Updateable, Pretty):

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -67,18 +67,18 @@ pol_btn = partial(tb.select, 'Policy')
 mon_btn = partial(tb.select, 'Monitoring')
 
 nav.add_branch('infrastructure_providers',
-               {'infrastructure_provider_new': lambda _: cfg_btn(
-                   'Add a New Infrastructure Provider'),
-                'infrastructure_provider_discover': lambda _: cfg_btn(
-                    'Discover Infrastructure Providers'),
-                'infrastructure_provider': [lambda ctx: sel.click(Quadicon(ctx['provider'].name,
-                                                                      'infra_prov')),
-                                   {'infrastructure_provider_edit':
-                                    lambda _: cfg_btn('Edit this Infrastructure Provider'),
-                                    'infrastructure_provider_policy_assignment':
-                                    lambda _: pol_btn('Manage Policies'),
-                                    'infrastructure_provider_timelines':
-                                    lambda _: mon_btn('Timelines')}]})
+             {'infrastructure_provider_new': lambda _: cfg_btn(
+                 'Add a New Infrastructure Provider'),
+              'infrastructure_provider_discover': lambda _: cfg_btn(
+                  'Discover Infrastructure Providers'),
+              'infrastructure_provider': [lambda ctx: sel.click(Quadicon(ctx['provider'].name,
+                                                                         'infra_prov')),
+                                          {'infrastructure_provider_edit':
+                                           lambda _: cfg_btn('Edit this Infrastructure Provider'),
+                                           'infrastructure_provider_policy_assignment':
+                                           lambda _: pol_btn('Manage Policies'),
+                                           'infrastructure_provider_timelines':
+                                           lambda _: mon_btn('Timelines')}]})
 
 
 class Provider(Pretty, CloudInfraProvider):

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -5,7 +5,7 @@
            Resource pool pages.
 """
 
-import ui_navigate as nav
+from cfme.web_ui.menu import nav
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import Quadicon, Region, toolbar as tb
 from functools import partial

--- a/cfme/services/catalogs/cloud_catalog_item.py
+++ b/cfme/services/catalogs/cloud_catalog_item.py
@@ -3,9 +3,9 @@ catalog item of type "Amazon
 
 """
 import functools
-import ui_navigate as nav
 
 import cfme.fixtures.pytest_selenium as sel
+from cfme.web_ui.menu import nav
 import cfme.web_ui as web_ui
 import cfme.web_ui.toolbar as tb
 from cfme.provisioning import provisioning_form as request_form

--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -1,188 +1,299 @@
 # -*- coding: utf-8 -*-
 import inspect
-import ui_navigate as nav
+from ui_navigate import UINavigate
 
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import accordion, toolbar
 from lya import AttrDict
 from selenium.common.exceptions import NoSuchElementException
+from utils import version
 
 
-toplevel_tabs_loc = '//nav[contains(@class, "navbar")]/div/ul[@id="maintab"]'
-toplevel_loc = toplevel_tabs_loc + ('/li/a[normalize-space(.)="{}"'
-    'and (contains(@class, "visible-lg"))]')
+class Menu(UINavigate):
+    toplevel_tabs_loc = '//nav[contains(@class, "navbar")]/div/ul[@id="maintab"]'
+    toplevel_loc = toplevel_tabs_loc + ('/li/a[normalize-space(.)="{}"'
+        'and (contains(@class, "visible-lg"))]')
 
+    # Upstream
+    ROOT = '//ul[@id="maintab"]/..'
+    NAMED_LEV = ('/../div/ul[contains(@class,"list-group")]/li[contains(@class,"list-group-item")]'
+        '/a[normalize-space(.)="{}"]')
+    ACTIVE_LEV = ('/../div/ul[contains(@class,"list-group")]/li[contains(@class,"active")]'
+        '/a')
+    ANY_LEV = ('/../div/ul[contains(@class,"list-group")]/li[contains(@class,"list-group-item")]'
+        '/a')
 
-def get_current_toplevel_name():
-    """Returns text of the currently selected top level menu item."""
-    return sel.text("//ul[@id='maintab']/li[not(contains(@class, 'drop'))]/a[2]")\
-        .encode("utf-8").strip()
+    # 5.5
+    TOP_LEV_ACTIVE = '//ul[@id="maintab"]/li[contains(@class,"active")]/a[normalize-space(.)="{}"]'
+    TOP_LEV_INACTIVE = ('//ul[@id="maintab"]/li[contains(@class,"dropdown")]'
+        '/a[normalize-space(.)="{}"]')
+    SECOND_LEV_ACTIVE = '/../ul[contains(@class,"nav")]/li/a[normalize-space(.)="{}"]'
+    SECOND_LEV_INACTIVE = '/../ul[contains(@class,"dropdown-menu")]/li/a[normalize-space(.)="{}"]'
+    SECOND_LEV_ACTIVE_HREF = '/../ul[contains(@class,"nav")]/li/a[@href="{}"]'
+    SECOND_LEV_INACTIVE_HREF = '/../ul[contains(@class,"dropdown-menu")]/li/a[@href="{}"]'
 
+    def __init__(self):
+        self._branches = None
+        self._branch_stack = []
+        super(Menu, self).__init__()
 
-def _tree_func_with_grid(*args):
-    def f():
-        accordion.tree(*args)
-        toolbar.select('Grid View')
-    return f
-
-# Dictionary of (nav destination name, section title) section tuples
-# Keys are toplevel sections (the main tabs), values are a supertuple of secondlevel sections
-# You can also add a resetting callable that is called after clicking the second level.
-sections = {
-    ('cloud_intelligence', 'Cloud Intelligence'): (
-        ('dashboard', 'Dashboard'),
-        ('reports', 'Reports'),
-        ('chargeback', 'Chargeback'),
-        ('timelines', 'Timelines'),
-        ('rss', 'RSS')
-    ),
-    ('services', 'Services'): (
-        ('my_services', 'My Services'),
-        ('services_catalogs', 'Catalogs'),
-        ('services_workloads', 'Workloads'),
-        ('services_requests', 'Requests')
-    ),
-    ('clouds', 'Clouds'): (
-        ('clouds_providers', 'Providers', lambda: toolbar.select('Grid View')),
-        ('clouds_availability_zones', 'Availability Zones'),
-        ('clouds_tenants', 'Tenants'),
-        ('clouds_flavors', 'Flavors'),
-        ('clouds_security_groups', 'Security Groups'),
-        ('clouds_instances', 'Instances',
-            _tree_func_with_grid("Instances by Provider", "Instances by Provider")),
-        ('clouds_stacks', 'Stacks')
-    ),
-    ('containers', 'Containers'): (
-        ('containers_providers', 'Providers'),
-        ('containers_projects', 'Projects'),
-        ('containers_nodes', 'Nodes'),
-        ('containers_pods', 'Pods'),
-        ('containers_routes', 'Routes'),
-        ('containers_replicators', 'Replicators'),
-        ('containers_services', 'Services'),
-        ('containers_containers', 'Containers'),
-        ('containers_images', 'Container Images'),
-        ('containers_image_registries', 'Image Registries'),
-        ('containers_topology', 'Topology')
-    ),
-    ('middleware', 'Middleware'): (
-        ('middleware_providers', 'Providers'),
-        ('middleware_servers', 'Middleware Servers')
-    ),
-    ('infrastructure', 'Infrastructure'): (
-        ('infrastructure_providers', 'Providers', lambda: toolbar.select('Grid View')),
-        ('infrastructure_clusters', "/ems_cluster"),
-        ('infrastructure_hosts', "/host"),
-        ('infrastructure_virtual_machines', 'Virtual Machines',
-            _tree_func_with_grid("VMs & Templates", "All VMs & Templates")),
-        ('infrastructure_resource_pools', 'Resource Pools'),
-        ('infrastructure_datastores', 'Datastores'),
-        ('infrastructure_repositories', 'Repositories'),
-        ('infrastructure_pxe', 'PXE'),
-        ('infrastructure_requests', 'Requests'),
-        ('infrastructure_config_management', 'Configuration Management')
-    ),
-    ('middleware', 'Middleware'): (
-        ('middleware_providers', 'Providers'),
-        ('middleware_servers', "Middleware Servers"),
-        ('middleware_deployments', "Middleware Deployments"),
-        ('middleware_topology', "Topology"),
-    ),
-    ('control', 'Control'): (
-        ('control_explorer', 'Explorer'),
-        ('control_simulation', 'Simulation'),
-        ('control_import_export', 'Import / Export'),
-        ('control_log', 'Log')
-    ),
-    ('automate', 'Automate'): (
-        ('automate_explorer', 'Explorer'),
-        ('automate_simulation', 'Simulation'),
-        ('automate_customization', 'Customization'),
-        ('automate_import_export', 'Import / Export'),
-        ('automate_log', 'Log'),
-        ('automate_requests', 'Requests')
-    ),
-    ('optimize', 'Optimize'): (
-        ('utilization', 'Utilization'),
-        ('planning', 'Planning'),
-        ('bottlenecks', 'Bottlenecks')
-    ),
-    ('configure', 'Configure'): (
-        ('my_settings', 'My Settings'),
-        ('tasks', 'Tasks'),
-        ('configuration', 'Configuration'),
-        ('smartproxies', 'SmartProxies'),
-        ('about', 'About')
-    )
-}
-
-
-TOP_LEV_ACTIVE = '//ul[@id="maintab"]/li[contains(@class,"active")]/a[normalize-space(.)="{}"]'
-TOP_LEV_INACTIVE = '//ul[@id="maintab"]/li[contains(@class,"dropdown")]/a[normalize-space(.)="{}"]'
-SECOND_LEV_ACTIVE = '/../ul[contains(@class,"nav")]/li/a[normalize-space(.)="{}"]'
-SECOND_LEV_INACTIVE = '/../ul[contains(@class,"dropdown-menu")]/li/a[normalize-space(.)="{}"]'
-SECOND_LEV_ACTIVE_HREF = '/../ul[contains(@class,"nav")]/li/a[@href="{}"]'
-SECOND_LEV_INACTIVE_HREF = '/../ul[contains(@class,"dropdown-menu")]/li/a[@href="{}"]'
-
-
-def is_page_active(toplevel, secondlevel=None):
-    try:
-        if get_current_toplevel_name() != toplevel:
-            return False
-    except NoSuchElementException:
-        return False
-    if secondlevel:
-        try:
-            sel.element(("//nav[contains(@class, 'navbar')]//ul/li[@class='active']"
-                        "/a[normalize-space(.)='{}']/..".format(secondlevel)))
-        except NoSuchElementException:
-            return False
-    return True
-
-
-def nav_to_fn(toplevel, secondlevel=None, reset_action=None, _final=False):
-    def f(_):
-        # Can't do this currently because silly menu traps us
-        # if is_page_active(toplevel, secondlevel):
-        #     return
-        if callable(toplevel):
-            top_level = toplevel()
-        else:
-            top_level = toplevel
-
-        if secondlevel is not None:
-            if callable(secondlevel):
-                second_level = secondlevel()
+    def initialize(self):
+        if not self._branches:
+            self._branches = self.branch_convert(self.sections)
+            self.add_branch('toplevel', self._branches)
+            while self._branch_stack:
+                name, branches = self._branch_stack.pop(0)
+                self.add_branch(name, branches)
+            if version.current_version() < "5.6.0.1":
+                self.CURRENT_TOP_MENU = "//ul[@id='maintab']/li[not(contains(@class, 'drop'))]/a[2]"
             else:
-                second_level = secondlevel
+                self.CURRENT_TOP_MENU = "{}{}".format(self.ROOT, self.ACTIVE_LEV)
 
-            if secondlevel.startswith('/'):
-                active_loc = (TOP_LEV_ACTIVE + SECOND_LEV_ACTIVE_HREF).format(
-                    top_level, second_level)
-                inactive_loc = (TOP_LEV_INACTIVE + SECOND_LEV_INACTIVE_HREF).format(
-                    top_level, second_level)
-            else:
-                active_loc = (TOP_LEV_ACTIVE + SECOND_LEV_ACTIVE).format(top_level, second_level)
-                inactive_loc = (TOP_LEV_INACTIVE + SECOND_LEV_INACTIVE).format(
-                    top_level, second_level)
-            el = "{} | {}".format(active_loc, inactive_loc)
-
-            try:
-                href = sel.get_attribute(el, 'href')
-                sel.execute_script('document.location.href="{}"'.format(href))
-            except NoSuchElementException:
-                raise
+    def add_branch(self, name, branches):
+        if self._branches:
+            super(Menu, self).add_branch(name, branches)
         else:
-            active_loc = TOP_LEV_ACTIVE.format(top_level)
-            inactive_loc = TOP_LEV_INACTIVE.format(top_level)
-            el = "{} | {}".format(active_loc, inactive_loc)
+            self._branch_stack.append((name, branches))
 
+    def get_current_toplevel_name(self):
+        """Returns text of the currently selected top level menu item."""
+        return self.get_current_menu_state()[0]
+
+    def get_current_menu_state(self):
+        lev = [None, None, None]
+        lev[0] = (sel.text(self.CURRENT_TOP_MENU).encode("utf-8").strip())
+        if version.current_version() < "5.6.0.1":
             try:
-                href = sel.get_attribute(el, 'href')
-                sel.execute_script('document.location.href="{}"'.format(href))
+                lev[1] = sel.text("//nav[contains(@class, 'navbar')]//ul/li[@class='active']/a") \
+                    .encode("utf-8").strip()
             except NoSuchElementException:
-                raise
+                pass
+        else:
+            lev[1] = sel.text("{}{}".format(
+                self.CURRENT_TOP_MENU, self.ACTIVE_LEV)).encode("utf-8").strip()
+            try:
+                lev[2] = sel.text("{}{}{}".format(
+                    self.CURRENT_TOP_MENU, self.ACTIVE_LEV, self.ACTIVE_LEV)).encode(
+                        "utf-8").strip()
+            except NoSuchElementException:
+                pass
+
+        return lev
+
+    @staticmethod
+    def _tree_func_with_grid(*args):
+        def f():
+            accordion.tree(*args)
+            toolbar.select('Grid View')
+        return f
+
+    @property
+    def sections(self):
+        # Dictionary of (nav destination name, section title) section tuples
+        # Keys are toplevel sections (the main tabs), values are a supertuple of secondlevel
+        # sections
+        # You can also add a resetting callable that is called after clicking the second level.
+        if version.current_version() < "5.6.0.1":
+            sections = {
+                ('cloud_intelligence', 'Cloud Intelligence'): (
+                    ('dashboard', 'Dashboard'),
+                    ('reports', 'Reports'),
+                    ('chargeback', 'Chargeback'),
+                    ('timelines', 'Timelines'),
+                    ('rss', 'RSS')
+                ),
+                ('services', 'Services'): (
+                    ('my_services', 'My Services'),
+                    ('services_catalogs', 'Catalogs'),
+                    ('services_workloads', 'Workloads'),
+                    ('services_requests', 'Requests')
+                ),
+                ('clouds', 'Clouds'): (
+                    ('clouds_providers', 'Providers', lambda: toolbar.select('Grid View')),
+                    ('clouds_availability_zones', 'Availability Zones'),
+                    ('clouds_tenants', 'Tenants'),
+                    ('clouds_flavors', 'Flavors'),
+                    ('clouds_security_groups', 'Security Groups'),
+                    ('clouds_instances', 'Instances',
+                        self._tree_func_with_grid(
+                            "Instances by Provider", "Instances by Provider")),
+                    ('clouds_stacks', 'Stacks')
+                ),
+                ('containers', 'Containers'): (
+                    ('containers_providers', 'Providers'),
+                    ('containers_projects', 'Projects'),
+                    ('containers_nodes', 'Nodes'),
+                    ('containers_pods', 'Pods'),
+                    ('containers_routes', 'Routes'),
+                    ('containers_replicators', 'Replicators'),
+                    ('containers_services', 'Services'),
+                    ('containers_containers', 'Containers'),
+                    ('containers_images', 'Container Images'),
+                    ('containers_image_registries', 'Image Registries'),
+                    ('containers_topology', 'Topology')
+                ),
+                ('middleware', 'Middleware'): (
+                    ('middleware_providers', 'Providers'),
+                    ('middleware_servers', 'Middleware Servers')
+                ),
+                ('infrastructure', 'Infrastructure'): (
+                    ('infrastructure_providers', 'Providers', lambda: toolbar.select('Grid View')),
+                    ('infrastructure_clusters', "/ems_cluster"),
+                    ('infrastructure_hosts', "/host"),
+                    ('infrastructure_virtual_machines', 'Virtual Machines',
+                        self._tree_func_with_grid("VMs & Templates", "All VMs & Templates")),
+                    ('infrastructure_resource_pools', 'Resource Pools'),
+                    ('infrastructure_datastores', 'Datastores'),
+                    ('infrastructure_repositories', 'Repositories'),
+                    ('infrastructure_pxe', 'PXE'),
+                    ('infrastructure_requests', 'Requests'),
+                    ('infrastructure_config_management', 'Configuration Management')
+                ),
+                ('middleware', 'Middleware'): (
+                    ('middleware_providers', 'Providers'),
+                    ('middleware_servers', "Middleware Servers"),
+                    ('middleware_deployments', "Middleware Deployments"),
+                    ('middleware_topology', "Topology"),
+                ),
+                ('control', 'Control'): (
+                    ('control_explorer', 'Explorer'),
+                    ('control_simulation', 'Simulation'),
+                    ('control_import_export', 'Import / Export'),
+                    ('control_log', 'Log')
+                ),
+                ('automate', 'Automate'): (
+                    ('automate_explorer', 'Explorer'),
+                    ('automate_simulation', 'Simulation'),
+                    ('automate_customization', 'Customization'),
+                    ('automate_import_export', 'Import / Export'),
+                    ('automate_log', 'Log'),
+                    ('automate_requests', 'Requests')
+                ),
+                ('optimize', 'Optimize'): (
+                    ('utilization', 'Utilization'),
+                    ('planning', 'Planning'),
+                    ('bottlenecks', 'Bottlenecks')
+                ),
+                ('configure', 'Configure'): (
+                    ('my_settings', 'My Settings'),
+                    ('tasks', 'Tasks'),
+                    ('configuration', 'Configuration'),
+                    ('smartproxies', 'SmartProxies'),
+                    ('about', 'About')
+                )
+            }
+        else:
+            sections = {
+                ('cloud_intelligence', 'Cloud Intelligence'): (
+                    ('dashboard', 'Dashboard'),
+                    ('reports', 'Reports'),
+                    ('chargeback', 'Chargeback'),
+                    ('timelines', 'Timelines'),
+                    ('rss', 'RSS')
+                ),
+                ('compute', 'Compute'): {
+                    ('clouds', 'Clouds'): (
+                        ('clouds_providers', 'Providers', lambda: toolbar.select('Grid View')),
+                        ('clouds_availability_zones', 'Availability Zones'),
+                        ('clouds_tenants', 'Tenants'),
+                        ('clouds_flavors', 'Flavors'),
+                        ('clouds_security_groups', 'Security Groups'),
+                        ('clouds_instances', 'Instances',
+                            self._tree_func_with_grid(
+                                "Instances by Provider", "Instances by Provider")),
+                        ('clouds_stacks', 'Stacks')
+                    ),
+                    ('services', 'Services'): (
+                        ('my_services', 'My Services'),
+                        ('services_catalogs', 'Catalogs'),
+                        ('services_workloads', 'Workloads'),
+                        ('services_requests', 'Requests')
+                    ),
+                    ('infrastructure', 'Infrastructure'): (
+                        ('infrastructure_providers',
+                            'Providers', lambda: toolbar.select('Grid View')),
+                        ('infrastructure_clusters', "/ems_cluster"),
+                        ('infrastructure_hosts', "/host"),
+                        ('infrastructure_virtual_machines', 'Virtual Machines',
+                            self._tree_func_with_grid("VMs & Templates", "All VMs & Templates")),
+                        ('infrastructure_resource_pools', 'Resource Pools'),
+                        ('infrastructure_datastores', 'Datastores'),
+                        ('infrastructure_repositories', 'Repositories'),
+                        ('infrastructure_pxe', 'PXE'),
+                        ('infrastructure_requests', 'Requests'),
+                        ('infrastructure_config_management', 'Configuration Management')
+                    ),
+                    ('middleware', 'Middleware'): (
+                        ('middleware_providers', 'Providers'),
+                        ('middleware_servers', "Middleware Servers"),
+                        ('middleware_deployments', "Middleware Deployments"),
+                        ('middleware_topology', "Topology"),
+                    ),
+                    ('containers', 'Containers'): (
+                        ('containers_providers', 'Providers'),
+                        ('containers_projects', 'Projects'),
+                        ('containers_nodes', 'Nodes'),
+                        ('containers_pods', 'Pods'),
+                        ('containers_routes', 'Routes'),
+                        ('containers_replicators', 'Replicators'),
+                        ('containers_services', 'Services'),
+                        ('containers_containers', 'Containers'),
+                        ('containers_images', 'Container Images'),
+                        ('containers_image_registries', 'Image Registries'),
+                        ('containers_topology', 'Topology')
+                    ),
+                },
+                ('n_configuration', 'Configuration'): (
+                    ('infrastructure_config_management', 'Configuration Management'),
+                ),
+                ('containers', 'Containers'): (
+                    ('containers_providers', 'Providers'),
+                ),
+                ('control', 'Control'): (
+                    ('control_explorer', 'Explorer'),
+                    ('control_simulation', 'Simulation'),
+                    ('control_import_export', 'Import / Export'),
+                    ('control_log', 'Log')
+                ),
+                ('automate', 'Automate'): (
+                    ('automate_explorer', 'Explorer'),
+                    ('automate_simulation', 'Simulation'),
+                    ('automate_customization', 'Customization'),
+                    ('automate_import_export', 'Import / Export'),
+                    ('automate_log', 'Log'),
+                    ('automate_requests', 'Requests')
+                ),
+                ('optimize', 'Optimize'): (
+                    ('utilization', 'Utilization'),
+                    ('planning', 'Planning'),
+                    ('bottlenecks', 'Bottlenecks')
+                ),
+                ('configure', 'Settings'): (
+                    ('my_settings', 'My Settings'),
+                    ('tasks', 'Tasks'),
+                    ('configuration', 'Configuration'),
+                    ('about', 'About')
+                )
+            }
+        return sections
+
+    def is_page_active(self, toplevel, secondlevel=None, thirdlevel=None):
+        present = self.get_current_menu_state()
+        required = toplevel, secondlevel, thirdlevel
+        for present, required in zip(present, required):
+            if required and present != required:
+                return False
+        else:
+            return True
+
+    @staticmethod
+    def _try_nav(el):
+        href = sel.get_attribute(el, 'href')
+        sel.execute_script('document.location.href = arguments[0];', href)
         sel.wait_for_ajax()
+
+    @staticmethod
+    def _try_reset_action(reset_action, _final, nav_fn):
         if reset_action is not None:
             try:
                 if callable(reset_action):
@@ -196,124 +307,239 @@ def nav_to_fn(toplevel, secondlevel=None, reset_action=None, _final=False):
                 else:
                     # Work around the problem when the display selector disappears after returning
                     # from VM summary view. Can be fixed by renavigating, it then appears again.
-                    nav_to_fn(toplevel, secondlevel, reset_action, _final=True)
-        # todo move to element on the active tab to clear the menubox
-        sel.wait_for_ajax()
-    return f
+                    nav_fn()
 
+    @classmethod
+    def nav_to_fn(cls, toplevel, secondlevel=None, thirdlevel=None, reset_action=None,
+            _final=False):
+        def f(_):
+            # Can't do this currently because silly menu traps us
+            # if is_page_active(toplevel, secondlevel):
+            #     return
+            if callable(toplevel):
+                top_level = toplevel()
+            else:
+                top_level = toplevel
 
-def reverse_lookup(toplevel_path, secondlevel_path=None):
-    """Reverse lookup for navigation destinations defined in this module, based on menu text
+            if secondlevel is not None:
+                if callable(secondlevel):
+                    second_level = secondlevel()
+                else:
+                    second_level = secondlevel
 
-    Usage:
+                if secondlevel.startswith('/'):
+                    active_loc = (cls.TOP_LEV_ACTIVE + cls.SECOND_LEV_ACTIVE_HREF).format(
+                        top_level, second_level)
+                    inactive_loc = (cls.TOP_LEV_INACTIVE + cls.SECOND_LEV_INACTIVE_HREF).format(
+                        top_level, second_level)
+                else:
+                    active_loc = (cls.TOP_LEV_ACTIVE + cls.SECOND_LEV_ACTIVE).format(
+                        top_level, second_level)
+                    inactive_loc = (cls.TOP_LEV_INACTIVE + cls.SECOND_LEV_INACTIVE).format(
+                        top_level, second_level)
+                el = "{} | {}".format(active_loc, inactive_loc)
+                cls._try_nav(el)
 
-        # Returns 'clouds'
-        reverse_lookup('Clouds')
+            else:
+                active_loc = cls.TOP_LEV_ACTIVE.format(top_level)
+                inactive_loc = cls.TOP_LEV_INACTIVE.format(top_level)
+                el = "{} | {}".format(active_loc, inactive_loc)
+                cls._try_nav(el)
 
-        # Returns 'clouds_providers'
-        reverse_lookup('Clouds', 'Providers')
+            nav_fn = lambda: cls.nav_to_fn(toplevel, secondlevel, reset_action, _final=True)
+            cls._try_reset_action(reset_action, _final, nav_fn)
+            # todo move to element on the active tab to clear the menubox
+            sel.wait_for_ajax()
 
-        # Returns 'automate_import_export'
-        reverse_lookup('Automate', 'Import / Export')
+        def f2(_):
+            args = [toplevel, secondlevel, thirdlevel]
+            loc = cls.ROOT
+            for arg in args:
+                if arg:
+                    loc = "{}{}".format(loc, cls.NAMED_LEV).format(arg)
+                else:
+                    break
+            cls._try_nav(loc)
 
-    Note:
+            nav_fn = lambda: cls.nav_to_fn(toplevel, secondlevel, thirdlevel, reset_action,
+                _final=True)
+            cls._try_reset_action(reset_action, _final, nav_fn)
 
-        It may be tempting to use this when you don't know the name of a page, e.g.:
-
-            go_to(reverse_lookup('Infrastructure', 'Providers'))
-
-        Don't do that; use the nav tree name.
-
-    """
-    if secondlevel_path:
-        menu_path = '{}/{}'.format(toplevel_path, secondlevel_path)
-    else:
-        menu_path = toplevel_path
-
-    for (toplevel_dest, toplevel), secondlevels in sections.items():
-        if callable(toplevel):
-            top_level = toplevel()
+        if version.current_version() < "5.6.0.1":
+            return f
         else:
-            top_level = toplevel
-        if menu_path == top_level:
-            return toplevel_dest
-        for level in secondlevels:
+            return f2
+
+    def reverse_lookup(self, toplevel_path, secondlevel_path=None, thirdlevel_path=None):
+        """Reverse lookup for navigation destinations defined in this module, based on menu text
+
+        Usage:
+
+            # Returns 'clouds'
+            reverse_lookup('Clouds')
+
+            # Returns 'clouds_providers'
+            reverse_lookup('Clouds', 'Providers')
+
+            # Returns 'automate_import_export'
+            reverse_lookup('Automate', 'Import / Export')
+
+        Note:
+
+            It may be tempting to use this when you don't know the name of a page, e.g.:
+
+                go_to(reverse_lookup('Infrastructure', 'Providers'))
+
+            Don't do that; use the nav tree name.
+
+        """
+        if thirdlevel_path:
+            menu_path = '{}/{}/{}'.format(toplevel_path, secondlevel_path, thirdlevel_path)
+        elif secondlevel_path:
+            menu_path = '{}/{}'.format(toplevel_path, secondlevel_path)
+        else:
+            menu_path = toplevel_path
+
+        def pco_b(level, str_so_far, next_levels=None):
             if len(level) == 2:
-                secondlevel_dest, secondlevel = level
+                level_dest, level = level
                 reset_action = None
             else:
-                secondlevel_dest, secondlevel, reset_action = level
-            if callable(secondlevel):
-                second_level = secondlevel()
+                level_dest, level, reset_action = level
+            if callable(level):
+                level = level()
             else:
-                second_level = secondlevel
-            if menu_path == '{}/{}'.format(toplevel, second_level):
-                return secondlevel_dest
-
-
-def visible_toplevel_tabs():
-    menu_names = []
-    ele = 'li/a[2]'
-
-    for menu_elem in sel.elements(ele, root=toplevel_tabs_loc):
-        menu_names.append(sel.text(menu_elem))
-    return menu_names
-
-
-def visible_pages():
-    """Return a list of all the menu pages currently visible top- and second-level pages
-
-    Mainly useful for RBAC testing
-
-    """
-    # Gather up all the visible toplevel tabs
-    menu_names = visible_toplevel_tabs()
-
-    # Now go from tab to tab and pull the secondlevel names from the visible links
-    displayed_menus = []
-    for menu_name in menu_names:
-        menu_elem = sel.element(toplevel_loc.format(menu_name))
-        sel.move_to_element(menu_elem)
-        for submenu_elem in sel.elements('../ul/li/a', root=menu_elem):
-            displayed_menus.append((menu_name, sel.text(submenu_elem)))
-
-    # Do reverse lookups so we can compare to the list of nav destinations for this group
-    return sorted([reverse_lookup(*displayed) for displayed in displayed_menus])
-
-# Construct the nav tree based on sections
-
-# The main tab destination is usually the first secondlevel page in that tab
-# Since this is redundant, it's arguable that the toplevel tabs should be
-# nav destination at all; they're included here "just in case". The toplevel
-# and secondlevel destinations exist at the same level of nav_tree because the
-# secondlevel destinations don't depend on the toplevel nav taking place to reach
-# their destination.
-
-
-def branch_convert(input_set):
-    _branches = dict()
-    for (toplevel_dest, toplevel), secondlevels in input_set.items():
-        for level in secondlevels:
-            if len(level) == 2:
-                secondlevel_dest, secondlevel = level
-                reset_action = None
-            elif len(level) == 3:
-                secondlevel_dest, secondlevel, reset_action = level
+                level = level
+            if str_so_far:
+                str_so_far = "{}/{}".format(str_so_far, level)
             else:
-                raise Exception("Wrong length of menu navigation tuple! ({})".format(len(level)))
-            _branches[secondlevel_dest] = nav_to_fn(toplevel, secondlevel, reset_action)
-        _branches[toplevel_dest] = [nav_to_fn(toplevel, None), {}]
-    return _branches
+                str_so_far = level
 
-_branches = branch_convert(sections)
-nav.add_branch('toplevel', _branches)
+            if menu_path == str_so_far:
+                return level_dest
+            else:
+                if next_levels:
+                    return process_level(next_levels, str_so_far)
+                else:
+                    return False
+
+        def process_level(levels, str_so_far=None):
+            if isinstance(levels, tuple):
+                for level in levels:
+                    ache = pco_b(level, str_so_far)
+                    if ache:
+                        return ache
+            else:
+                for level, next_levels in levels.items():
+                    ache = pco_b(level, str_so_far, next_levels)
+                    if ache:
+                        return ache
+
+        return process_level(self.sections)
+
+    def _old_visible_toplevel_tabs(self):
+        menu_names = []
+        ele = 'li/a[2]'
+
+        for menu_elem in sel.elements(ele, root=self.toplevel_tabs_loc):
+            menu_names.append(sel.text(menu_elem))
+        return menu_names
+
+    def _old_visible_pages(self):
+        # Gather up all the visible toplevel tabs
+        menu_names = self._old_visible_toplevel_tabs()
+
+        # Now go from tab to tab and pull the secondlevel names from the visible links
+        displayed_menus = []
+        for menu_name in menu_names:
+            menu_elem = sel.element(self.toplevel_loc.format(menu_name))
+            sel.move_to_element(menu_elem)
+            for submenu_elem in sel.elements('../ul/li/a', root=menu_elem):
+                displayed_menus.append((menu_name, sel.text(submenu_elem)))
+        return displayed_menus
+
+        # Do reverse lookups so we can compare to the list of nav destinations for this group
+
+    def _new_visible_pages(self):
+
+        nodes = []
+
+        def proc_node(loc, c=0, prev_node=None):
+            if not prev_node:
+                prev_node = []
+            for el in sel.elements(loc + self.ANY_LEV):
+                sel.move_to_element(el)
+                new_loc = loc + self.NAMED_LEV.format(el.text)
+                nn = prev_node[:]
+                nn.append(el.text)
+                proc_node(new_loc, c + 1, nn)
+            else:
+                nodes.append(prev_node)
+
+        proc_node(self.ROOT)
+        return nodes
+
+    def visible_pages(self):
+        """Return a list of all the menu pages currently visible top- and second-level pages
+
+        Mainly useful for RBAC testing
+
+        """
+        if version.current_version() < "5.6.0.1":
+            displayed_menus = self._old_visible_pages()
+        else:
+            displayed_menus = self._new_visible_pages()
+        return sorted(
+            [self.reverse_lookup(*displayed) for displayed in displayed_menus if displayed])
+
+    # Construct the nav tree based on sections
+
+    # The main tab destination is usually the first secondlevel page in that tab
+    # Since this is redundant, it's arguable that the toplevel tabs should be
+    # nav destination at all; they're included here "just in case". The toplevel
+    # and secondlevel destinations exist at the same level of nav_tree because the
+    # secondlevel destinations don't depend on the toplevel nav taking place to reach
+    # their destination.
+
+    def branch_convert(self, input_set):
+        _branches = dict()
+        for (toplevel_dest, toplevel), secondlevels in input_set.items():
+            if isinstance(secondlevels, dict):
+                for (secondlevel_dest, secondlevel), thirdlevels in secondlevels.items():
+                    for level in thirdlevels:
+                        if len(level) == 2:
+                            thirdlevel_dest, thirdlevel = level
+                            reset_action = None
+                        elif len(level) == 3:
+                            thirdlevel_dest, thirdlevel, reset_action = level
+                        else:
+                            raise Exception(
+                                "Wrong length of menu navigation tuple! ({})".format(len(level)))
+                        _branches[thirdlevel_dest] = self.nav_to_fn(
+                            toplevel, secondlevel, thirdlevel, reset_action)
+                    _branches[secondlevel_dest] = self.nav_to_fn(
+                        toplevel, secondlevel, reset_action)
+            else:
+                for level in secondlevels:
+                    if len(level) == 2:
+                        secondlevel_dest, secondlevel = level
+                        reset_action = None
+                    elif len(level) == 3:
+                        secondlevel_dest, secondlevel, reset_action = level
+                    else:
+                        raise Exception(
+                            "Wrong length of menu navigation tuple! ({})".format(len(level)))
+                    _branches[secondlevel_dest] = self.nav_to_fn(
+                        toplevel, secondlevel, reset_action)
+            _branches[toplevel_dest] = [self.nav_to_fn(toplevel, None), {}]
+        return _branches
 
 
 ##
 # Tree class DSL
 # TODOS:
-# * Maybe kwargify the functions? So we can then specify the args directly in the methods and not
-#   pull them from the context. (probably more question on ui_navigate itself)
+# * Maybe kwargify the functions? So we can then specify the args directly in the methods and
+#   not pull them from the context. (probably more question on ui_navigate itself)
 def _scavenge_class(cls, ignore_navigate=False):
     """Scavenges locations and nav functions from the class. Recursively goes through so no loops.
 
@@ -386,3 +612,5 @@ def extend_nav(cls):
     """
     nav.add_branch(cls.__name__, _scavenge_class(cls, ignore_navigate=True))
     return cls
+
+nav = Menu()

--- a/docs/guides/page_development.rst
+++ b/docs/guides/page_development.rst
@@ -56,12 +56,12 @@ To begin with we have the imports, we have added comments after each to specify 
 
   from functools import partial                   # Standard library
   from selenium.webdriver.common.by import By     # Convenience functions for locators, ID etc.
-  import ui_navigate as nav                       # Navigation library
+  from cfme.web_ui.menu import nav                # Navigation library
   import cfme                                     # Core cfme module
   import cfme.web_ui.menu                         # Standard menu for grafting additional menus onto
   from cfme.web_ui import Region, Quadicon, Form  # Loads the Region, Quadicon and Form UI elements
   import cfme.web_ui.flash as flash               # Flash message handler
-  import cfme.fixtures.pytest_selenium as browser # The selenium zero-level functions
+  import cfme.fixtures.pytest_selenium as sel     # The selenium zero-level functions
   import utils.conf as conf                       # Loads all configuration from the yamls
   from utils.update import Updateable             # Updatable class to give update capabilities
   import cfme.web_ui.toolbar as tb                # Toolbar UI element for clicking Center Toolbar
@@ -101,7 +101,7 @@ Locators are usually supplied as a Python dict. The key is a name which should c
 These elements can then be used to perform actions as shown later in the file by::
 
           if cancel:
-              browser.click(page.cancel_button)
+              sel.click(page.cancel_button)
 
 Forms
 ^^^^^
@@ -123,7 +123,7 @@ automatically, without worrying about field type. We begin by defining a Form::
 
 Notice that a Form is very similar to a Region. In fact, a Form inherits a Region so as above
 when we clicked on the cancel button by referencing it as an attribute of the page object. We
-can do the same here. ``browser.set_text(form.api_port, "6000")``, for example, would set the text
+can do the same here. ``sel.set_text(form.api_port, "6000")``, for example, would set the text
 of the locator described by key value ``api_port`` to ``6000``.
 
 The details to fill in the form are loaded into a variable inside the management object
@@ -172,9 +172,9 @@ In our provider page we are going to hook in the toolbar button presses to the n
 This means we are able to do something the code below and have the page execute the toolbar button
 clicks to navigate to the page in question. We could simply use the
 :py:func:`cfme.web_ui.toolbar.select` function, but to make it clearer that we expect to navigate
-away from the current page, using the ``nav.goto`` function is better::
+away from the current page, using the ``sel.force_navigate`` function is better::
 
-  nav.go_to('cloud_provider_new')
+  sel.force_navigate('cloud_provider_new')
 
 We need to add a few buttons to the center menu to handle "Add a New Cloud Provider", "Discover
 Cloud Providers" and a special case.
@@ -186,7 +186,7 @@ more elements onto the tree::
   nav.add_branch('clouds_providers',
                  {'cloud_provider_new': lambda: cfg_btn('Add a New Cloud Provider'),
                   'cloud_provider_discover': lambda: cfg_btn('Discover Cloud Providers'),
-                  'cloud_provider': [lambda ctx: browser.click(Quadicon(ctx['provider'].name)),
+                  'cloud_provider': [lambda ctx: sel.click(Quadicon(ctx['provider'].name)),
                                      {'cloud_provider_edit':
                                       lambda: cfg_btn('Edit Selected Cloud Provider')}]})
 

--- a/ui_navigate.py
+++ b/ui_navigate.py
@@ -1,0 +1,152 @@
+"""A library for UI Automation to navigate a hierarchical interface.
+
+Each part of the interface that is activated by a certain action, can be a
+node in a tree.  For example, a website can be a tree of pages, where the root
+is the home page, and each node is the name of the page and a function that gets
+the browser from the parent to the current page.
+
+A navigation node is a tuple (or dict entry), first item a string name of the node,
+2nd item either a function to navigate with, or a list of a function and a dict
+containing other nodes.
+
+.. moduleauthor:: Jeff Weiss <jweiss@redhat.com>
+"""
+from itertools import dropwhile
+from copy import deepcopy
+import functools
+
+
+class UINavigate(object):
+    def __init__(self):
+        self.nav_tree = ['toplevel', lambda _: None]
+
+    @staticmethod
+    def _has_children(node):
+        return (isinstance(node[1], (list, tuple)) and len(node[1]) > 1)
+
+    @classmethod
+    def _children(cls, node):
+        if cls._has_children(node):
+            return node[1][1]
+        else:
+            return {}
+
+    @classmethod
+    def _get_child(cls, node, name):
+        return [name, cls._children(node).get(name)]
+
+    @staticmethod
+    def _name(node):
+        return node[0]
+
+    @classmethod
+    def _fn(cls, node):
+        if cls._has_children(node):
+            return node[1][0]
+        else:
+            return node[1]
+
+    @classmethod
+    def tree_path(cls, target, tree):
+        if cls._name(tree) == target:
+            return []
+        else:
+            for i in cls._children(tree).items():
+                found = cls.tree_path(target, i)
+                if not (found is None):
+                    return [cls._name(i)] + found
+            return None
+
+    @classmethod
+    def tree_find(cls, tree, path=None):
+        if not path:
+            path = []
+        plain_node = [cls._fn(tree)]
+        if path:
+            return plain_node + cls.tree_find(cls._get_child(tree, path[0]), path[1:])
+        else:
+            return plain_node
+
+    def tree_graft(self, target, branches, tree=None):
+        """Add a branch of navigation nodes to the navigation tree.
+
+        target: str name of node to add branches to
+        branches: dict of nodes that can be directly navigated to from the target.
+        tree: An existing tree to graft onto. By default, graft onto the module's
+        top-level tree.
+
+        returns a new tree with branches added (does not modify existing tree)
+        """
+        if not tree:
+            tree = self.nav_tree
+        path = self.tree_path(target, tree)
+        if path is None:
+            raise LookupError("Unable to find target {} in nav tree.".format(target))
+        new_tree = deepcopy(tree)
+        parent_node = None
+        node = new_tree
+        for idx in path:
+            parent_node = node
+            node = [idx, self._children(node).get(idx)]
+            if node is None:
+                raise LookupError("Unable to find node {} in nav tree.".format(idx))
+        if not parent_node:
+            if self._has_children(node):
+                self._children(node).update(branches)
+            else:
+                node[1] = [node[1], branches]
+        elif self._has_children(node):
+            self._children(
+                self._get_child(
+                    parent_node, self._name(node))).update(branches)
+        else:
+            parent_node[1][1][self._name(node)] = [node[1], branches]
+        return new_tree
+
+    @classmethod
+    def navigate(cls, tree, end, start=None, context=None):
+        """Navigates the tree from the start node to the end node.
+
+        tree: A navigation tree
+        end: str name of the destination node
+        start: str name of the starting node (if the UI's
+        current state is already known, otherwise start from
+        the root node)
+        context: a dict of context data.  Usually this is dynamic application data
+        for example, something you just created in the UI, and now you want to
+        navigate to edit it.
+
+        """
+        path = cls.tree_path(end, tree)
+        if path is None:
+            raise ValueError("Destination not found in navigation tree: {}".format(end))
+        steps = cls.tree_find(tree, path)
+        if start:
+            steps = list(dropwhile(lambda s: cls._name(s) != start, steps))
+            if len(steps) == 0:
+                raise ValueError("Starting location {} not found in navigation tree.".format(start))
+        for step in steps:
+            step(context)
+
+    def add_branch(self, target, branches):
+        self.nav_tree = self.tree_graft(target, branches)
+
+    def go_to(self, dest, start=None, context=None):
+        """Navigates the module's nav_tree from start to dest.  See navigate
+        function.
+
+        """
+
+        self.navigate(self.nav_tree, dest, start=start, context=context)
+
+    @staticmethod
+    def fn(f):
+        """Takes a function of no args and makes it take 1 arg,
+        making it suitable for use as a navigation step."""
+        def g(_):
+            return f()
+        return g
+
+    @classmethod
+    def partial(cls, f, *args):
+        return cls.fn(functools.partial(f, *args))


### PR DESCRIPTION
Major changes to the menu library here, in order to support 5.6s new side based nav. This new nav not only is composed differently with new elements, but is triple layered, instead of being only double layered.

Summary of changes:

 * Added a pending UINavigate() class to overide the original, this is to make the ui_navigate module a class, and not a singleton.
 * Fixes to various object model files to get them to import in the correct way
 * Branches are now not added on import, instead they are pushed into a deferral stack which is invoked the first time you call force_navigate(). This now makes force_navigate() the _ONLY_ way to
   navigate and this function may very well move inside the menu module soon.
 * The menu module has been reshaped to give a class based Menu() object. This is to allow multiple Menu objects to be created, removing yet another singleton.
 * Currently the new Menu() object is exposed as a module level "nav" object this was to keep inline with current code and minimise non-related changes in this PR.