### PR TITLE
Fixed menu lookup error

### DIFF
--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -78,7 +78,14 @@ class Menu(UINavigate):
             self.add_branch('toplevel', self._branches)
             while self._branch_stack:
                 name, branches = self._branch_stack.pop(0)
-                self.add_branch(name, branches)
+                try:
+                    self.add_branch(name, branches)
+                except LookupError:
+                    logger.error(
+                        'Menu tried to graft onto [{}] which is not available'.format(name))
+                except Exception:
+                    logger.error('Something bad went wrong in menu initialization, see traceback')
+                    raise
             if version.current_version() < "5.6.0.1":
                 self.CURRENT_TOP_MENU = "//ul[@id='maintab']/li[not(contains(@class, 'drop'))]/a[2]"
             else:


### PR DESCRIPTION
This was an awesomely weird and bad bug. Owing to the deferred nature of
the menu instantiation, now happening inside force_navigate(), the
branch stack processing actually happens inside a test context. This
meant that if a LookupError happened inside the menu initialization(),
it would raise the exception, be caught as a test failure, and the
framework would continue testing, unaware that the branch stack hadn't
necessarily finished being processed. This change detects a LookupError,
and logs a warning. We also raise in the case of any other failures.