### PR TITLE
fix issue with save button for log_depot test

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -592,9 +592,11 @@ class ServerLogDepot(Pretty):
         )
 
         validate = form_buttons.FormButton("Validate the credentials by logging into the Server")
+        # add FormButton because of inconsistency in attributes for Save buttons in cfme
         save_button = {
             version.LOWEST: form_buttons.save,
             "5.4": form_buttons.angular_save,
+            "5.6": form_buttons.FormButton("Save Changes", ng_click="btnClick()")
         }
 
         def __init__(self, p_type, name, uri, username=None, password=None):

--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -11,7 +11,6 @@ import re
 from utils.timeutil import parsetime
 from utils import conf
 from utils.ftp import FTPClient
-from utils.blockers import BZ
 from utils.path import log_path
 from cfme.configure import configuration as configure
 
@@ -200,15 +199,7 @@ def depot_configured(request, depot_type, depot_machine, depot_credentials):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.meta(
-    blockers=[
-        1018578,
-        1108087,
-        1221716,
-        BZ(1151173, unblock=lambda depot_type: depot_type != "ftp"),
-        BZ(1184465, unblock=lambda depot_type: depot_type != "ftp"),
-    ]
-)
+@pytest.mark.meta(blockers=[1335824], forced_streams=['5.6', 'upstream'])
 @pytest.sel.go_to('dashboard')
 def test_collect_log_depot(depot_type,
                            depot_machine,


### PR DESCRIPTION
add button for 5.6 into log collection page
{{pytest: cfme/tests/configure/ -k log_depot -v}}