### PR TITLE
Override metafunc.parametrize by testgen.parametrize

### DIFF
--- a/fixtures/testgen.py
+++ b/fixtures/testgen.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+Wrapper for metafunc.parametrize
+It makes sure that parametrization using pytest_generate_tests is done through testgen.parametrize
+which checks parameters and uncollects tests with no argvalues instead of skipping them like pytest
+does by default.
+"""
+import pytest
+from functools import partial
+from utils import testgen
+
+
+@pytest.mark.hookwrapper
+def pytest_generate_tests(metafunc):
+    # override metafunc.parametrize by testgen.parametrize but pass the original
+    # metafunc.parametrize function further down the line so it can be eventually used
+    metafunc.parametrize = partial(
+        testgen.parametrize, metafunc, custom_parametrize_fn=metafunc.parametrize)
+    yield

--- a/markers/uncollect.py
+++ b/markers/uncollect.py
@@ -105,13 +105,8 @@ def pytest_collection_modifyitems(session, config, items):
 
     with open(os.path.join(log_path.strpath, 'uncollected.log'), 'w') as f:
         for item in items:
-            # Workaround for a known bug in pytest 2.7.0
-            # If a test has argnames but no argvalues, it should be ignored (uncollected)
-            values = extract_fixtures_values(item)
-            if values and all(type(v) is object for v in values.itervalues()):
-                continue
             # First filter out all items who have the uncollect mark
-            elif item.get_marker('uncollect') or not uncollectif(item):
+            if item.get_marker('uncollect') or not uncollectif(item):
                 marker = item.get_marker('uncollectif')
                 if marker:
                     reason = marker.kwargs.get('reason', "No reason given")

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -161,10 +161,22 @@ def parametrize(metafunc, argnames, argvalues, *args, **kwargs):
     """parametrize wrapper that calls :py:func:`param_check`, and only parametrizes when needed
 
     This can be used in any place where conditional parametrization is used.
+    It will use metafunc.parametrize to parametrize the test unless a custom parametrization
+    function is passed into it.
+
+    If a parametrized function doesn't pass the param check, it is uncollected.
 
     """
+    if 'custom_parametrize_fn' in kwargs:
+        parametrize_fn = kwargs['custom_parametrize_fn']
+        del kwargs['custom_parametrize_fn']
+    else:
+        parametrize_fn = metafunc.parametrize
+
     if param_check(metafunc, argnames, argvalues):
-        metafunc.parametrize(argnames, argvalues, *args, **kwargs)
+        parametrize_fn(argnames, argvalues, *args, **kwargs)
+    else:
+        pytest.mark.uncollect(metafunc.function)
 
 
 def fixture_filter(metafunc, argnames, argvalues):


### PR DESCRIPTION
Uncollect parametrized tests with no argvalues by default