### PR TITLE
Added feature, to navigate through provider for middleware servers, deployments

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -279,7 +279,7 @@ class SummaryValue(object):
             raise ValueError("Cannot click on {} because it is not clickable".format(repr(self)))
         try:
             return sel.click(self.link, wait_ajax, no_custom_handler=True)
-        except self.sel.StaleElementReferenceException:
+        except sel.StaleElementReferenceException:
             raise RuntimeError('Couldnt click on {} because the page was left.'.format(repr(self)))
 
 

--- a/cfme/middleware/__init__.py
+++ b/cfme/middleware/__init__.py
@@ -1,4 +1,5 @@
 from functools import partial
+from random import sample
 
 from cfme.common import Validatable
 from cfme.fixtures import pytest_selenium as sel
@@ -23,3 +24,12 @@ class MiddlewareBase(Validatable):
         """ Returns ``True`` if on the providers detail page, ``False`` if not."""
         ensure_browser_open()
         return sel.is_displayed('//h1[contains(., "{} (Summary)")]'.format(self.name))
+
+
+def get_random_list(items, limit):
+    """In tests, when we have big list iterating through each element will take lot of time.
+    To avoid this, select random list with limited numbers"""
+    if len(items) > limit:
+        return sample(items, limit)
+    else:
+        return items

--- a/cfme/middleware/datasource.py
+++ b/cfme/middleware/datasource.py
@@ -1,36 +1,54 @@
 import re
 from cfme.common import Taggable
 from cfme.fixtures import pytest_selenium as sel
+from cfme.middleware.server import MiddlewareServer
 from cfme.web_ui import CheckboxTable, paginator
 from cfme.web_ui.menu import nav, toolbar as tb
 from utils.db import cfmedb
+from utils.providers import get_crud, get_provider_key
+from utils.providers import list_middleware_providers
 from . import LIST_TABLE_LOCATOR, MiddlewareBase
 
 list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)
 
 
 def _db_select_query(name=None, server=None, provider=None):
+    """Column order: `nativeid`, `name`, `properties`, `server_name`, `feed`, `provider_name`"""
     t_ms = cfmedb()['middleware_servers']
     t_mds = cfmedb()['middleware_datasources']
     t_ems = cfmedb()['ext_management_systems']
-    query = cfmedb().session.query(t_mds.nativeid, t_mds.name,
-                                   t_mds.ems_ref, t_ms.name, t_ems.name,
-                                   t_mds.properties).join(t_ms,
-                                            t_mds.server_id == t_ms.id).join(t_ems,
-                                            t_mds.ems_id == t_ems.id)
+    query = cfmedb().session.query(t_mds.nativeid, t_mds.name, t_mds.properties,
+                                   t_ms.name.label('server_name'), t_ms.feed,
+                                   t_ems.name.label('provider_name'))\
+        .join(t_ms, t_mds.server_id == t_ms.id).join(t_ems, t_mds.ems_id == t_ems.id)
     if name:
         query = query.filter(t_mds.name == name)
     if server:
-        query = query.filter(t_mds.nativeid.like('%{}%'.format(server)))
+        query = query.filter(t_ms.name == server.name)
+        if server.feed:
+            query = query.filter(t_ms.feed == server.feed)
     if provider:
-        query = query.filter(t_ems.name == provider)
+        query = query.filter(t_ems.name == provider.name)
     return query
+
+
+def _get_datasources_page(provider, server):
+    if server:  # if server instance is provided navigate through server page
+        server.summary.reload()
+        if server.summary.relationships.middleware_datasources.value == 0:
+            return
+        server.summary.relationships.middleware_datasources.click()
+    elif provider:  # if provider instance is provided navigate through provider page
+        provider.summary.reload()
+        if provider.summary.relationships.middleware_datasources.value == 0:
+            return
+        provider.summary.relationships.middleware_datasources.click()
+    else:  # if None(provider and server) given navigate through all middleware datasources page
+        sel.force_navigate('middleware_datasources')
 
 nav.add_branch(
     'middleware_datasources', {
         'middleware_datasource': lambda ctx: list_tbl.select_row('Datasource Name', ctx['name']),
-        'middleware_datasource_detail':
-            lambda ctx: list_tbl.click_row_by_cells({'Datasource Name': ctx['name']}),
     }
 )
 
