### PR TITLE
Move _num_db_generic from containers.Provider to common.BaseProvider

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -308,6 +308,19 @@ class BaseProvider(Taggable, Updateable):
         except AttributeError:
             return None
 
+    def _num_db_generic(self, table_str):
+        """ Fetch number of rows related to this provider in a given table
+
+        Args:
+            table_str: Name of the table; e.g. 'vms' or 'hosts'
+        """
+        res = cfmedb().engine.execute(
+            "SELECT count(*) "
+            "FROM ext_management_systems, {0} "
+            "WHERE {0}.ems_id=ext_management_systems.id "
+            "AND ext_management_systems.name='{1}'".format(table_str, self.name))
+        return int(res.first()[0])
+
     def _do_stats_match(self, client, stats_to_match=None, refresh_timer=None, ui=False):
         """ A private function to match a set of statistics, with a Provider.
 

--- a/cfme/containers/provider.py
+++ b/cfme/containers/provider.py
@@ -108,14 +108,6 @@ class Provider(BaseProvider, Pretty):
         self.navigate(detail=True)
         return details_page.infoblock.text(*ident)
 
-    def _num_db_generic(self, table_str):
-        res = cfmedb().engine.execute(
-            "SELECT count(*) "
-            "FROM ext_management_systems, {0} "
-            "WHERE {0}.ems_id=ext_management_systems.id "
-            "AND ext_management_systems.name='{1}'".format(table_str, self.name))
-        return int(res.first()[0])
-
     @variable(alias='db')
     def num_project(self):
         return self._num_db_generic('container_projects')


### PR DESCRIPTION
Tested `_num_db_generic('vms')` with vsphere6 and ec2, both worked. Container providers inherit BaseProvider so nothing will change there, Config Managers dont inherit BaseProvider so... no change there.