### PR TITLE
[FIX] Fix wait_for_ajax

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -326,10 +326,9 @@ def wait_for_ajax():
 
     def _events_not_finished():
         events = get_events()
-        not_finished = False
-        not_finished |= orig_events["maxTimeoutId"] >= events['minTimeoutId'] > 0
 
-        return not_finished
+        return orig_events["maxTimeoutId"] >= events['minTimeoutId'] \
+            if events['minTimeoutId'] > 0 else False
 
     def _nothing_in_flight():
         """Checks if there is no ajax in flight and also logs current status

--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -326,6 +326,7 @@ def wait_for_ajax():
         anything_in_flight |= running["document"] != "complete"
         anything_in_flight |= running["autofocus"] > 0
         anything_in_flight |= running["miqQE"] > 0
+        anything_in_flight |= running["miqProcessing"]
         log_msg = ', '.join(["{}: {}".format(k, str(v)) for k, v in running.iteritems()])
         # Log the message only if it's different from the last one
         if prev_log_msg != log_msg:

--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -327,6 +327,7 @@ def wait_for_ajax():
         anything_in_flight |= running["autofocus"] > 0
         anything_in_flight |= running["miqQE"] > 0
         anything_in_flight |= running["miqProcessing"]
+        anything_in_flight |= running["angular"]
         log_msg = ', '.join(["{}: {}".format(k, str(v)) for k, v in running.iteritems()])
         # Log the message only if it's different from the last one
         if prev_log_msg != log_msg:

--- a/cfme/js.py
+++ b/cfme/js.py
@@ -12,6 +12,9 @@ function xpath(root, xpath) {
 
 in_flight = """
 function isHidden(el) {if(el === null) return true; return el.offsetParent === null;}