@@ -43,8 +61,8 @@ class MiddlewareDatasource(MiddlewareBase, Taggable):
     Args:
         name: Name of the datasource
         provider: Provider object (HawkularProvider)
-        id: Native id (internal id) of datasource
-        server: Server name of the datasource
+        nativeid: Native id (internal id) of datasource
+        server: Server object of the datasource (MiddlewareServer)
         properties: Datasource driver name, connection URL and JNDI name
 
     Usage:
@@ -59,55 +77,86 @@ class MiddlewareDatasource(MiddlewareBase, Taggable):
     """
     property_tuples = [('name', 'name')]
 
-    def __init__(self, name, provider=None, **kwargs):
+    def __init__(self, name, server, provider=None, **kwargs):
         if name is None:
             raise KeyError("'name' should not be 'None'")
+        if not isinstance(server, MiddlewareServer):
+            raise KeyError("'server' should be an instance of MiddlewareServer")
         self.name = name
         self.provider = provider
-        self.id = kwargs['id'] if 'id' in kwargs else None
-        self.server = kwargs['server'] if 'server' in kwargs else None
+        self.server = server
+        self.nativeid = kwargs['nativeid'] if 'nativeid' in kwargs else None
         self.properties = kwargs['properties'] if 'properties' in kwargs else None
 
     @classmethod
-    def datasources(cls, provider=None):
+    def datasources(cls, provider=None, server=None):
         datasources = []
-        if provider:
-            # if provider instance is provided try to navigate provider's datasources page
-            # if no datasources are registered in provider, returns empty list
-            if not provider.load_all_provider_datasources():
-                return []
-        else:
-            # if provider instance is not provided then navigates  to all datasources page
-            sel.force_navigate('middleware_datasources')
+        _get_datasources_page(provider=provider, server=server)
         if sel.is_displayed(list_tbl):
-            for page in paginator.pages():
+            for _ in paginator.pages():
                 for row in list_tbl.rows():
+                    _server = MiddlewareServer(provider=provider, name=row.server.text)
                     datasources.append(MiddlewareDatasource(name=row.datasource_name.text,
-                                                            server=row.server.text))
+                                                            server=_server))
         return datasources
 
     @classmethod
-    def datasources_in_db(cls, server=None, provider=None):
+    def datasources_in_db(cls, server=None, provider=None, strict=True):
         datasources = []
-        rows = _db_select_query(server=server, provider=(provider.name if provider else None)).all()
+        rows = _db_select_query(server=server, provider=provider).all()
+        _provider = provider
         for datasource in rows:
-            datasources.append(MiddlewareDatasource(id=datasource[0], name=datasource[1],
-                                                    server=datasource[3], provider=datasource[4],
-                                                    properties=datasource[5]))
+            if strict:
+                _provider = get_crud(get_provider_key(datasource.provider_name))
+            _server = MiddlewareServer(name=datasource.server_name, feed=datasource.feed,
+                                       provider=provider)
+            datasources.append(MiddlewareDatasource(nativeid=datasource.nativeid,
+                                                    name=datasource.name,
+                                                    server=_server, provider=_provider,
+                                                    properties=datasource.properties))
         return datasources
 
     @classmethod
-    def datasources_in_mgmt(cls, provider):
+    def _datasources_in_mgmt(cls, provider, server=None):
         datasources = []
         rows = provider.mgmt.list_server_datasource()
         for datasource in rows:
-            datasources.append(MiddlewareDatasource(provider=provider.name,
-                    id=datasource.id, name=datasource.name,
-                    server=re.sub(r'~~$', '', datasource.path.resource[0])))
+            _server = MiddlewareServer(name=re.sub(r'~~$', '', datasource.path.resource[0]),
+                                       feed=datasource.path.feed,
+                                       provider=provider)
+            _include = False
+            if server:
+                if server.name == _server.name:
+                    _include = True if not server.feed else server.feed == _server.feed
+            else:
+                _include = True
+            if _include:
+                datasources.append(MiddlewareDatasource(nativeid=datasource.id,
+                                                        name=datasource.name,
+                                                        server=_server,
+                                                        provider=provider))
         return datasources
+
+    @classmethod
+    def datasources_in_mgmt(cls, provider=None, server=None):
+        if provider is None:
+            datasources = []
+            for _provider in list_middleware_providers():
+                datasources.extend(cls._datasources_in_mgmt(get_crud(_provider), server))
+            return datasources
+        else:
+            return cls._datasources_in_mgmt(provider, server)
+
+    def _on_detail_page(self):
+        """Override existing `_on_detail_page` and return `False` always.
+        There is no uniqueness on summary page of this resource.
+        Refer: https://github.com/ManageIQ/manageiq/issues/9046
+        """
+        return False
 
     def load_details(self, refresh=False):
         if not self._on_detail_page():
-            sel.force_navigate('middleware_datasource_detail', context={'name': self.name})
+            _get_datasources_page(provider=self.provider, server=self.server)
+            list_tbl.click_row_by_cells({'Datasource Name': self.name, 'Server': self.server.name})
         if refresh:
             tb.refresh()

--- a/cfme/middleware/provider.py
+++ b/cfme/middleware/provider.py
@@ -3,7 +3,6 @@ from cfme.web_ui import (
     Region, Form, AngularSelect, form_buttons, Input, CheckboxTable
 )
 from cfme.web_ui.menu import nav
-from cfme.fixtures import pytest_selenium as sel
 from utils.varmeth import variable
 from . import cfg_btn, mon_btn, pol_btn, LIST_TABLE_LOCATOR, MiddlewareBase
 
@@ -103,60 +102,27 @@ class HawkularProvider(MiddlewareBase, BaseProvider):
         return self._num_db_generic('middleware_deployments')
 
     @num_deployment.variant('ui')
-    def num_deployment_ui(self):
-        return int(self.summary.relationships.middleware_deployments.value)
+    def num_deployment_ui(self, reload_data=True):
+        if reload_data:
+            self.summary.reload()
+        return self.summary.relationships.middleware_deployments.value
 
     @variable(alias='db')
     def num_server(self):
         return self._num_db_generic('middleware_servers')
 
     @num_server.variant('ui')
-    def num_server_ui(self):
-        return int(self.summary.relationships.middleware_servers.value)
+    def num_server_ui(self, reload_data=True):
+        if reload_data:
+            self.summary.reload()
+        return self.summary.relationships.middleware_servers.value
 
     @variable(alias='db')
     def num_datasource(self):
         return self._num_db_generic('middleware_datasources')
 
     @num_datasource.variant('ui')
-    def num_datasource_ui(self):
-        return int(self.get_detail("Relationships", "Middleware Datasources"))
-
-    def load_all_provider_servers(self):
-        """ Loads the list of servers that are running under the provider.
-
-        If it could click through the link in infoblock, returns ``True``. If it sees that the
-        number of instances is 0, it returns ``False``.
-        """
-        self.load_details()
-        if getattr(self, 'num_server')(method='ui') == 0:
-            return False
-        else:
-            sel.click(self.summary.relationships.middleware_servers)
-            return True
-
-    def load_all_provider_deployments(self):
-        """ Loads the list of deployments that are running under the provider.
-
-        If it could click through the link in infoblock, returns ``True``. If it sees that the
-        number of instances is 0, it returns ``False``.
-        """
-        self.load_details()
-        if getattr(self, 'num_deployment')(method='ui') == 0:
-            return False
-        else:
-            sel.click(self.summary.relationships.middleware_deployments)
-            return True
-
-    def load_all_provider_datasources(self):
-        """ Loads the list of datasources that are running under the provider.
-
-        If it could click through the link in infoblock, returns ``True``. If it sees that the
-        number of instances is 0, it returns ``False``.
-        """
-        self.load_details()
-        if getattr(self, 'num_datasource')(method='ui') == 0:
-            return False
-        else:
-            sel.click(self.summary.relationships.middleware_datasources)
-            return True
+    def num_datasource_ui(self, reload_data=True):
+        if reload_data:
+            self.summary.reload()
+        return self.summary.relationships.middleware_datasources.value

--- a/cfme/tests/middleware/test_middleware_datasource.py
+++ b/cfme/tests/middleware/test_middleware_datasource.py
@@ -4,13 +4,13 @@ from utils import testgen
 from utils.version import current_version
 
 pytestmark = [
-    pytest.mark.usefixtures('single_middleware_provider'),
+    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
 ]
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, ["hawkular"], scope="function")
 
 
-def test_list_datasources(provider):
+def test_list_datasources():
     """Tests datasources list between UI, DB and Management system
     This test requires that no any other provider should exist before.
 
