### PR TITLE
First stab at integrating Azure into the providers code

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -361,6 +361,100 @@ class EC2Instance(Instance):
             raise OptionNotAvailable(option + " is not a supported action")
 
 
+@VM.register_for_provider_type("azure")
+class AzureInstance(Instance):
+    # CFME & provider power control options Added by Jeff Teehan on 5-16-2016
+    START = "Start"
+    POWER_ON = START  # For compatibility with the infra objects.
+    STOP = "Stop"
+    TERMINATE = "Terminate"
+    # CFME-only power control options
+    SOFT_REBOOT = "Soft Reboot"
+    # Provider-only power control options
+    RESTART = "Restart"
+
+    # CFME power states
+    STATE_ON = "on"
+    STATE_OFF = "off"
+    STATE_SUSPENDED = "suspended"
+    STATE_TERMINATED = "terminated"
+    STATE_UNKNOWN = "unknown"
+
+    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
+               security_groups=None, instance_type=None, guest_keypair=None, cancel=False,
+               **prov_fill_kwargs):
+        """Provisions an Azure instance with the given properties through CFME
+
+        Args:
+            email: Email of the requester
+            first_name: Name of the requester
+            last_name: Surname of the requester
+            availability_zone: Name of the zone the instance should belong to
+            security_groups: List of security groups the instance should belong to
+                             (currently, only the first one will be used)
+            instance_type: Type of the instance
+            guest_keypair: Name of the key pair used to access the instance
+            cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
+                    (Defaults to `False`)
+        Note:
+            For more optional keyword arguments, see
+            :py:data:`cfme.cloud.provisioning.provisioning_form`
+        """
+        from cfme.provisioning import provisioning_form
+        sel.force_navigate('clouds_provision_instances', context={
+            'provider': self.provider,
+            'template_name': self.template_name,
+        })
+
+        fill(provisioning_form, dict(
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            instance_name=self.name,
+            availability_zone=availability_zone,
+            # not supporting multiselect now, just take first value
+            security_groups=security_groups[0],
+            instance_type=instance_type,
+            guest_keypair=guest_keypair,
+            **prov_fill_kwargs
+        ))
+
+        if cancel:
+            sel.click(provisioning_form.cancel_button)
+            flash.assert_success_message(
+                "Add of new VM Provision Request was cancelled by the user")
+        else:
+            sel.click(provisioning_form.submit_button)
+            flash.assert_success_message(
+                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+
+        row_description = 'Provision from [{}] to [{}]'.format(self.template_name, self.name)
+        cells = {'Description': row_description}
+        row, __ = wait_for(requests.wait_for_request, [cells],
+                           fail_func=requests.reload, num_sec=900, delay=20)
+        assert row.last_message.text == 'Vm Provisioned Successfully'
+
+    def power_control_from_provider(self, option):
+        """Power control the instance from the provider
+
+        Args:
+            option: power control action to take against instance
+
+        Raises:
+            OptionNotAvailable: option param must have proper value
+        """
+        if option == AzureInstance.START:
+            self.provider.mgmt.start_vm(self.name)
+        elif option == AzureInstance.STOP:
+            self.provider.mgmt.stop_vm(self.name)
+        elif option == AzureInstance.RESTART:
+            self.provider.mgmt.restart_vm(self.name)
+        elif option == AzureInstance.TERMINATE:
+            self.provider.mgmt.delete_vm(self.name)
+        else:
+            raise OptionNotAvailable(option + " is not a supported action")
+
+
 ###
 # Multi-object functions
 #

--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -41,7 +41,9 @@ properties_form_55 = Form(
     fields=[
         ('type_select', {version.LOWEST: Select('select#server_emstype'),
             '5.5': AngularSelect("emstype")}),
+        ('tenant_id', Input("azure_tenant_id")),
         ('name_text', Input("name")),
+        ('azure_region_select', AngularSelect("provider_region")),
         ('hostname_text', Input("hostname")),
         ('ipaddress_text', Input("ipaddress"), {"removed_since": "5.4.0.0.15"}),
         ('region_select', {version.LOWEST: Select("select#provider_region"),
@@ -52,6 +54,8 @@ properties_form_55 = Form(
                 "5.5": "api_port",
             }
         )),
+        ('infra_provider', Input("provider_id")),
+        ('subscription', Input("subscription")),
         ("api_version", AngularSelect("api_version"), {"appeared_in": "5.5"}),
         ('sec_protocol', AngularSelect("security_protocol"), {"appeared_in": "5.5"}),
         ('infra_provider', {
@@ -69,6 +73,12 @@ properties_form_56 = TabStripForm(
         ("api_version", AngularSelect("ems_api_version")),
         ('infra_provider', AngularSelect("ems_infra_provider_id")),
         ('google_project_text', Input("project")),
+        ('azure_tenant_id', Input("azure_tenant_id")),
+        ('azure_subscription_id', Input("subscription")),
+        ('azure_region_select', AngularSelect("provider_region")),
+        ('amazon_region_select', {version.LOWEST: Select("select#provider_region"),
+            "5.5": AngularSelect("provider_region")}),
+        ("api_version", AngularSelect("api_version")),
     ],
     tab_fields={
         "Default": [
@@ -158,6 +168,23 @@ class Provider(Pretty, CloudInfraProvider):
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name')}
+
+
+class AzureProvider(Provider):
+    def __init__(self, name=None, credentials=None, zone=None, key=None, region=None,
+                 tenant_id=None, subscription_id=None):
+        super(AzureProvider, self).__init__(name=name, credentials=credentials,
+                                            zone=zone, key=key)
+        self.region = region
+        self.tenant_id = tenant_id
+        self.subscription_id = subscription_id
+
+    def _form_mapping(self, create=None, **kwargs):
+        return {'name_text': kwargs.get('name'),
+                'type_select': create and 'Azure',
+                'azure_region_select': kwargs.get('region'),
+                'azure_tenant_id': kwargs.get('tenant_id'),
+                'azure_subscription_id': kwargs.get('subscription_id')}
 
 
 class EC2Provider(Provider):

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -583,6 +583,10 @@ def _fill_credential(form, cred, validate=None):
             'candu_secret': cred.secret,
             'candu_verify_secret': cred.verify_secret,
             'validate_btn': validate})
+    elif cred.type == 'azure':
+        fill(cred.form, {'default_username': cred.principal,
+                         'default_password': cred.secret,
+                         'default_verify': cred.secret})
     elif cred.type == 'ssh':
         fill(cred.form, {'ssh_user': cred.principal, 'ssh_key': cred.secret})
     elif cred.type == 'token':

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -2,7 +2,8 @@
 import fauxfactory
 import cfme.web_ui.flash as flash
 import pytest
-from cfme.cloud.instance import EC2Instance, Instance, OpenStackInstance, get_all_instances
+from cfme.cloud.instance import (EC2Instance, Instance, OpenStackInstance,
+                                 AzureInstance, get_all_instances)
 from cfme.fixtures import pytest_selenium as sel
 from utils import error, testgen, version
 from utils.blockers import GH
@@ -57,6 +58,10 @@ def check_power_options(soft_assert, instance, power_state):
     """ Checks if power options match given power state ('on', 'off')
     """
     must_be_available = {
+        AzureInstance: {
+            'on': [AzureInstance.STOP, AzureInstance.SUSPEND, AzureInstance.TERMINATE],
+            'off': [AzureInstance.START, AzureInstance.TERMINATE]
+        },
         EC2Instance: {
             'on': [EC2Instance.STOP, EC2Instance.SOFT_REBOOT, EC2Instance.TERMINATE],
             'off': [EC2Instance.START, EC2Instance.TERMINATE]
@@ -72,6 +77,10 @@ def check_power_options(soft_assert, instance, power_state):
         }
     }
     mustnt_be_available = {
+        AzureInstance: {
+            'on': [AzureInstance.START],
+            'off': [AzureInstance.STOP, AzureInstance.SUSPEND, AzureInstance.SOFT_REBOOT]
+        },
         EC2Instance: {
             'on': [EC2Instance.START],
             'off': [EC2Instance.STOP, EC2Instance.SOFT_REBOOT]

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -10,7 +10,7 @@ import utils.error as error
 from cfme import Credential
 from cfme.exceptions import FlashMessageException
 from cfme.cloud.provider import (discover, EC2Provider, wait_for_a_provider,
-    Provider, OpenStackProvider, prop_region)
+    Provider, OpenStackProvider, prop_region, AzureProvider)
 from cfme.web_ui import fill, flash
 from utils import testgen, version
 from utils.providers import get_credentials_from_config

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 
 from cfme.automate import explorer as automate
 from cfme.cloud.instance import Instance
-from cfme.cloud.provider import OpenStackProvider
+from cfme.cloud.provider import (OpenStackProvider, AzureProvider)
 from cfme.fixtures import pytest_selenium as sel
 from utils import testgen
 from utils.update import update
@@ -56,6 +56,13 @@ def test_provision_from_template(request, setup_provider, provider, vm_name, pro
 
     if isinstance(provider, OpenStackProvider):
         inst_args['cloud_network'] = provisioning['cloud_network']
+
+    if isinstance(provider, AzureProvider):
+        inst_args['environment__cloud_network'] = provisioning['cloud_network']
+        inst_args['environment__cloud_subnet'] = provisioning['cloud_subnet']
+        inst_args['environment__security_groups'] = provisioning['security_group']
+        inst_args['environment__resource_group'] = provisioning['resource_group']
+        inst_args['hardware__instance_type'] = provisioning['vm_size']
 
     sel.force_navigate("clouds_instances_by_provider")
     instance.create(**inst_args)

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -11,6 +11,7 @@ from functools import partial
 from operator import methodcaller
 
 from mgmtsystem.virtualcenter import VMWareSystem
+from mgmtsystem.azure import AzureSystem
 from mgmtsystem.scvmm import SCVMMSystem
 from mgmtsystem.ec2 import EC2System
 from mgmtsystem.google import GoogleCloudSystem
@@ -45,6 +46,7 @@ infra_provider_type_map = {
 
 #: mapping of cloud provider type names to ``mgmtsystem`` classes
 cloud_provider_type_map = {
+    'azure': AzureSystem,
     'ec2': EC2System,
     'openstack': OpenstackSystem,
     'gce': GoogleCloudSystem,
@@ -764,6 +766,12 @@ def get_crud(provider_config_name):
             zone=prov_config['zone'],
             region=prov_config['region'],
             credentials={'default': ser_acc_creds},
+            key=provider_config_name)
+    elif prov_type == 'azure':
+        from cfme.cloud.provider import AzureProvider
+        return AzureProvider(name=prov_config['name'],
+            region=prov_config['region'],
+            credentials={'default': credentials},
             key=provider_config_name)
     elif prov_type == 'openstack':
         from cfme.cloud.provider import OpenStackProvider


### PR DESCRIPTION
Better get this checked in.  Already lost it once.

Going to need help getting the right fields on the forms, but I think these are the fields azure will be using, at least in 5.6  I don't really care about 5.5

{{pytest: cfme/tests/cloud -k "test_provider_crud or test_instance_power_control" --use-provider azure }}