+function angularGet() {
+    try { return (ManageIQ.angular.scope.afterGet === false); } catch(err) { return false; };
+}
 
 return {
     jquery: jQuery.active,
@@ -22,7 +25,8 @@ return {
     document: document.readyState,
     autofocus: (typeof checkMiqQE === "undefined") ? 0 : checkMiqQE('autofocus'),
     miqQE: (typeof checkAllMiqQE === "undefined") ? 0 : checkAllMiqQE(),
-    miqProcessing: ManageIQ.observe.processing || ManageIQ.observe.queue.length > 0
+    miqProcessing: ManageIQ.observe.processing || ManageIQ.observe.queue.length > 0,
+    angular: angularGet()
 };
 """
 

--- a/cfme/js.py
+++ b/cfme/js.py
@@ -30,6 +30,27 @@ return {
 };
 """
 
+get_events = """
+function timeoutsMaxId() {
+    try {
+        var maxid = Object.keys(window.testing.timeouts)[Object.keys(window.testing.timeouts).length - 1];
+        return (maxid) ? maxid : 0;
+    } catch(err) { return 0; }
+}
+
+function timeoutsMinId() {
+    try {
+        var minid = Object.keys(window.testing.timeouts)[0];
+        return (min) ? minid : 0;
+    } catch(err) { return 0; }
+}
+
+return {
+    minTimeoutId: timeoutsMinId(),
+    maxTimeoutId: timeoutsMaxId()
+};
+"""
+
 update_retirement_date_function_script = """\
 function updateDate(newValue) {
     if(typeof $j == "undefined") {

--- a/cfme/js.py
+++ b/cfme/js.py
@@ -25,7 +25,8 @@ return {
     document: document.readyState,
     autofocus: (typeof checkMiqQE === "undefined") ? 0 : checkMiqQE('autofocus'),
     miqQE: (typeof checkAllMiqQE === "undefined") ? 0 : checkAllMiqQE(),
-    miqProcessing: ManageIQ.observe.processing || ManageIQ.observe.queue.length > 0,
+    miqProcessing: (typeof ManageIQ === "undefined") ? false :
+        ManageIQ.observe.processing || ManageIQ.observe.queue.length > 0,
     angular: angularGet()
 };
 """

--- a/cfme/js.py
+++ b/cfme/js.py
@@ -21,7 +21,8 @@ return {
         && isHidden(document.getElementById("lightbox_div")),
     document: document.readyState,
     autofocus: (typeof checkMiqQE === "undefined") ? 0 : checkMiqQE('autofocus'),
-    miqQE: (typeof checkAllMiqQE === "undefined") ? 0 : checkAllMiqQE()
+    miqQE: (typeof checkAllMiqQE === "undefined") ? 0 : checkAllMiqQE(),
+    miqProcessing: ManageIQ.observe.processing || ManageIQ.observe.queue.length > 0
 };
 """
 

--- a/cfme/js.py
+++ b/cfme/js.py
@@ -33,15 +33,16 @@ return {
 get_events = """
 function timeoutsMaxId() {
     try {
-        var maxid = Object.keys(window.testing.timeouts)[Object.keys(window.testing.timeouts).length - 1];
+        var maxid = parseInt(Object.keys(window.testing.timeouts)[
+            Object.keys(window.testing.timeouts).length - 1], 10);
         return (maxid) ? maxid : 0;
     } catch(err) { return 0; }
 }
 
 function timeoutsMinId() {
     try {
-        var minid = Object.keys(window.testing.timeouts)[0];
-        return (min) ? minid : 0;
+        var minid = parseInt(Object.keys(window.testing.timeouts)[0], 10);
+        return (minid) ? minid : 0;
     } catch(err) { return 0; }
 }
 

--- a/cfme/js.py
+++ b/cfme/js.py
@@ -10,7 +10,7 @@ function xpath(root, xpath) {
 }
 """
 
-in_flight = """
+in_flight = jsmin("""\
 function isHidden(el) {if(el === null) return true; return el.offsetParent === null;}
 function angularGet() {
     try { return (ManageIQ.angular.scope.afterGet === false); } catch(err) { return false; };
@@ -29,29 +29,29 @@ return {
         ManageIQ.observe.processing || ManageIQ.observe.queue.length > 0,
     angular: angularGet()
 };
-"""
+""")
 
-get_events = """
+get_events = jsmin("""\
 function timeoutsMaxId() {
     try {
         var maxid = parseInt(Object.keys(window.testing.timeouts)[
             Object.keys(window.testing.timeouts).length - 1], 10);
-        return (maxid) ? maxid : 0;
     } catch(err) { return 0; }
+    return (maxid) ? maxid : 0;
 }
 
 function timeoutsMinId() {
     try {
         var minid = parseInt(Object.keys(window.testing.timeouts)[0], 10);
-        return (minid) ? minid : 0;
     } catch(err) { return 0; }
+    return (minid) ? minid : 0;
 }
 
 return {
     minTimeoutId: timeoutsMinId(),
     maxTimeoutId: timeoutsMaxId()
 };
-"""
+""")
 
 update_retirement_date_function_script = """\
 function updateDate(newValue) {

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1353,10 +1353,10 @@ def _fill_form_list(form, values, action=None, action_always=False):
 
     """
     logger.info('Beginning to fill in form...')
-    sel.wait_for_ajax()
     values = list(val for key in form.fields for val in values if val[0] == key[0])
     res = []
     for field, value in values:
+        sel.wait_for_ajax()
         if value is not None and form.field_valid(field):
             loc = form.locators[field]
             logger.trace(' Dispatching fill for %s', field)

--- a/data/patches/miq_application.js.diff
+++ b/data/patches/miq_application.js.diff
@@ -1,6 +1,6 @@
---- miq_application.js	2016-05-09 15:44:20.785132210 -0400
-+++ miq_application.js.new	2016-05-10 02:12:20.945132210 -0400
-@@ -1,5 +1,37 @@
+--- miq_application.js	2016-05-23 15:46:51.571062620 +0200
++++ miq_application.js.new	2016-05-23 15:48:51.438832567 +0200
+@@ -1,5 +1,92 @@
  // MIQ specific JS functions
 
 +// MiqQE section
@@ -33,6 +33,61 @@
 +  return v_incomplete;
 +}
 +// --------------
++
++
++// setTimeout and clearTimeout monitoring
++// ---------------
++
++// Set up container to hold timeout and interval state
++window.testing = {
++  timeouts: {}
++};
++
++// Make a copy of the original setTimeout function
++window._setTimeout = window.setTimeout;
++window.setTimeout = function(callback, timeout) {
++  // We need a handle to store our timeout under, we can't just use the
++  // timeout ID because we don't know it until after we create the timeout
++  var handle = _.uniqueId();
++
++  // Call the old setTimeout function
++  var timeoutId = window._setTimeout(
++    function() {
++      // The callback is the function we were originally deferring
++      callback();
++
++      // Once a timeout completes, we need to remove our reference to it
++      delete window.testing.timeouts[handle];
++    },
++    timeout
++  );
++
++  // Store the id of the timeout we just created so it can be queried
++  window.testing.timeouts[handle] = timeoutId;
++  return timeoutId;
++};
++
++// Make a copy of the original clearTimeout function
++window._clearTimeout = window.clearTimeout;
++window.clearTimeout = function(timeoutId) {
++  // Call the original clearTimeout function to actually clear the timeout
++  var returnValue = window._clearTimeout(timeoutId);
++
++  var timeoutToClear;
++  // Look over all the timeouts we have stored and find the one with
++  // the timeoutID we just passed in
++  _.each(window.testing.timeouts, function(storedTimeoutID, handle) {
++    if(storedTimeoutID === timeoutId) {
++      timeoutToClear = handle;
++    }
++  });
++
++  // Delete our stored reference to the timeout
++  delete window.testing.timeouts[timeoutToClear];
++
++  return returnValue;
++};
++// ---------------
 +
 +
  // Things to be done on page loads


### PR DESCRIPTION
I've been running into
``[E] Message: Element <cfme.web_ui.Input _names=('hostname',), _use_id=False> not found on page.``
when adding the 'OpenShift Enterprise' containers provider. The 'hostname' field is displayed only after the provider type is selected using the drop down menu. The test was not waiting for the field to appear even though the 'wait_for_ajax' method was called in the process.
I debugged the the provider page, added new check to the 'wait_for_ajax' method and verified that the problem is no longer present.
Using the trace log it can be verified that the new check makes sense:
``2016-05-19 19:22:07,714 [I] Ajax running: miqQE: 0, jquery: 0, prototype: 0, miqProcessing: True, spinner: False, miq: None, autofocus: 0, document: complete (cfme/fixtures/pytest_selenium.py:335)``