@@ -22,7 +22,7 @@ def test_list_datasources(provider):
     """
     ui_dses = _get_datasources_set(MiddlewareDatasource.datasources())
     db_dses = _get_datasources_set(MiddlewareDatasource.datasources_in_db())
-    mgmt_dses = _get_datasources_set(MiddlewareDatasource.datasources_in_mgmt(provider=provider))
+    mgmt_dses = _get_datasources_set(MiddlewareDatasource.datasources_in_mgmt())
     assert ui_dses == db_dses == mgmt_dses, \
         ("Lists of datasources mismatch! UI:{}, DB:{}, MGMT:{}"
          .format(ui_dses, db_dses, mgmt_dses))
@@ -50,4 +50,4 @@ def _get_datasources_set(datasources):
     Return the set of datasources which contains only necessary fields,
     such as 'name' and 'server'
     """
-    return set((datasource.name, datasource.server) for datasource in datasources)
+    return set((datasource.name, datasource.server.name) for datasource in datasources)

--- a/cfme/tests/middleware/test_middleware_deployment.py
+++ b/cfme/tests/middleware/test_middleware_deployment.py
@@ -1,33 +1,49 @@
-from random import sample
-
 import pytest
+from cfme.middleware import get_random_list
 from cfme.middleware.deployment import MiddlewareDeployment
