### PR TITLE
Fixed table logic

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -487,7 +487,7 @@ class Table(Pretty):
             if isinstance(value, re._pattern_type):
                 return value.match(row[heading].text) is not None
             elif partial_check:
-                return row[heading].text in value
+                return value in row[heading].text
             else:
                 return row[heading].text == value
 


### PR DESCRIPTION
A previous PR changed the Table handling, and reverse the direction of the ```in``` conditional. This restores the original functionality.