### PR TITLE
Middleware provider page code changes to Quadicon support

### DIFF
--- a/cfme/middleware/provider.py
+++ b/cfme/middleware/provider.py
@@ -1,12 +1,11 @@
 from cfme.common.provider import BaseProvider
+from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
-    Region, Form, AngularSelect, form_buttons, Input, CheckboxTable
+    Region, Form, AngularSelect, form_buttons, Input, Quadicon
 )
 from cfme.web_ui.menu import nav
 from utils.varmeth import variable
-from . import cfg_btn, mon_btn, pol_btn, LIST_TABLE_LOCATOR, MiddlewareBase
-
-list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)
+from . import cfg_btn, mon_btn, pol_btn, MiddlewareBase
 
 details_page = Region(infoblock_type='detail')
 
@@ -17,7 +16,7 @@ nav.add_branch(
             lambda _: cfg_btn('Add a New Middleware Provider'),
         'middleware_provider':
         [
-            lambda ctx: list_tbl.select_row('name', ctx['provider'].name),
+            lambda ctx: sel.check(Quadicon(ctx['provider'].name).checkbox),
             {
                 'middleware_provider_edit':
                 lambda _: cfg_btn('Edit Selected Middleware Provider'),
@@ -26,7 +25,7 @@ nav.add_branch(
             }],
         'middleware_provider_detail':
         [
-            lambda ctx: list_tbl.click_cells({'name': ctx['provider'].name}),
+            lambda ctx: sel.click(Quadicon(ctx['provider'].name)),
             {
                 'middleware_provider_edit_detail':
                 lambda _: cfg_btn('Edit this Middleware Provider'),

--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -292,8 +292,8 @@ class Menu(UINavigate):
                         # ('infrastructure_config_management', 'Configuration Management')
                     ),
                     ('middleware', 'Middleware'): (
-                        ('middleware_providers', 'Providers', lambda: toolbar.select('List View')
-                            if not toolbar.is_active("List View") else None),
+                        ('middleware_providers', 'Providers', lambda: toolbar.select('Grid View')
+                            if not toolbar.is_active("Grid View") else None),
                         ('middleware_servers', 'Middleware Servers',
                          lambda: toolbar.select('List View')
                             if not toolbar.is_active("List View") else None),

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -558,7 +558,10 @@ def clear_middleware_providers(validate=True):
     total = paginator.rec_total()
     if total > 0:
         logger.info(' Providers exist, so removing all middleware providers')
-        paginator.results_per_page('100')
+        # TODO: Fix.
+        # TEXT: "Items per page" hidden and failed to click paginator items drop down selection
+        # For the moment allow it go with default value 20
+        # paginator.results_per_page('100')
         sel.click(paginator.check_all())
         toolbar.select('Configuration', 'Remove Middleware Providers from the VMDB',
                        invokes_alert=True)


### PR DESCRIPTION
From #3049 middleware page supports for `Quadicon` icon.
* `provider.wait_for_delete()` works properly

{{pytest: cfme/tests/middleware/ -v --long-running --use-provider hawkular}}