### PR TITLE
don't check for vmdb.yml.db on upstream for db address.

### DIFF
--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -1293,6 +1293,8 @@ class IPAppliance(object):
         # ip address (and issuing a warning) if that fails. methods that set up the internal
         # db should set db_address to something else when they do that
         try:
+            if not self.is_downstream:
+                return self.address
             db = self.get_yaml_file('/var/www/miq/vmdb/config/vmdb.yml.db')['server']['host']
             db = db.strip()
             ip_addr = self.ssh_client.run_command('ip address show')


### PR DESCRIPTION
  * return the address, if version is not downstream as vmdb.yml.db
    is not present on upstream any more.