+from cfme.middleware.server import MiddlewareServer
 from utils import testgen
 from utils.version import current_version
 
 pytestmark = [
-    pytest.mark.usefixtures('single_middleware_provider'),
+    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
 ]
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, ["hawkular"], scope="function")
+ITEMS_LIMIT = 5  # when we have big list, limit number of items to test
 
 
-def test_list_deployments(provider):
-    """Tests deployments list between UI, DB and Management system
-    This test requires that no any other provider should exist before.
+def test_list_deployments():
+    """Tests deployments list between UI, DB and management system
 
     Steps:
         * Get deployments list from UI
         * Get deployments list from Database
-        * Get deployments list from Management system(Hawkular)
         * Compare size of all the list [UI, Database, Management system]
     """
     ui_deps = _get_deployments_set(MiddlewareDeployment.deployments())
     db_deps = _get_deployments_set(MiddlewareDeployment.deployments_in_db())
-    mgmt_deps = _get_deployments_set(MiddlewareDeployment.deployments_in_mgmt(provider=provider))
+    mgmt_deps = _get_deployments_set(MiddlewareDeployment.deployments_in_mgmt())
     assert ui_deps == db_deps == mgmt_deps, \
-        ("Lists of deployments mismatch! UI:{}, DB:{}, MGMT:{}"
-         .format(ui_deps, db_deps, mgmt_deps))
+        ("Lists of deployments mismatch! UI:{}, DB:{}, MGMT:{}".format(ui_deps, db_deps, mgmt_deps))
+
+
+def test_list_server_deployments():
+    """Gets servers list and tests deployments list for each server
+
+    Steps:
+        * Get servers list from UI
+        * Get deployments list from UI of server
+        * Get deployments list from Database of server
+        * Compare size of all the list [UI, Database]
+    """
+    servers = MiddlewareServer.servers()
+    assert len(servers) > 0, "There is no server(s) available in UI"
+    for server in get_random_list(servers, ITEMS_LIMIT):
+        ui_deps = _get_deployments_set(MiddlewareDeployment.deployments(server=server))
+        db_deps = _get_deployments_set(MiddlewareDeployment.deployments_in_db(server=server))
+        assert ui_deps == db_deps, \
+            ("Lists of deployments mismatch! UI:{}, DB:{}".format(ui_deps, db_deps))
 
 
 def test_list_provider_deployments(provider):
@@ -43,8 +59,34 @@ def test_list_provider_deployments(provider):
     db_deps = _get_deployments_set(MiddlewareDeployment.deployments_in_db(provider=provider))
     mgmt_deps = _get_deployments_set(MiddlewareDeployment.deployments_in_mgmt(provider=provider))
     assert ui_deps == db_deps == mgmt_deps, \
-        ("Lists of deployments mismatch! UI:{}, DB:{}, MGMT:{}"
-         .format(ui_deps, db_deps, mgmt_deps))
+        ("Lists of deployments mismatch! UI:{}, DB:{}, MGMT:{}".format(ui_deps, db_deps, mgmt_deps))
+
+
+def test_list_provider_server_deployments(provider):
+    """Tests deployments list from current Provider for each server
+    between UI, DB and Management system
+
+    Steps:
+        * Get servers list from UI of provider
+        * Get deployments list for the server
+        * Get deployments list from UI of provider, server
+        * Get deployments list from Database of provider, server
+        * Get deployments list from Database of provider, server
+        * Get deployments list from Management system(Hawkular) of server
+        * Compare size of all the list [UI, Database, Management system]
+    """
+    servers = MiddlewareServer.servers(provider=provider)
+    assert len(servers) > 0, "There is no server(s) available in UI"
+    for server in get_random_list(servers, ITEMS_LIMIT):
+        ui_deps = _get_deployments_set(
+            MiddlewareDeployment.deployments(provider=provider, server=server))
+        db_deps = _get_deployments_set(
+            MiddlewareDeployment.deployments_in_db(provider=provider, server=server))
+        mgmt_deps = _get_deployments_set(
+            MiddlewareDeployment.deployments_in_mgmt(provider=provider, server=server))
+        assert ui_deps == db_deps == mgmt_deps, \
+            ("Lists of deployments mismatch! UI:{}, DB:{}, MGMT:{}"
+             .format(ui_deps, db_deps, mgmt_deps))
 
 
 def _get_deployments_set(deployments):
@@ -52,7 +94,7 @@ def _get_deployments_set(deployments):
     Return the set of deployments which contains only necessary fields,
     such as 'name' and 'server'
     """
