### PR TITLE
Log a warning when DB is not available instead of raising a KeyError exception

### DIFF
--- a/fixtures/log.py
+++ b/fixtures/log.py
@@ -41,9 +41,15 @@ def pytest_runtest_logreport(report):
         path, lineno, domaininfo = report.location
         test_status = _test_status(_format_nodeid(report.nodeid, False))
         if test_status == "failed":
-            logger().info(
-                "Managed providers: {}".format(
-                    ", ".join(pytest.store.current_appliance.managed_providers)))
+            try:
+                logger().info(
+                    "Managed providers: {}".format(
+                        ", ".join(pytest.store.current_appliance.managed_providers)))
+            except KeyError as ex:
+                if 'ext_management_systems' in ex.msg:
+                    logger().warning("Unable to query ext_management_systems table; DB issue")
+                else:
+                    raise
         logger().info(log.format_marker('{} result: {}'.format(_format_nodeid(report.nodeid),
                 test_status)),
             extra={'source_file': path, 'source_lineno': lineno})


### PR DESCRIPTION
See: http://pastebin.test.redhat.com/374498

Encountered during test_db_migrate testing, #2976