### PR TITLE
Fix incorrect login text

### DIFF
--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -1,7 +1,7 @@
 import pytest
 from cfme import dashboard, login, Credential
 from cfme.configure.access_control import User
-from utils import browser, conf, error, version
+from utils import browser, conf, error
 
 pytestmark = pytest.mark.usefixtures('browser')
 
@@ -41,8 +41,6 @@ def test_bad_password():
     creds = Credential(principal=conf.credentials['default']['username'], secret="badpassword@#$")
     user = User(credential=creds)
 
-    with error.expected(version.pick({
-            version.LOWEST: "Sorry, the username or password you entered is incorrect.",
-            "5.6": "Incorrect username or password"})):
+    with error.expected("Sorry, the username or password you entered is incorrect."):
         login.login(user)
         assert login.page.is_displayed()


### PR DESCRIPTION
55, 56 and upstream now have the same err flash message again. Thanks to @psav for catching this.