-    return set((deployment.name, deployment.server) for deployment in deployments)
+    return set((deployment.name, deployment.server.name) for deployment in deployments)
 
 
 def test_deployment(provider):
@@ -60,19 +102,14 @@ def test_deployment(provider):
 
     Steps:
         * Get deployments list from UI
-        * Select up to 3 deployments randomly
+        * Select up to `ITEMS_LIMIT` deployments randomly
         * Compare selected deployment details with CFME database
     """
     ui_deps = MiddlewareDeployment.deployments(provider=provider)
     assert len(ui_deps) > 0, "There is no deployment(s) available in UI"
-    # select random deployments
-    if len(ui_deps) > 3:
-        sample_deps = sample(ui_deps, 3)
-    else:
-        sample_deps = ui_deps
-    for dep_ui in sample_deps:
-        # https://github.com/ManageIQ/manageiq/issues/8418, via server navigation failing
-        dep_ui.server = None
+    for dep_ui in get_random_list(ui_deps, ITEMS_LIMIT):
         dep_db = dep_ui.deployment(method='db')
         assert dep_ui.name == dep_db.name, "deployment name does not match between UI and DB"
+        assert dep_ui.server.name == dep_db.server.name, \
+            "deployment server name does not match between UI and DB"
         dep_ui.validate_properties()

--- a/cfme/tests/middleware/test_middleware_provider.py
+++ b/cfme/tests/middleware/test_middleware_provider.py
@@ -1,8 +1,13 @@
 import uuid
-import pytest
 
+import pytest
 from utils import testgen
 from utils.update import update
+from utils.version import current_version
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+]
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
* Added navigation feature for the pages `middleware servers` and `middleware deployments`.
* `servers` can navigate through `provider` page
* `deployments` can navigate through `provider` page [or] `provider >> server` page
* New test cases added for deployment page
* usage, 
```
MiddlewareProvider.deployments()  # lists all deployments
MiddlewareProvider.deployments(provider=_haw)  # lists all deployments from _haw provider
MiddlewareProvider.deployments(provider=_haw, server=_ser)  # lists all deployments from _haw provider >> _ser

MiddlewareProvider.servers()  # lists all servers
MiddlewareProvider.servers(provider=_haw)  # lists all servers from _haw provider
```

{{pytest: cfme/tests/middleware/ -v --long-running --use-provider hawkular}}