### PR TITLE
Fixed call to restart evm server rudely

### DIFF
--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -1140,7 +1140,10 @@ class IPAppliance(object):
         log_callback('restarting evm service')
         with self.ssh_client as ssh:
             if rude:
-                status, msg = ssh.run_command('killall -9 ruby; service evmserverd start')
+                status, msg = ssh.run_command(
+                    'killall -9 ruby;'
+                    'service rh-postgresql94-postgresql stop;'
+                    'service evmserverd start')
             else:
                 status, msg = ssh.run_command('systemctl restart evmserverd')
 


### PR DESCRIPTION
If postgres is left hanging and a restart of it is not initiated, the server gets into a funny state